### PR TITLE
Add CODEOWNERS and clean up deploy workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @zoltan-baba @matenadasdi @aorcsik

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Build and Deploy
 
 on:
   push:
-    branches: [main, claude/festive-shamir-31a238]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -35,7 +35,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CF_API_TOKEN_PAGES }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          command: pages deploy ./build --project-name=bitrise-docs --branch=${{ github.ref_name == 'claude/festive-shamir-31a238' && 'main' || (github.head_ref || github.ref_name) }}
+          command: pages deploy ./build --project-name=bitrise-docs --branch=${{ github.head_ref || github.ref_name }}
 
       - name: Comment preview URL
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- Remove temporary `claude/festive-shamir-31a238` branch references from deploy workflow
- Add CODEOWNERS file requiring review from @zoltan-baba, @matenadasdi, @aorcsik

## Test plan
- [ ] Verify deploy workflow triggers only on `main`, PRs, and manual dispatch
- [ ] Enable "Require review from Code Owners" in branch protection settings for `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)