### PR TITLE
Fix unresolvable links: replace see-topic placeholders and urn:resource URNs

### DIFF
--- a/docs/bitrise-build-cache/build-cache-for-gradle/gradle-execution-reason-diagnostic-builds.mdx
+++ b/docs/bitrise-build-cache/build-cache-for-gradle/gradle-execution-reason-diagnostic-builds.mdx
@@ -15,7 +15,7 @@ When running Gradle tasks, a change in task inputs usually lead to a cache miss.
 
 You can keep on reading to understand the details of how Gradle tasks and their caching works.
 
-To learn how to set up diagnostic builds on Bitrise, skip ahead to [see topic](#diagnostic-builds).
+To learn how to set up diagnostic builds on Bitrise, skip ahead to [Diagnostic builds](#diagnostic-builds).
 
 
 ## Gradle tasks and caching

--- a/docs/bitrise-build-cache/insights.mdx
+++ b/docs/bitrise-build-cache/insights.mdx
@@ -11,7 +11,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GlossTerm from '@site/src/components/GlossTerm';
 
-[Bitrise Insights](urn:resource:publication:94879) offers detailed metrics on the performance of your Build Cache, including invocation count, command duration, or cache hit rate. You can explore Insights starting from any invocation:
+[Bitrise Insights](/en/insights) offers detailed metrics on the performance of your Build Cache, including invocation count, command duration, or cache hit rate. You can explore Insights starting from any invocation:
 
 1. Open the Build Cache.
 1. Open the [Invocation details](/en/bitrise-build-cache/getting-started-with-the-build-cache/invocations) page.

--- a/docs/bitrise-ci/api/adding-and-managing-apps.mdx
+++ b/docs/bitrise-ci/api/adding-and-managing-apps.mdx
@@ -356,7 +356,7 @@ curl -X 'PUT' \
 | PATCH /user/\{user-slug\}/apps/machine_types | Migrate a specified machine type to another in all apps owned by the same user. | N/A |
 | PATCH /organizations/\{org-slug\}/apps/machine_types | Migrate a specified machine type to another in all apps owned by the same Workspace. | Workspace owner |
 
-The Bitrise API provides two endpoints that allow you to switch between one [machine type](/en/bitrise-platform/infrastructure/build-machines/about-build-machines) and another for all apps owned by either a user or a [Workspace](urn:resource:component:42180). The endpoints parse the `bitrise.yml` file of each app, look for all occurrences of a specified machine type, and replace them with another type. For example, you can switch from M1 Medium to M1 Large on all your apps with this endpoint.
+The Bitrise API provides two endpoints that allow you to switch between one [machine type](/en/bitrise-platform/infrastructure/build-machines/about-build-machines) and another for all apps owned by either a user or a [Workspace](/en/bitrise-platform/workspaces/workspaces-overview). The endpoints parse the `bitrise.yml` file of each app, look for all occurrences of a specified machine type, and replace them with another type. For example, you can switch from M1 Medium to M1 Large on all your apps with this endpoint.
 
 Both endpoints take two parameters:
 

--- a/docs/bitrise-ci/api/managing-android-keystore-files.mdx
+++ b/docs/bitrise-ci/api/managing-android-keystore-files.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GlossTerm from '@site/src/components/GlossTerm';
 
-This guide describes how to manage your Android keystore files with the Bitrise API. If you’d like to learn more about how to do the same on the UI, please check out [Android code signing](urn:resource:component:42718).
+This guide describes how to manage your Android keystore files with the Bitrise API. If you’d like to learn more about how to do the same on the UI, please check out [Android code signing](/en/bitrise-ci/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step).
 
 | Endpoints | Function | Required role on the app's team |
 | --- | --- | --- |

--- a/docs/bitrise-ci/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step.mdx
+++ b/docs/bitrise-ci/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step.mdx
@@ -24,7 +24,7 @@ Please note that AAB files can only be signed with jarsigner. The Step uses `jar
 1. [Upload your keystore file to Bitrise](/en/bitrise-ci/code-signing/android-code-signing/uploading-android-keystore-files-to-bitrise).
 1. Add the [**Android Sign**](https://github.com/bitrise-steplib/steps-sign-apk) Step to your Workflow after the Step that builds your APK or AAB file.
 
-   Bitrise uses the above Environment Variables and sets them as inputs into the respective fields of the [**Android Sign**](https://github.com/bitrise-steplib/steps-sign-apk) Step. Once the Step runs, it produces either a signed APK or an AAB. The signed APK or AAB is used in deploy Steps, for example, the[**Google Play Deploy**](https://github.com/bitrise-io/steps-google-play-deploy) Step or the **Deploy to Bitrise.io** Step. The latter deploys the APK/AAB on the **Artifacts** tab. You can also use [Release Management](urn:resource:publication:90740) to deploy your app once you built an installable artifact.
+   Bitrise uses the above Environment Variables and sets them as inputs into the respective fields of the [**Android Sign**](https://github.com/bitrise-steplib/steps-sign-apk) Step. Once the Step runs, it produces either a signed APK or an AAB. The signed APK or AAB is used in deploy Steps, for example, the[**Google Play Deploy**](https://github.com/bitrise-io/steps-google-play-deploy) Step or the **Deploy to Bitrise.io** Step. The latter deploys the APK/AAB on the **Artifacts** tab. You can also use [Release Management](/en/release-management) to deploy your app once you built an installable artifact.
 
 :::note[Downloading your keystore file]
 

--- a/docs/bitrise-ci/configure-builds/configuring-build-settings/configuring-email-notifications.mdx
+++ b/docs/bitrise-ci/configure-builds/configuring-build-settings/configuring-email-notifications.mdx
@@ -19,9 +19,9 @@ To receive automatic email messages, [you need to be watching the app](/en/bitri
 
 :::
 
-Email notifications are automatically set up for all applications when first creating them but you can modify these notification settings at any time: [see topic](#changing-your-email-notification-settings)
+Email notifications are automatically set up for all applications when first creating them but you can modify these notification settings at any time: [Changing your email notification settings](#changing-your-email-notification-settings)
 
-The alternative solution is to send emails via a dedicated <GlossTerm baseform="Step">Step</GlossTerm>. This allows for far more customization regarding the notifications: [see topic](#sending-emails-with-a-step)
+The alternative solution is to send emails via a dedicated <GlossTerm baseform="Step">Step</GlossTerm>. This allows for far more customization regarding the notifications: [Sending emails with a Step](#sending-emails-with-a-step)
 
 
 ## Watching a project

--- a/docs/bitrise-ci/configure-builds/configuring-build-settings/configuring-tool-versions.mdx
+++ b/docs/bitrise-ci/configure-builds/configuring-build-settings/configuring-tool-versions.mdx
@@ -13,8 +13,8 @@ Bitrise can automatically set up any tools with the right version for your CI pr
 
 There are two ways to set up tools:
 
-- A declarative, YAML-based method: add your tool and its version to the `tools` property on the top level of your <GlossTerm baseform="configuration yaml">configuration YAML</GlossTerm> file. We recommend getting started with this method: [see topic](#declarative-tool-setup).
-- Installation during <GlossTerm baseform="workflow">Workflow</GlossTerm> execution: either via a purpose-built Bitrise <GlossTerm baseform="step">Step</GlossTerm> or a script that runs a CLI subcommand: [see topic](#tool-setup-during-workflow-execution).
+- A declarative, YAML-based method: add your tool and its version to the `tools` property on the top level of your <GlossTerm baseform="configuration yaml">configuration YAML</GlossTerm> file. We recommend getting started with this method: [Declarative tool setup](#declarative-tool-setup).
+- Installation during <GlossTerm baseform="workflow">Workflow</GlossTerm> execution: either via a purpose-built Bitrise <GlossTerm baseform="step">Step</GlossTerm> or a script that runs a CLI subcommand: [Tool setup during Workflow execution](#tool-setup-during-workflow-execution).
 
 To help you choose the right approach, consider the differences and limitations of each method:
 

--- a/docs/bitrise-ci/configure-builds/configuring-build-settings/reporting-the-build-status-to-your-git-hosting-provider.mdx
+++ b/docs/bitrise-ci/configure-builds/configuring-build-settings/reporting-the-build-status-to-your-git-hosting-provider.mdx
@@ -94,7 +94,7 @@ app:
 
 We recommend using `target_id`: it's the name of the Workflow or Pipeline that the build uses. With this variable, Git commit statuses from different Workflows/Pipelines on the same commit don't override each other.
 
-Find the available variables here: [see topic](#dynamic-variables).
+Find the available variables here: [Dynamic variables](#dynamic-variables).
 
 ### Workflow/Pipeline level status reports
 
@@ -130,7 +130,7 @@ pipeline:
 
 We recommend using `target_id`: it's the name of the Workflow or Pipeline that the build uses. With this variable, Git commit statuses from different Workflows/Pipelines on the same commit don't override each other.
 
-Find the available variables here: [see topic](#dynamic-variables).
+Find the available variables here: [Dynamic variables](#dynamic-variables).
 
 :::note[Branch protection rules]
 

--- a/docs/bitrise-ci/configure-builds/configuring-build-settings/rolling-builds.mdx
+++ b/docs/bitrise-ci/configure-builds/configuring-build-settings/rolling-builds.mdx
@@ -32,7 +32,7 @@ For example, if you trigger a build on the **main** branch of your repository wi
    ![rolling-builds.png](/img/_paligo/uuid-74153d13-4c04-d223-7389-268265192245.png)
 
    - **Abort builds triggered by pull requests**: Cancel all previous builds still **on-hold** for Pull Requests and all related Pushes. **Running** builds will **not** be canceled unless **Running builds are aborted** is also enabled.
-   - **Abort builds triggered by pushes**: Cancel all previous builds still **on-hold** for Pushes to the same branch. **Running** builds will **not** be canceled unless **Running builds are aborted** is also enabled. You can configure exclusions for push events: [see topic](#managing-exclusions-for-push-events)
+   - **Abort builds triggered by pushes**: Cancel all previous builds still **on-hold** for Pushes to the same branch. **Running** builds will **not** be canceled unless **Running builds are aborted** is also enabled. You can configure exclusions for push events: [Managing exclusions for push events](#managing-exclusions-for-push-events)
    - **Abort on-hold builds triggered by tags**: Cancel all previous builds still **on-hold** if they were triggered by Git tags.
    - **Abort running builds**: Auto-cancel running builds in addition to on-hold ones.
 

--- a/docs/bitrise-ci/dependencies-and-caching/react-native-dependencies.mdx
+++ b/docs/bitrise-ci/dependencies-and-caching/react-native-dependencies.mdx
@@ -11,7 +11,7 @@ import GlossTerm from '@site/src/components/GlossTerm';
 
 [npm](https://docs.npmjs.com/) and [Yarn](https://yarnpkg.com/) are both package managers for Node.js. They can manage the dependencies of a project, or globally installed Javascript tools. For mobile development, they are frequently used as package managers for React Native projects. If you have a React Native app on Bitrise, you can use our dedicated npm or Yarn <GlossTerm baseform="Step">Steps</GlossTerm> to install and cache your dependencies.
 
-You can also install native dependencies by using the dedicated Steps: [see topic](#installing-native-dependencies-for-a-react-native-app).
+You can also install native dependencies by using the dedicated Steps: [Installing native dependencies for a React Native app](#installing-native-dependencies-for-a-react-native-app).
 
 ## Installing dependencies with npm and Yarn
 
@@ -59,7 +59,7 @@ Check out our React Native demo app for a working example. If you add the app to
 
 :::
 
-1. Make sure your Workflow installs your npm packages: [see topic](#installing-dependencies-with-npm-and-yarn).
+1. Make sure your Workflow installs your npm packages: [Installing dependencies with npm and Yarn](#installing-dependencies-with-npm-and-yarn).
 
    You can have a separate Workflow that is only responsible for installing npm packages, and it's inserted to run before your main Workflow: [Chaining Workflows together](/en/bitrise-ci/workflows-and-pipelines/workflows/managing-workflows#chaining-workflows-together). It can be a [utility Workflow](/en/bitrise-ci/workflows-and-pipelines/workflows/managing-workflows#utility-workflows).
 1. Add the [**React Native Bundle**](https://github.com/bitrise-steplib/steps-react-native-bundle) Step to your Workflow.

--- a/docs/bitrise-ci/deploying/android-deployment/deploying-android-apps-to-bitrise-and-google-play.mdx
+++ b/docs/bitrise-ci/deploying/android-deployment/deploying-android-apps-to-bitrise-and-google-play.mdx
@@ -18,8 +18,8 @@ You need a new service account created in the Google Play Console so that Bitris
 
 To set up your project for the first time:
 
-1. Register a [Google Play Developer Account](https://developer.android.com/distribute/console/). If you already have a Google Play Developer account, and have already deployed your app to Google Play Store, skip to [see topic](#setting-up-google-play-api-access).
-1. Go through [see topic](#setting-up-google-play-deployment-for-the-first-time).
+1. Register a [Google Play Developer Account](https://developer.android.com/distribute/console/). If you already have a Google Play Developer account, and have already deployed your app to Google Play Store, skip to [Setting up Google Play API access](#setting-up-google-play-api-access).
+1. Go through [Setting up Google Play deployment for the first time](#setting-up-google-play-deployment-for-the-first-time).
 
 
 ## Setting up Google Play API access

--- a/docs/bitrise-ci/deploying/android-deployment/exporting-a-universal-apk-from-an-aab.mdx
+++ b/docs/bitrise-ci/deploying/android-deployment/exporting-a-universal-apk-from-an-aab.mdx
@@ -110,4 +110,4 @@ To configure this Step:
 </Tabs>
 
 
-The [**Export Universal APK**](https://github.com/bitrise-steplib/bitrise-step-export-universal-apk) Step exports the APK to the `$BITRISE_APK_PATH` Environment Variable which the next Steps can pick up. If the [**Deploy to Bitrise.io - Build Artifacts, Test Reports, and Pipeline intermediate files**](https://github.com/bitrise-steplib/steps-deploy-to-bitrise-io) Step is included in your Workflow, [Release Management](urn:resource:publication:90740) can deploy the APK for you.
+The [**Export Universal APK**](https://github.com/bitrise-steplib/bitrise-step-export-universal-apk) Step exports the APK to the `$BITRISE_APK_PATH` Environment Variable which the next Steps can pick up. If the [**Deploy to Bitrise.io - Build Artifacts, Test Reports, and Pipeline intermediate files**](https://github.com/bitrise-steplib/steps-deploy-to-bitrise-io) Step is included in your Workflow, [Release Management](/en/release-management) can deploy the APK for you.

--- a/docs/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-app-center-to-bitrise.mdx
+++ b/docs/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-app-center-to-bitrise.mdx
@@ -111,7 +111,7 @@ An enhanced Release Management solution with test distribution features is comin
 
 ## App Center Distribute and Bitrise Release Management
 
-The App Center Distribute service allows you to manage app distribution across multiple platforms in one place. Bitrise [Release Management](urn:resource:publication:90740) offers exactly that: a one-stop shop for your release requirements. You can:
+The App Center Distribute service allows you to manage app distribution across multiple platforms in one place. Bitrise [Release Management](/en/release-management) offers exactly that: a one-stop shop for your release requirements. You can:
 
 - Automate all your releases.
 - Release your apps across multiple platforms at the same time.

--- a/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-expo-projects.mdx
+++ b/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-expo-projects.mdx
@@ -110,7 +110,7 @@ In case you don’t want to use EAS, you can use [Turtle CLI](https://docs.expo.
 
 :::note[CodePush]
 
-You can deploy updates to your users' devices with Bitrise CodePush. CodePush is part of [Release Management](urn:resource:publication:90740) and it is supported for React Native and Expo apps.
+You can deploy updates to your users' devices with Bitrise CodePush. CodePush is part of [Release Management](/en/release-management) and it is supported for React Native and Expo apps.
 
 For more information about CodePush, check out the official guides: [CodePush](/en/release-management/codepush/about-codepush).
 

--- a/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-ioniccordova-projects.mdx
+++ b/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-ioniccordova-projects.mdx
@@ -250,7 +250,7 @@ Please note that AAB files can only be signed with jarsigner. The Step uses `jar
 1. [Upload your keystore file to Bitrise](/en/bitrise-ci/code-signing/android-code-signing/uploading-android-keystore-files-to-bitrise).
 1. Add the **Android Sign** Step to your Workflow after the Step that builds your APK or AAB file.
 
-   Bitrise uses the above Environment Variables and sets them as inputs into the respective fields of the **Android Sign** Step. Once the Step runs, it produces either a signed APK or an AAB. The signed APK or AAB is used in deploy Steps, for example, the**Google Play Deploy** Step or the **Deploy to Bitrise.io** Step. The latter deploys the APK/AAB on the **Artifacts** tab. You can also use [Release Management](urn:resource:publication:90740) to deploy your app once you built an installable artifact.
+   Bitrise uses the above Environment Variables and sets them as inputs into the respective fields of the **Android Sign** Step. Once the Step runs, it produces either a signed APK or an AAB. The signed APK or AAB is used in deploy Steps, for example, the**Google Play Deploy** Step or the **Deploy to Bitrise.io** Step. The latter deploys the APK/AAB on the **Artifacts** tab. You can also use [Release Management](/en/release-management) to deploy your app once you built an installable artifact.
 
 :::note[Downloading your keystore file]
 

--- a/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-react-native-projects.mdx
+++ b/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-react-native-projects.mdx
@@ -258,7 +258,7 @@ You can deploy your React Native app to:
 
 :::note[CodePush]
 
-You can deploy updates to your users' devices with Bitrise CodePush. CodePush is part of [Release Management](urn:resource:publication:90740) and it is supported for React Native and Expo apps.
+You can deploy updates to your users' devices with Bitrise CodePush. CodePush is part of [Release Management](/en/release-management) and it is supported for React Native and Expo apps.
 
 For more information about CodePush, check out the official guides: [CodePush](/en/release-management/codepush/about-codepush).
 

--- a/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci.mdx
+++ b/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci.mdx
@@ -185,7 +185,7 @@ For Ruby projects, we automatically generate a testing Workflow with the right t
 
 Bitrise offers two distinct caching solutions:
 
-- [The Bitrise Build Cache](urn:resource:publication:94853): If you build your project with Bazel or Gradle, the Bitrise Build Cache caches build and test outputs to minimize how much work is done in subsequent builds. It's compatible with any CI tool and accelerates the build cycle without requiring you to manage a caching infrastructure.
+- [The Bitrise Build Cache](/en/bitrise-build-cache): If you build your project with Bazel or Gradle, the Bitrise Build Cache caches build and test outputs to minimize how much work is done in subsequent builds. It's compatible with any CI tool and accelerates the build cycle without requiring you to manage a caching infrastructure.
 - [Key-based caching](/en/bitrise-ci/dependencies-and-caching/key-based-caching/using-key-based-caching): Key-based caching works by associating cache archives with a key. A Workflow can restore a cache archive by referring to the key; at the end of the Workflow, the build files can be saved into the cache archive that the key indicates. This overwrites the cache archive.
 
 ### Bitrise Build Cache

--- a/docs/bitrise-ci/getting-started/the-bitrise-dashboard.mdx
+++ b/docs/bitrise-ci/getting-started/the-bitrise-dashboard.mdx
@@ -13,12 +13,12 @@ Your first stop when logging in to Bitrise is the dashboard. It allows you to na
 
 - Your <GlossTerm baseform="Project">projects</GlossTerm>.
 - Your [CI builds](/en/bitrise-ci/run-and-analyze-builds/finding-a-specific-build) on your workspace's CI dashboard.
-- The [Bitrise Build Cache](urn:resource:publication:94853).
-- [Release Management](urn:resource:publication:90740).
+- The [Bitrise Build Cache](/en/bitrise-build-cache).
+- [Release Management](/en/release-management).
 
 ![dashboard-overview.png](/img/_paligo/uuid-c88d4641-9945-2d84-dd14-ef30fdd68fc4.png)
 
-You can also find [Insights](urn:resource:publication:94879) data for the workspace.
+You can also find [Insights](/en/insights) data for the workspace.
 
 ## Checking project details
 
@@ -44,7 +44,7 @@ You can create projects without a CI configuration: add a new app to Release Man
 
 :::
 
-Any CI project added this way will also be visible on the dashboard. You can also access [Release Management](urn:resource:publication:90740) to add an app and link it to the project.
+Any CI project added this way will also be visible on the dashboard. You can also access [Release Management](/en/release-management) to add an app and link it to the project.
 
 ## Workspace insights
 
@@ -57,4 +57,4 @@ In the **Insights for workspace** section, you can see some basic aggregated dat
 
 ![workspace-insights.png](/img/_paligo/uuid-b15d9482-748d-bb6a-1aaa-c1153ed8392b.png)
 
-Explore [Insights](urn:resource:publication:94879) to see more metrics, providing data-driven visibility.
+Explore [Insights](/en/insights) to see more metrics, providing data-driven visibility.

--- a/docs/bitrise-ci/references/steps-reference/step-inputs-reference.mdx
+++ b/docs/bitrise-ci/references/steps-reference/step-inputs-reference.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GlossTerm from '@site/src/components/GlossTerm';
 
-<GlossTerm baseform="Step">Step</GlossTerm> inputs are environment items that tell the [Bitrise CLI](urn:resource:component:43013) how to run a given Step. The inputs of a Step are defined in the `step.yml` file of every Step by setting the `inputs` property..
+<GlossTerm baseform="Step">Step</GlossTerm> inputs are environment items that tell the [Bitrise CLI](/en/bitrise-ci/bitrise-cli/installing-and-updating-the-bitrise-cli) how to run a given Step. The inputs of a Step are defined in the `step.yml` file of every Step by setting the `inputs` property..
 
 Step inputs have the same syntax as every environment property. It consists of two main parts: a `KEY: value` pair and an `opts` field.
 

--- a/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-checks-on-github.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-checks-on-github.mdx
@@ -93,7 +93,7 @@ Please note that only workspace owners and project admins can enable this toggle
 
    :::important[Can't toggle the switch?]
 
-   If you can't toggle the switch, check out [see topic](#cant-enable-github-checks).
+   If you can't toggle the switch, check out [Can't enable GitHub Checks](#cant-enable-github-checks).
 
    :::
 1. <GlossTerm baseform="trigger">Trigger</GlossTerm> a build. You can do so either automatically or manually. If you trigger a build manually, provide a specific commit hash to build.

--- a/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/rebuilding-a-failed-build.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/rebuilding-a-failed-build.mdx
@@ -45,7 +45,7 @@ You can rebuild a Pipeline either in full or its unsuccessful Workflows with the
 1. On the Pipeline summary screen, click **Rebuild** to bring up the rebuild dropdown menu.
 1. Select an option:
 
-   - **Rebuild unsuccessful Workflows**: This option only rebuilds the Workflows that failed. This option might not be available for variant Workflows using the `parallel` property: [see topic](#rebuilding-pipelines-using-different-workflow-variants).
+   - **Rebuild unsuccessful Workflows**: This option only rebuilds the Workflows that failed. This option might not be available for variant Workflows using the `parallel` property: [Rebuilding Pipelines using different Workflow variants](#rebuilding-pipelines-using-different-workflow-variants).
    - **Rebuild the entire Pipeline**: This option rebuilds the entire Pipeline from start to finish.
    - **Rebuild unsuccessful Workflows with remote access**: Remote access allows you to access the build machine remotely while the build is running: [Remote access](/en/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/remote-access).
    - **Rebuild entire Pipeline with remote access**: See above.
@@ -54,7 +54,7 @@ You can rebuild a Pipeline either in full or its unsuccessful Workflows with the
 
 You can rebuild a Pipeline from a specific failed Workflow. This will rebuild all Workflows that come after the failed Workflow in the Pipeline.
 
-This option might not be available for variant Workflows using the `parallel` property: [see topic](#rebuilding-pipelines-using-different-workflow-variants).
+This option might not be available for variant Workflows using the `parallel` property: [Rebuilding Pipelines using different Workflow variants](#rebuilding-pipelines-using-different-workflow-variants).
 
 1. Open Bitrise CI.
 1. Click a finished Pipeline build for your project.

--- a/docs/bitrise-ci/run-and-analyze-builds/build-triggers/configuring-build-triggers.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/build-triggers/configuring-build-triggers.mdx
@@ -191,7 +191,7 @@ This feature is only supported for GitHub and GitLab repositories.
 
 By default, opening a draft PR triggers builds. You can disable this at any time.
 
-If opening a draft PR triggers a build, submitting it for review (converting it to "full" PR, in other words) will not trigger another. You can check out the exact code events that trigger builds depending on the draft PR trigger settings: [see topic](#build-trigger-behavior-for-draft-prs).
+If opening a draft PR triggers a build, submitting it for review (converting it to "full" PR, in other words) will not trigger another. You can check out the exact code events that trigger builds depending on the draft PR trigger settings: [Build trigger behavior for draft PRs](#build-trigger-behavior-for-draft-prs).
 
 Each separate trigger has its own toggle: you can configure your app so that certain triggers start a build from draft PRs while other triggers don't.
 

--- a/docs/bitrise-ci/run-and-analyze-builds/managing-build-files/uploading-files-for-your-builds.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/managing-build-files/uploading-files-for-your-builds.mdx
@@ -14,7 +14,7 @@ If your build requires any files to make it work, you can upload them to Bitrise
 
 Once a file is uploaded, it is stored [as an Environment Variable (Env Var)](/en/bitrise-ci/configure-builds/environment-variables). You can use this Env Var to access the file and use it in your builds. The file can also be:
 
-- Downloaded by anyone who has either [admin or owner role](/en/bitrise-platform/projects/roles-and-permissions-for-bitrise-ci) on the app’s team on Bitrise. You can prevent this: [see topic](#protecting-your-uploaded-files)
+- Downloaded by anyone who has either [admin or owner role](/en/bitrise-platform/projects/roles-and-permissions-for-bitrise-ci) on the app’s team on Bitrise. You can prevent this: [Protecting your uploaded files](#protecting-your-uploaded-files)
 - Exposed to pull request builds.
 
 :::important[File restrictions]

--- a/docs/bitrise-ci/run-and-analyze-builds/starting-builds/scheduling-builds.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/starting-builds/scheduling-builds.mdx
@@ -52,7 +52,7 @@ How to schedule a build with the basic configuration options on Bitrise:
 
    :::
 
-   For advanced configuration options, see the [see topic](#advanced-configuration-options-for-startingscheduling-builds) section.
+   For advanced configuration options, see the [Advanced configuration options for starting/scheduling builds](#advanced-configuration-options-for-startingscheduling-builds) section.
 
    ![schedule-basic.png](/img/_paligo/uuid-9e21a75a-a3ed-54f2-9b07-53a46d9a3d2d.png)
 1. When done, click **Schedule build**.

--- a/docs/bitrise-ci/workflows-and-pipelines/steps/enabling-or-disabling-a-step-conditionally.mdx
+++ b/docs/bitrise-ci/workflows-and-pipelines/steps/enabling-or-disabling-a-step-conditionally.mdx
@@ -11,7 +11,7 @@ import GlossTerm from '@site/src/components/GlossTerm';
 
 You can enable or disable a <GlossTerm baseform="Step">Step</GlossTerm> in any given <GlossTerm baseform="Workflow">Workflow</GlossTerm>, and you can also set conditions for Steps. You can do it either on your own computer, with the Bitrise CLI or by using the **<GlossTerm baseform="bitrise.yml">bitrise.yml</GlossTerm>** tab of the <GlossTerm baseform="workflow editor">Workflow Editor</GlossTerm>.
 
-We mostly use `run_if` expressions to do these things. Check out the examples for possible template expressions: [see topic](#examples-of-run_if-expressions).
+We mostly use `run_if` expressions to do these things. Check out the examples for possible template expressions: [Examples of run_if expressions](#examples-of-run_if-expressions).
 
 You can also view the examples on GitHub: [Template expression examples](https://github.com/bitrise-io/bitrise/blob/master/_examples/experimentals/templates/bitrise.yml).
 

--- a/docs/bitrise-ci/workflows-and-pipelines/steps/step-bundles.mdx
+++ b/docs/bitrise-ci/workflows-and-pipelines/steps/step-bundles.mdx
@@ -201,7 +201,7 @@ Step bundles allow nesting: you can add a Step bundle within another Step bundle
 
 In any Step bundle, a list of inputs can be defined under the `inputs` key. These are the only inputs you can set for a Step bundle: you can't define additional inputs outside the bundle definition.
 
-You can, however, set values for the predefined inputs of a Step bundle outside the bundle definition: [see topic](#configuring-step-bundle-inputs).
+You can, however, set values for the predefined inputs of a Step bundle outside the bundle definition: [Configuring Step bundle inputs](#configuring-step-bundle-inputs).
 
 Step bundle inputs share the same model as Step inputs. You can read more about Step inputs and their format: [Step inputs reference](/en/bitrise-ci/references/steps-reference/step-inputs-reference).
 

--- a/docs/bitrise-ci/workflows-and-pipelines/workflows/default-workflows.mdx
+++ b/docs/bitrise-ci/workflows-and-pipelines/workflows/default-workflows.mdx
@@ -95,7 +95,7 @@ For Python, a single `run_tests` Workflow is generated. The included Steps depen
 
 | Workflow ID | Workflow summary | Workflow description |
 | --- | --- | --- |
-| `run_tests` | Run your project’s tests. | The Workflow clones your Git repository and installs Python based on the detected version. If no version is detected, the <GlossTerm baseform="stack">stack's</GlossTerm> default Python version is used. Installs dependencies: the exact command used depends on the [detected package manager](urn:resource:component:133846).  If `pytest` is detected, the Workflow runs your tests. |
+| `run_tests` | Run your project’s tests. | The Workflow clones your Git repository and installs Python based on the detected version. If no version is detected, the <GlossTerm baseform="stack">stack's</GlossTerm> default Python version is used. Installs dependencies: the exact command used depends on the [detected package manager](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci#package-manager-detection-for-python).  If `pytest` is detected, the Workflow runs your tests. |
 
 
 ## Default Workflows for a Flutter project

--- a/docs/bitrise-platform/infrastructure/bitrise-on-aws-cloud-controller/creating-and-configuring-a-controller.mdx
+++ b/docs/bitrise-platform/infrastructure/bitrise-on-aws-cloud-controller/creating-and-configuring-a-controller.mdx
@@ -77,7 +77,7 @@ For more information, read [the official AWS documentation on VPCs](https://docs
 
    - **Stack name**: Any value works here. This helps to identify the stack if you have multiple stacks.
    - **Latest AMI ID**: This AMI ID is used as a base AMI to run the Cloud Controller on.
-   - **Bitrise Controller Token**: The token is generated as part of controller creation on Bitrise: [see topic](#configuring-the-controller-on-bitrise).
+   - **Bitrise Controller Token**: The token is generated as part of controller creation on Bitrise: [Configuring the controller on Bitrise](#configuring-the-controller-on-bitrise).
    - **Bitrise Workspace ID**: [Identifying Workspaces and apps with their slugs](/en/bitrise-ci/api/identifying-workspaces-and-apps-with-their-slugs).
    - **Controller Log Group Class** : The Cloud Controller generates logs that are accessible to the customers in AWS. This configuration specifies what features the customer wants to use during log analysis. The default is **Infrequent access**, which provides a limited log analyzing capability at a lower cost.
    - **Controller Log Retention In Days** : Determines how long AWS stores the Cloud Controller logs.
@@ -122,7 +122,7 @@ For more information, read [the official AWS documentation on VPCs](https://docs
 
    - **Stack name**: Any value works here. This helps to identify the stack if you have multiple stacks.
    - **Latest AMI ID**: This AMI ID is used as a base AMI to run the Cloud Controller on.
-   - **Bitrise Controller Token**: The token is generated as part of controller creation on Bitrise: [see topic](#configuring-the-controller-on-bitrise).
+   - **Bitrise Controller Token**: The token is generated as part of controller creation on Bitrise: [Configuring the controller on Bitrise](#configuring-the-controller-on-bitrise).
    - **Bitrise Workspace ID**: [Identifying Workspaces and apps with their slugs](/en/bitrise-ci/api/identifying-workspaces-and-apps-with-their-slugs).
    - **Controller Log Group Class** : The Cloud Controller generates logs that are accessible to the customers in AWS. This configuration specifies what features the customer wants to use during log analysis. The default is **Infrequent access**, which provides a limited log analyzing capability at a lower cost.
    - **Controller Log Retention In Days** : Determines how long AWS stores the Cloud Controller logs.

--- a/docs/bitrise-platform/infrastructure/build-machines/about-build-machines.mdx
+++ b/docs/bitrise-platform/infrastructure/build-machines/about-build-machines.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GlossTerm from '@site/src/components/GlossTerm';
 
-For [Bitrise CI](urn:resource:publication:94442), both Linux and Xcode <GlossTerm baseform="stack">stacks</GlossTerm> are available on several different build machine types. Each machine type offers several options with varying computing power, depending on [your subscription plan](http://www.bitrise.io/pricing).
+For [Bitrise CI](/en/bitrise-ci), both Linux and Xcode <GlossTerm baseform="stack">stacks</GlossTerm> are available on several different build machine types. Each machine type offers several options with varying computing power, depending on [your subscription plan](http://www.bitrise.io/pricing).
 
 You can configure a default machine type for each of your projects and you can also set <GlossTerm baseform="Workflow">Workflow</GlossTerm>-specific machine types. You can do this when selecting stacks for your project: [Setting the stack for your builds](/en/bitrise-ci/configure-builds/configuring-build-settings/setting-the-stack-for-your-builds).
 

--- a/docs/bitrise-platform/infrastructure/build-machines/configuring-your-network-to-access-our-build-machines.mdx
+++ b/docs/bitrise-platform/infrastructure/build-machines/configuring-your-network-to-access-our-build-machines.mdx
@@ -10,9 +10,9 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GlossTerm from '@site/src/components/GlossTerm';
 
-Our datacenters are behind a set of public static IP addresses, with the virtual machines having their own internal subnets behind these addresses. Depending on your company security policy, you may need to allowlist the public IP addresses to be able to access the build machine: [see topic](#ip-address-ranges-for-the-bitrise-build-machines).
+Our datacenters are behind a set of public static IP addresses, with the virtual machines having their own internal subnets behind these addresses. Depending on your company security policy, you may need to allowlist the public IP addresses to be able to access the build machine: [IP address ranges for the Bitrise build machines](#ip-address-ranges-for-the-bitrise-build-machines).
 
-Similarly, the Bitrise background workers powering [app.bitrise.io](http://app.bitrise.io) UI and related control plane, configuration management, signaling to your services are accessible at a set of static IP addresses. Allowlisting these addresses can ensure you can still receive build status updates or that Bitrise can access the `<GlossTerm baseform="bitrise.yml">bitrise.yml</GlossTerm>` file: [see topic](#ip-address-ranges-for-bitrise-backend-workers) of your app.
+Similarly, the Bitrise background workers powering [app.bitrise.io](http://app.bitrise.io) UI and related control plane, configuration management, signaling to your services are accessible at a set of static IP addresses. Allowlisting these addresses can ensure you can still receive build status updates or that Bitrise can access the `<GlossTerm baseform="bitrise.yml">bitrise.yml</GlossTerm>` file: [IP address ranges for Bitrise backend workers](#ip-address-ranges-for-bitrise-backend-workers) of your app.
 
 
 ## IP address ranges for the Bitrise build machines

--- a/docs/bitrise-platform/integrations/ai-code-reviewer.mdx
+++ b/docs/bitrise-platform/integrations/ai-code-reviewer.mdx
@@ -46,7 +46,7 @@ The AI code reviewer runs a Bitrise build that shows up in your list of Bitrise 
 - Doesn't count towards any of your resource limits (credits, build count, build minutes).
 - Doesn't count towards concurrency limits.
 - Increases the actual [build number](/en/bitrise-ci/run-and-analyze-builds/build-numbering-and-app-versioning#adding-the-ssh-key-to-the-machine-user).
-- Is included in [Insights](urn:resource:publication:94879) data.
+- Is included in [Insights](/en/insights) data.
 
 For each new commit on a pull request, the code reviewer starts a new review and a new build.
 

--- a/docs/bitrise-platform/integrations/apple-services-connection/about-connecting-to-apple-services.mdx
+++ b/docs/bitrise-platform/integrations/apple-services-connection/about-connecting-to-apple-services.mdx
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GlossTerm from '@site/src/components/GlossTerm';
 
-Both [Bitrise CI](urn:resource:publication:94442) and [Release Management](urn:resource:publication:90740) helps you automate Mobile DevOps processes that require Apple's online services. To connect to these services, such as the Apple Developer Portal or App Store Connect, you need to provide authentication data to Bitrise and select the established authentication method for your project.
+Both [Bitrise CI](/en/bitrise-ci) and [Release Management](/en/release-management) helps you automate Mobile DevOps processes that require Apple's online services. To connect to these services, such as the Apple Developer Portal or App Store Connect, you need to provide authentication data to Bitrise and select the established authentication method for your project.
 
 You can authenticate with Apple’s official API key or with Apple ID and password.
 

--- a/docs/bitrise-platform/integrations/apple-services-connection/steps-requiring-apple-authentication.mdx
+++ b/docs/bitrise-platform/integrations/apple-services-connection/steps-requiring-apple-authentication.mdx
@@ -83,7 +83,7 @@ With [this Step](https://www.bitrise.io/integrations/steps/deploy-to-itunesconne
 
 ## [fastlane](https://github.com/bitrise-io/steps-fastlane) Step
 
-With this Step you can run your [*fastlane*](https://fastlane.tools/) lanes on Bitrise just like you would locally. Check out our guide about [Integrating fastlane to Bitrise](urn:resource:component:77300) for more information.
+With this Step you can run your [*fastlane*](https://fastlane.tools/) lanes on Bitrise just like you would locally.
 
 Please note that in the case of 2FA enabled Apple ID, the [**Fastlane**](https://github.com/bitrise-io/steps-fastlane) Step can only work with Apple ID authentication which you can set on the **Apple Service** page of your profile.
 

--- a/docs/bitrise-platform/integrations/connecting-a-google-service-account-to-bitrise.mdx
+++ b/docs/bitrise-platform/integrations/connecting-a-google-service-account-to-bitrise.mdx
@@ -11,7 +11,7 @@ import GlossTerm from '@site/src/components/GlossTerm';
 import Partial_OpeningTheWorkspaceSettingsPage from '@site/src/partials/opening-the-workspace-settings-page.mdx';
 import Partial_GettingToTheProjectSettingsPage from '@site/src/partials/getting-to-the-project-settings-page.mdx';
 
-You can connect a Google Console Service account to a <GlossTerm baseform="workspace">Workspace</GlossTerm>. The service account will be available to use for all the projects owned by that Workspace. It allows you to seamlessly deploy your Android apps to Google Play with [Release Management](urn:resource:component:77516).
+You can connect a Google Console Service account to a <GlossTerm baseform="workspace">Workspace</GlossTerm>. The service account will be available to use for all the projects owned by that Workspace. It allows you to seamlessly deploy your Android apps to Google Play with [Release Management](/en/release-management).
 
 You can add multiple service accounts to a Workspace but a Bitrise <GlossTerm baseform="project">project</GlossTerm> can only have a single service account connected to it at any given time. However, you can change the connected account at any time.
 

--- a/docs/bitrise-platform/projects/creating-white-label-app-versions.mdx
+++ b/docs/bitrise-platform/projects/creating-white-label-app-versions.mdx
@@ -17,7 +17,7 @@ What you’ll need for this setup:
 
 - A main Workflow that launches each version-specific Workflow.
 - One or more version-specific Workflow(s) where you can set all the parameters that distinguish your versions from each other.
-- A utility Workflow which describes your build logic, and refers to the version-specific options as parameters. [Utility Workflows are Workflows that have an underscore before their Workflow ID](urn:resource:component:43026). Utility Workflows cannot be executed with the `bitrise_run` command: you need to reference them with the `before_run` or `after_run` properties. You can [chain utility Workflows with your regular Workflows](/en/bitrise-ci/workflows-and-pipelines/workflows/managing-workflows#chaining-workflows-together) in the <GlossTerm baseform="Workflow Editor">Workflow Editor</GlossTerm>.
+- A utility Workflow which describes your build logic, and refers to the version-specific options as parameters. [Utility Workflows are Workflows that have an underscore before their Workflow ID](/en/bitrise-ci/workflows-and-pipelines/workflows/managing-workflows#utility-workflows). Utility Workflows cannot be executed with the `bitrise_run` command: you need to reference them with the `before_run` or `after_run` properties. You can [chain utility Workflows with your regular Workflows](/en/bitrise-ci/workflows-and-pipelines/workflows/managing-workflows#chaining-workflows-together) in the <GlossTerm baseform="Workflow Editor">Workflow Editor</GlossTerm>.
 
 
 ## Prepping Workflows of a white label app
@@ -40,7 +40,7 @@ What you’ll need for this setup:
    In this example we’re adding Workflow Environment Variables to our **green**, **red** and **white** Workflows but leaving **allcolor** intact.
 
    ![env-ars-whitelabel.png](/img/_paligo/uuid-68837c3f-707c-19aa-86e2-bbac732be5a5.png)
-1. Go back to **Workflows** and create a [utility Workflow](urn:resource:component:43026).
+1. Go back to **Workflows** and create a [utility Workflow](/en/bitrise-ci/workflows-and-pipelines/workflows/managing-workflows#utility-workflows).
 
    Make sure you give a name that starts with an underscore, for example, **_runner**, otherwise Bitrise CLI will not treat it as a utility Workflow.
 1. Add <GlossTerm baseform="step">Steps</GlossTerm> to your utility Workflow.

--- a/docs/bitrise-platform/projects/managing-user-access-to-a-project.mdx
+++ b/docs/bitrise-platform/projects/managing-user-access-to-a-project.mdx
@@ -51,7 +51,7 @@ You need to be a project admin or a workspace owner to be able to add outside co
 1. Configure product access by enabling one or more toggles and then selecting a role in the dialog. You have the option to grant universal access or to set roles on a product basis:
 
    - **Admin access** allows the contributor to manage all aspects of the project, including both the Bitrise CI configuration and the Release Management apps. Note that this gives full access to an outside contributor!
-   - Select a product to assign the contributor specific roles that only apply to that product. If the project doesn't have a [CI configuration](urn:resource:publication:94442) or a [Release Management app](urn:resource:publication:90740), the respective option won't be available.
+   - Select a product to assign the contributor specific roles that only apply to that product. If the project doesn't have a [CI configuration](/en/bitrise-ci) or a [Release Management app](/en/release-management), the respective option won't be available.
 1. Click **Confirm access**.
 
 <Partial_AddingWorkspaceGroupsToAProject />

--- a/docs/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/workspace-collaboration.mdx
+++ b/docs/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/workspace-collaboration.mdx
@@ -14,7 +14,7 @@ Your <GlossTerm baseform="Workspace">workspace</GlossTerm> isn't just an environ
 
 You can manage workspace membership on the **Collaboration** page of the workspace settings. You can add members to a workspace in three ways:
 
-- Invite individual members: [see topic](#adding-members-to-workspaces).
+- Invite individual members: [Adding members to workspaces](#adding-members-to-workspaces).
 - Add them to a project as outside contributors.
 - Organize them into [workspace groups](/en/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/workspace-groups).
 

--- a/docs/insights/available-metrics-in-insights/bitrise-ci-metrics.mdx
+++ b/docs/insights/available-metrics-in-insights/bitrise-ci-metrics.mdx
@@ -17,7 +17,7 @@ Insights allows you to track three main categories of CI metrics:
 
 In addition, Insights can provide data for:
 
-- The [Bitrise Build Cache](urn:resource:publication:94853).
+- The [Bitrise Build Cache](/en/bitrise-build-cache).
 - Git operations: [Git Insights](/en/insights/git-insights).
 
 ## Build metrics

--- a/docs/release-management/codepush/codepush-updates-with-bitrise-ci.mdx
+++ b/docs/release-management/codepush/codepush-updates-with-bitrise-ci.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CodePush updates with Bitrise CI"
-description: "You can release your CodePush updates via a [Bitrise CI](urn:resource:publication:94442) Workflow that creates the update packages for both iOS and Android, and updates both to the Bitrise CodePush Server."
+description: "You can release your CodePush updates via a [Bitrise CI](/en/bitrise-ci) Workflow that creates the update packages for both iOS and Android, and updates both to the Bitrise CodePush Server."
 sidebar_position: 5
 slug: /release-management/codepush/codepush-updates-with-bitrise-ci
 ---
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GlossTerm from '@site/src/components/GlossTerm';
 
-You can release your CodePush updates via a [Bitrise CI](urn:resource:publication:94442) <GlossTerm baseform="Workflow">Workflow</GlossTerm>. The process requires:
+You can release your CodePush updates via a [Bitrise CI](/en/bitrise-ci) <GlossTerm baseform="Workflow">Workflow</GlossTerm>. The process requires:
 
 - Setting up CodePush credentials: create <GlossTerm baseform="Secret">Secrets</GlossTerm> and [Environment Variables](/en/bitrise-ci/configure-builds/environment-variables) that hold the deployment ID and the deployment key from Bitrise CodePush.
 - Creating a Workflow that creates the update packages for both iOS and Android, and updates both to the Bitrise CodePush Server.

--- a/docs/release-management/codepush/configuring-your-app-for-codepush.mdx
+++ b/docs/release-management/codepush/configuring-your-app-for-codepush.mdx
@@ -23,10 +23,10 @@ CodePush for React Native requires installing the SDK and then setting up CodePu
    ```bash
    npm install @code-push-next/react-native-code-push
    ```
-1. Set up CodePush for iOS. You can find the most important instructions here: [see topic](#ios-setup).
+1. Set up CodePush for iOS. You can find the most important instructions here: [iOS setup](#ios-setup).
 
    Read more in the GitHub repository of the SDK: [iOS](https://github.com/CodePushNext/react-native-code-push/blob/master/docs/setup-ios.md).
-1. Set up CodePush for Android. You can find the most important instructions here: [see topic](#android-setup).
+1. Set up CodePush for Android. You can find the most important instructions here: [Android setup](#android-setup).
 
    Read more in the GitHub repository of the SDK: [Android](https://github.com/CodePushNext/react-native-code-push/blob/master/docs/setup-android.md).
 

--- a/docs/release-management/codepush/creating-and-releasing-codepush-updates.mdx
+++ b/docs/release-management/codepush/creating-and-releasing-codepush-updates.mdx
@@ -164,7 +164,7 @@ You can upload the package either via the Release Management GUI or the Release 
 1. Click **New update**.
 1. In the **Target versions** field, add the version range of the update.
 
-   You can use range expressions: [see topic](#target-versions).
+   You can use range expressions: [Target versions](#target-versions).
 1. Optionally, add an update description.
 1. Check **Enabled** to make sure users can download the update.
 
@@ -186,7 +186,7 @@ You can upload the package either via the Release Management GUI or the Release 
 </TabItem>
 <TabItem value="api" label="API">
 
-1. Make sure your CodePush credentials are available: [see topic](#getting-your-codepush-credentials).
+1. Make sure your CodePush credentials are available: [Getting your CodePush credentials](#getting-your-codepush-credentials).
 1. Clone the `release-management-recipes` repository from Bitrise.
 
    The repository contains a helper script that we will use to upload the update package.

--- a/docs/release-management/releases/release-presets.mdx
+++ b/docs/release-management/releases/release-presets.mdx
@@ -52,7 +52,7 @@ Preset options for the review and release stage:
 - **Release note**: You can create a release note preset for Android apps.
 - **App Store metadata**: You can create a release note preset for iOS apps.
 
-For details, read [see topic](#release-note-preset).
+For details, read [Release note preset](#release-note-preset).
 
 ## Release note preset
 

--- a/src/partials/adding-workspace-groups-to-a-project.mdx
+++ b/src/partials/adding-workspace-groups-to-a-project.mdx
@@ -35,7 +35,7 @@ There are two ways to assign workspace groups to a Bitrise <GlossTerm baseform="
 1. Configure product access by enabling one or more toggles and then selecting a role for your project in the dialog. You have the option to grant universal access or to set roles on a product basis:
 
    - **Admin access** allows the contributor to manage all aspects of the project, including both the Bitrise CI configuration and the Release Management apps. Note that this gives full access to an outside contributor!
-   - Select a product to assign the group specific roles that only apply to that product. If the project doesn't have a [CI configuration](urn:resource:publication:94442) or a [Release Management app](urn:resource:publication:90740), the respective option won't be available.
+   - Select a product to assign the group specific roles that only apply to that product. If the project doesn't have a [CI configuration](/en/bitrise-ci) or a [Release Management app](/en/release-management), the respective option won't be available.
 
    ![2025-08-07-access-in-rm-dialog.png](/img/_paligo/uuid-5b7fd557-dadc-4d73-eaa5-39119cd3b63f.png)
 
@@ -64,5 +64,5 @@ There are two ways to assign workspace groups to a Bitrise <GlossTerm baseform="
 1. Configure product access by enabling one or more toggles and then selecting a role in the dialog. You have the option to grant universal access or to set roles on a product basis:
 
    - **Admin access** allows the group members to manage all aspects of the project, including both the Bitrise CI configuration and the Release Management apps.
-   - Select a product to assign the group specific roles that only apply to that product. If the project doesn't have a [CI configuration](urn:resource:publication:94442) or a [Release Management app](urn:resource:publication:90740), the respective option won't be available.
+   - Select a product to assign the group specific roles that only apply to that product. If the project doesn't have a [CI configuration](/en/bitrise-ci) or a [Release Management app](/en/release-management), the respective option won't be available.
 1. Click **Confirm access**.


### PR DESCRIPTION
## Summary

- Replace 30 `[see topic](#anchor)` placeholder links with the actual heading title they point to, across 20 files
- Replace all `urn:resource:` links (leftover Paligo migration artifacts) with real URLs across 22 files — publications mapped to product index pages, components mapped to specific doc pages
- Remove one unresolvable fastlane guide sentence (`component:77300`) that had no equivalent page in the new docs

## Test plan

- [ ] Verify anchor links resolve correctly on the rendered pages
- [ ] Verify product-level links (`/en/release-management`, `/en/bitrise-ci`, `/en/bitrise-build-cache`, `/en/insights`) load correctly
- [ ] Verify `#utility-workflows` and `#package-manager-detection-for-python` anchors resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)