### PR TITLE
Fix broken external links and missing spaces around link text

### DIFF
--- a/docs/bitrise-ci/bitrise-cli/adding-a-new-project-from-a-cli.mdx
+++ b/docs/bitrise-ci/bitrise-cli/adding-a-new-project-from-a-cli.mdx
@@ -31,14 +31,14 @@ This procedure guides you through adding a project which Bitrise will access wit
 
 You can, of course, use an HTTPS URL to access your remote repository, too: in that case, you will not set an SSH key for your project. We only recommend using HTTPS URLs for public projects (open source projects).
 
-And that’s it! You are done: the URL to your new project will be printed out, and you can also view the project on your [Dashboard](https://project.bitrise.io/dashboard/).
+And that’s it! You are done: the URL to your new project will be printed out, and you can also view the project on your [Dashboard](https://app.bitrise.io/dashboard/).
 
 
 ## Adding the project
 
-1. Go to the [Create New project from CLI](https://project.bitrise.io/dashboard/add-project-from-cli) page.
+1. Go to the [Create New project from CLI](https://app.bitrise.io/dashboard/add-project-from-cli) page.
 
-   You can reach this page from your [Dashboard](https://project.bitrise.io/dashboard/builds): click the **Add new project** button on the right, and then select **Add New project from CLI**.
+   You can reach this page from your [Dashboard](https://app.bitrise.io/dashboard/builds): click the **Add new project** button on the right, and then select **Add New project from CLI**.
 
    ![2025-12-10-adding-project-with-cli.png](/img/_paligo/uuid-a6c8e931-615c-8697-8cf6-ab8d5269420b.png)
 1. Set the account that will own the project, and the privacy of the project.

--- a/docs/bitrise-ci/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step.mdx
+++ b/docs/bitrise-ci/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step.mdx
@@ -24,7 +24,7 @@ Please note that AAB files can only be signed with jarsigner. The Step uses `jar
 1. [Upload your keystore file to Bitrise](/en/bitrise-ci/code-signing/android-code-signing/uploading-android-keystore-files-to-bitrise).
 1. Add the [**Android Sign**](https://github.com/bitrise-steplib/steps-sign-apk) Step to your Workflow after the Step that builds your APK or AAB file.
 
-   Bitrise uses the above Environment Variables and sets them as inputs into the respective fields of the [**Android Sign**](https://github.com/bitrise-steplib/steps-sign-apk) Step. Once the Step runs, it produces either a signed APK or an AAB. The signed APK or AAB is used in deploy Steps, for example, the[**Google Play Deploy**](https://github.com/bitrise-io/steps-google-play-deploy) Step or the **Deploy to Bitrise.io** Step. The latter deploys the APK/AAB on the **Artifacts** tab. You can also use [Release Management](/en/release-management) to deploy your app once you built an installable artifact.
+   Bitrise uses the above Environment Variables and sets them as inputs into the respective fields of the [**Android Sign**](https://github.com/bitrise-steplib/steps-sign-apk) Step. Once the Step runs, it produces either a signed APK or an AAB. The signed APK or AAB is used in deploy Steps, for example, the [**Google Play Deploy**](https://github.com/bitrise-io/steps-google-play-deploy) Step or the **Deploy to Bitrise.io** Step. The latter deploys the APK/AAB on the **Artifacts** tab. You can also use [Release Management](/en/release-management) to deploy your app once you built an installable artifact.
 
 :::note[Downloading your keystore file]
 

--- a/docs/bitrise-ci/code-signing/ios-code-signing/managing-ios-code-signing-files-manual-provisioning.mdx
+++ b/docs/bitrise-ci/code-signing/ios-code-signing/managing-ios-code-signing-files-manual-provisioning.mdx
@@ -35,7 +35,7 @@ To manually upload your code signing files to Bitrise:
 
    - To add a certificate, click the **Add .p12 file** button. In the dialog box, upload the file and, if required, provide the password for the certificate.
    - To add provisioning profiles, click the **Add profile(s)** button. In the dialog box, upload the file(s).
-1. Make sure you have the [**Certificate and profile installer**](https://github.com/bitrise-steplib/steps-certificate-and-profile-installer)Step in your app’s <GlossTerm baseform="Workflow">Workflow</GlossTerm>. You can check it on the **Workflow** tab of the <GlossTerm baseform="Workflow Editor">Workflow Editor</GlossTerm>.
+1. Make sure you have the [**Certificate and profile installer**](https://github.com/bitrise-steplib/steps-certificate-and-profile-installer) Step in your app’s <GlossTerm baseform="Workflow">Workflow</GlossTerm>. You can check it on the **Workflow** tab of the <GlossTerm baseform="Workflow Editor">Workflow Editor</GlossTerm>.
 
    Please note that these Steps must be **BEFORE** the Steps that archive and export your app (for example, [**Xcode Archive & Export for iOS**](https://github.com/bitrise-steplib/steps-xcode-archive)) in your Workflow.
 

--- a/docs/bitrise-ci/configure-builds/configuration-yaml/editing-an-apps-bitriseyml-file.mdx
+++ b/docs/bitrise-ci/configure-builds/configuration-yaml/editing-an-apps-bitriseyml-file.mdx
@@ -37,7 +37,7 @@ To download the current `bitrise.yml` file, click **Download**. Alternatively, y
 
 ## Editing the bitrise.yml file locally
 
-Our YAML scheme is shared on [schemastore](http://schemastore.org/json/). This means that syntax highlight and auto-completion is available for the following files if you edit them locally:
+Our YAML scheme is shared on [schemastore](https://www.schemastore.org/bitrise.json). This means that syntax highlight and auto-completion is available for the following files if you edit them locally:
 
 - `bitrise.yml`
 - `step.yml`

--- a/docs/bitrise-ci/configure-builds/configuring-build-settings/setting-your-git-credentials-on-build-machines.mdx
+++ b/docs/bitrise-ci/configure-builds/configuring-build-settings/setting-your-git-credentials-on-build-machines.mdx
@@ -20,7 +20,7 @@ If you want to push back (`git push`) any commits to your own repo from Bitrise 
 
 - You can use a custom Script <GlossTerm baseform="Step">Step</GlossTerm> to set your credentials with the `git config` command.
 - You can set your Git credentials as Env Vars.
-- You can use the [**Set Git Credentials**](https://github.com/prosperllc/bitrise-step-set-git-credentials) Step.
+- You can use the [**Set Git Credentials**](https://bitrise.io/integrations/steps/set-git-credentials) Step.
 
 ## Setting your Git credentials using Env Vars
 
@@ -37,9 +37,9 @@ Git has various basic [Environmental Variables](https://git-scm.com/book/en/v2/G
 
    ![git_credentials.png](/img/_paligo/uuid-2b06167e-f54e-eb64-2314-315d36a5d17f.png)
 
-## Setting your Git credentials using the [Set Git Credentials](https://github.com/prosperllc/bitrise-step-set-git-credentials) Step
+## Setting your Git credentials using the [Set Git Credentials](https://bitrise.io/integrations/steps/set-git-credentials) Step
 
-1. Add a [**Set Git Credentials**](https://github.com/prosperllc/bitrise-step-set-git-credentials) Step as the very first step in your workflow. The Step has to come first before you’d `git commit`. This way you can make sure any changes you make to the current build will be attached to a commit associated with your username and email address.
+1. Add a [**Set Git Credentials**](https://bitrise.io/integrations/steps/set-git-credentials) Step as the very first step in your workflow. The Step has to come first before you’d `git commit`. This way you can make sure any changes you make to the current build will be attached to a commit associated with your username and email address.
 1. In the **Git Username** field, set the value to your own user name.
 1. In the **Git Email Address** field, set the value to your own email address.
 1. [Start a build.](/en/bitrise-ci/run-and-analyze-builds/starting-builds/approving-pull-request-builds)

--- a/docs/bitrise-ci/deploying/deploying-apps-to-applivery.mdx
+++ b/docs/bitrise-ci/deploying/deploying-apps-to-applivery.mdx
@@ -29,7 +29,7 @@ Combined with Bitrise, you can cover the entire development life cycle, from tes
 1. Add the **Applivery iOS Deploy** or the **Applivery Android Deploy** <GlossTerm baseform="Step">Step</GlossTerm> to your <GlossTerm baseform="Workflow">Workflow</GlossTerm>. Make sure you add the Step after the Steps that build your app.
 
    ![Applivery_Workflow_Step.png](/img/_paligo/uuid-794fef65-3c3b-12e1-e60f-f01f02802b37.png)
-1. Get your Applivery App Token to link your Bitrise app with your Applivery app. [Read more about how to get your App Token](https://www.applivery.com/docs/api/authentication/).
+1. Get your Applivery App Token to link your Bitrise app with your Applivery app. [Read more about how to get your App Token](https://www.applivery.com/docs/api/app-distribution/apps-api-authentication/).
 1. Open your app on Bitrise and click the **Workflows** tab to open the <GlossTerm baseform="workflow editor">Workflow Editor</GlossTerm>.
 1. Go to the **<GlossTerm baseform="secret">Secrets</GlossTerm>** tab.
 1. Click **Add New** and type `APPLIVERY_APP_TOKEN` in the key input field.

--- a/docs/bitrise-ci/deploying/deploying-apps-to-deploygate-from-bitrise.mdx
+++ b/docs/bitrise-ci/deploying/deploying-apps-to-deploygate-from-bitrise.mdx
@@ -45,7 +45,7 @@ You can also set optional variables for using advanced features as below:
 | Release Note | Message for the new release in distribution page. This message will be notified to your distribution page’s testers |
 | Disable Notify(iOS Only) | There is no DeployGate client app in iOS platform. By default, we use email notifications for release updates. If you don’t need email notification, please set this option as true |
 
-These options are based on [**DeployGate API**](https://docs.deploygate.com/reference). For more details, please read the references at [DeployGate.com](https://deploygate.com?locale=en).
+These options are based on [**DeployGate API**](https://docs.deploygate.com/docs/api/). For more details, please read the references at [DeployGate.com](https://deploygate.com?locale=en).
 
 You can use DeployGate's **Distribution Page** (Shareable link) feature to generate a landing page for the app installation of your app’s specific version.
 

--- a/docs/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-jenkins-to-bitrise.mdx
+++ b/docs/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-jenkins-to-bitrise.mdx
@@ -22,7 +22,7 @@ Jenkins is a self-hosted CI server where you have to manually install and mainta
 
 Bitrise takes care of all of the above. We have a vast array of automatized <GlossTerm baseform="step">Steps</GlossTerm>, [API](/en/bitrise-ci/api/api-overview), [CLI](/en/bitrise-ci/bitrise-cli/installing-and-updating-the-bitrise-cli), and [up-to-date Stacks](https://stacks.bitrise.io) with a highly intuitive GUI, called <GlossTerm baseform="workflow editor">Workflow Editor</GlossTerm>, all available at your fingertips.
 
-Learn more about our security measures on our [Security page](https://bitrise.io/platform/devops/security)which includes details on product, data, application, network, physical and business security.
+Learn more about our security measures on our [Security page](https://bitrise.io/platform/devops/security) which includes details on product, data, application, network, physical and business security.
 
 Check out the world of automated mobile development with Bitrise!
 
@@ -39,7 +39,7 @@ Check out the world of automated mobile development with Bitrise!
 This Quick Start Guide helps you start your first build on Bitrise with minimum config.
 
 1. [Sign up for Bitrise](/en/bitrise-platform/getting-started/signing-up-for-bitrise) if you don’t have an account yet.
-1. [Connect a repo](/en/bitrise-platform/getting-started/getting-started-with-the-bitrise-platform)and run an automatically configured standard <GlossTerm baseform="workflow">Workflow</GlossTerm> on any project.
+1. [Connect a repo](/en/bitrise-platform/getting-started/getting-started-with-the-bitrise-platform) and run an automatically configured standard <GlossTerm baseform="workflow">Workflow</GlossTerm> on any project.
 1. Once you’ve looked through the generated YML, make the changes you need: if you’re opting for a custom code, pop it into our [Script Step](https://www.bitrise.io/integrations/steps/script), and run your first build. Or find the Steps in our [Step Library](https://www.github.com/bitrise-io/bitrise-steplib) to replicate your Jenkinsfile’s behaviors. You can also run builds locally on your computer by installing our [Bitrise CLI](/en/bitrise-ci/bitrise-cli/installing-and-updating-the-bitrise-cli), Bitrise's open source runner.
 1. After getting to your new Workflow’s first green build, set up other jobs by configuring [automatic triggers](/en/bitrise-ci/run-and-analyze-builds/build-triggers/configuring-build-triggers) or [scheduled builds](/en/bitrise-ci/run-and-analyze-builds/starting-builds/scheduling-builds).
 1. Optimize your Workflows with [key-based caching](/en/bitrise-ci/dependencies-and-caching/key-based-caching/using-key-based-caching) for faster, safer, and more reproducible builds.
@@ -134,7 +134,7 @@ The **Workflow Editor** is the main place for configuring your Workflow. Jenkins
 
 The Workflow Editor has other powerful features built in to assist you with mobile development:
 
-- [Code signing](/en/bitrise-ci/code-signing/ios-code-signing/creating-a-signed-ipa-for-xcode-projects): Upload certificates, provisioning profiles, and keystores into Bitrise and and use our [iOS](/en/bitrise-ci/code-signing/ios-code-signing/ios-code-signing)and [Android](/en/bitrise-ci/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step) signing Steps to do all the code signing automatically for you before releasing an app to an app store.
+- [Code signing](/en/bitrise-ci/code-signing/ios-code-signing/creating-a-signed-ipa-for-xcode-projects): Upload certificates, provisioning profiles, and keystores into Bitrise and and use our [iOS](/en/bitrise-ci/code-signing/ios-code-signing/ios-code-signing) and [Android](/en/bitrise-ci/code-signing/android-code-signing/android-code-signing-using-the-android-sign-step) signing Steps to do all the code signing automatically for you before releasing an app to an app store.
 - [Secrets](/en/bitrise-ci/configure-builds/secrets): check out your project's secret Environment Variables or add new ones.
 - [Environment Variables](/en/bitrise-ci/configure-builds/environment-variables): there is no confusion of secrets and Env Vars in Bitrise. They are neatly organized into separate tabs so that you know where’s what. Add project Env Vars or Workflow specific Env Vars here. You can also reference Secrets as Env Vars with $.
 - [Triggers](/en/bitrise-ci/run-and-analyze-builds/build-triggers/configuring-build-triggers): You can configure triggers: code push events, pull requests, or tags can all be set up to automatically start builds on Bitrise.
@@ -190,7 +190,7 @@ When you add your app to Bitrise, our project selector automatically detects the
 
 We support the latest Xcode version shortly after its official release.
 
-In our [system reports](http:// https://bitrise.io/stacks) you can check the installed tools and their versions on each stack.
+In our [system reports](https://bitrise.io/stacks) you can check the installed tools and their versions on each stack.
 
 Learn more about our [macOS stack update policy](/en/bitrise-build-hub/infrastructure/build-stacks/macos-stack-update-policy).
 

--- a/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-expo-projects.mdx
+++ b/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-expo-projects.mdx
@@ -11,9 +11,9 @@ import GlossTerm from '@site/src/components/GlossTerm';
 import Partial_InstallingDependenciesForIonicCordovaReactApps from '@site/src/partials/installing-dependencies-for-ioniccordovareact-apps.mdx';
 import Partial_TestingYourReactNativeApp from '@site/src/partials/testing-your-react-native-app.mdx';
 
-You can generate React Native projects [with the React Native CLI or with the Expo CLI](https://facebook.github.io/react-native/docs/getting-started.html). [Expo](https://docs.expo.io/versions/latest/) is a toolchain that allows you to quickly get a React Native app up and running without having to use native code in Xcode or Android Studio.
+You can generate React Native projects [with the React Native CLI or with the Expo CLI](https://facebook.github.io/react-native/docs/getting-started.html). [Expo](https://docs.expo.dev/versions/latest/) is a toolchain that allows you to quickly get a React Native app up and running without having to use native code in Xcode or Android Studio.
 
-In this guide we discuss how to set up, test, code sign and deploy your React Native project built with the [Expo CLI](https://docs.expo.io/get-started/installation/).
+In this guide we discuss how to set up, test, code sign and deploy your React Native project built with the [Expo CLI](https://docs.expo.dev/get-started/installation/).
 
 
 ## Adding an Expo project to Bitrise
@@ -106,7 +106,7 @@ You have successfully set up your React Native project on [bitrise.io](https://w
 
 Bitrise supports [Expo Application Services](https://expo.dev/eas) (EAS) for Expo projects, and the default deploy Bitrise Workflow uses the [Run Expo Application Services (EAS) build](https://www.bitrise.io/integrations/steps/run-eas-build) <GlossTerm baseform="step">Step</GlossTerm> to <GlossTerm baseform="trigger">trigger</GlossTerm> a build on EAS.
 
-In case you don’t want to use EAS, you can use [Turtle CLI](https://docs.expo.dev/classic/turtle-cli/) for your Bitrise Workflows. See this [Workflow Recipe](/en/bitrise-ci/workflows-and-pipelines/workflows/workflow-recipes-for-cross-platform-projects/react-native-expo-build-using-turtle-cli) for details.
+In case you don’t want to use EAS, you can use [Turtle CLI](https://docs.expo.dev/eas/cli/) for your Bitrise Workflows. See this [Workflow Recipe](/en/bitrise-ci/workflows-and-pipelines/workflows/workflow-recipes-for-cross-platform-projects/react-native-expo-build-using-turtle-cli) for details.
 
 :::note[CodePush]
 

--- a/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-flutter-projects.mdx
+++ b/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-flutter-projects.mdx
@@ -175,9 +175,9 @@ You can share the generated binary file (APK for Android or an IPA file for iOS)
 
 :::important[Publishing to expo.io]
 
-The **Deploy to Bitrise.io** Step does not use Expo commands and doesn’t publish to [expo.io](https://docs.expo.io/workflow/publishing/). This Step publishes artifacts to Bitrise and is not specific to a particular platform.
+The **Deploy to Bitrise.io** Step does not use Expo commands and doesn’t publish to [expo.io](https://docs.expo.dev/workflow/publishing/). This Step publishes artifacts to Bitrise and is not specific to a particular platform.
 
-If you need to publish to [expo.io](https://docs.expo.io/workflow/publishing/), set the **Run expo publish after eject?** input of the **Eject Expo** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
+If you need to publish to [expo.io](https://docs.expo.dev/workflow/publishing/), set the **Run expo publish after eject?** input of the **Eject Expo** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
 
 :::
 

--- a/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-ioniccordova-projects.mdx
+++ b/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-ioniccordova-projects.mdx
@@ -287,9 +287,9 @@ You can share the generated binary file (APK for Android or an IPA file for iOS)
 
 :::important[Publishing to expo.io]
 
-The **Deploy to Bitrise.io** Step does not use Expo commands and doesn’t publish to [expo.io](https://docs.expo.io/workflow/publishing/). This Step publishes artifacts to Bitrise and is not specific to a particular platform.
+The **Deploy to Bitrise.io** Step does not use Expo commands and doesn’t publish to [expo.io](https://docs.expo.dev/workflow/publishing/). This Step publishes artifacts to Bitrise and is not specific to a particular platform.
 
-If you need to publish to [expo.io](https://docs.expo.io/workflow/publishing/), set the **Run expo publish after eject?** input of the **Eject Expo** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
+If you need to publish to [expo.io](https://docs.expo.dev/workflow/publishing/), set the **Run expo publish after eject?** input of the **Eject Expo** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
 
 :::
 

--- a/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-react-native-projects.mdx
+++ b/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-react-native-projects.mdx
@@ -272,9 +272,9 @@ You can share the generated binary file (APK for Android or an IPA file for iOS)
 
 :::important[Publishing to expo.io]
 
-The **Deploy to Bitrise.io** Step does not use Expo commands and doesn’t publish to [expo.io](https://docs.expo.io/workflow/publishing/). This Step publishes artifacts to Bitrise and is not specific to a particular platform.
+The **Deploy to Bitrise.io** Step does not use Expo commands and doesn’t publish to [expo.io](https://docs.expo.dev/workflow/publishing/). This Step publishes artifacts to Bitrise and is not specific to a particular platform.
 
-If you need to publish to [expo.io](https://docs.expo.io/workflow/publishing/), set the **Run expo publish after eject?** input of the **Eject Expo** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
+If you need to publish to [expo.io](https://docs.expo.dev/workflow/publishing/), set the **Run expo publish after eject?** input of the **Eject Expo** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
 
 :::
 

--- a/docs/bitrise-ci/references/steps-reference/step-data-in-the-bitriseyml-file.mdx
+++ b/docs/bitrise-ci/references/steps-reference/step-data-in-the-bitriseyml-file.mdx
@@ -31,7 +31,7 @@ Specify inputs for the Step with the `inputs:` list property. An input consists 
 
 :::warning[Indentation]
 
-Indentation in the [YAML format](http://yaml.org/faq.html) is very important! You should use two- or four-space indentation, and you can’t use tabs to indent!
+Indentation in the [YAML format](https://github.com/yaml/yaml-spec) is very important! You should use two- or four-space indentation, and you can’t use tabs to indent!
 
 :::
 

--- a/docs/bitrise-ci/testing/measuring-your-code-coverage-with-codecov.mdx
+++ b/docs/bitrise-ci/testing/measuring-your-code-coverage-with-codecov.mdx
@@ -52,7 +52,7 @@ To view your coverage on Codecov, you can do the following:
 - View the URL supplied on the Codecov Step on Bitrise.
 
   ![pic4.png](/img/_paligo/uuid-d981eb34-fe27-6796-ff24-0e9206369758.png)
-- Go to[https://codecov.io](https://about.codecov.io/)and navigate directly to the applicable pull request or commit.
+- Go to [https://codecov.io](https://about.codecov.io/) and navigate directly to the applicable pull request or commit.
 - Click on the links provided by Codecov that are available on your code host’s status checks or pull request comment.
 
 
@@ -61,6 +61,6 @@ To view your coverage on Codecov, you can do the following:
 Now that you have code coverage reports, you can take it to the next level with the following suggestions:
 
 - Set [non-blocking status checks](https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks) to get your developers in the habit of thinking about code coverage.
-- Start working towards code coverage by setting status checks to[increase overall coverage](https://docs.codecov.com/docs/common-recipe-list#increase-overall-coverage-on-each-pull-request) on every pull request.
-- Isolate your coverage reports for different types of tests or different parts of your system with [Flags](https://docs.codecov.io/docs/flags) to measure what matters.
-- Already using flags and don’t want to run your entire test suite with every Bitrise CI run? Try out [Carryforward Flags](https://docs.codecov.io/docs/carryforward-flags) to measure only what changes.
+- Start working towards code coverage by setting status checks to [increase overall coverage](https://docs.codecov.com/docs/common-recipe-list#increase-overall-coverage-on-each-pull-request) on every pull request.
+- Isolate your coverage reports for different types of tests or different parts of your system with [Flags](https://docs.codecov.com/docs/flags) to measure what matters.
+- Already using flags and don’t want to run your entire test suite with every Bitrise CI run? Try out [Carryforward Flags](https://docs.codecov.com/docs/carryforward-flags) to measure only what changes.

--- a/docs/bitrise-ci/workflows-and-pipelines/workflows/workflow-recipes-for-cross-platform-projects/react-native-expo-build-using-turtle-cli.md
+++ b/docs/bitrise-ci/workflows-and-pipelines/workflows/workflow-recipes-for-cross-platform-projects/react-native-expo-build-using-turtle-cli.md
@@ -5,13 +5,13 @@ sidebar_position: 2
 
 ## Description
 
-Publish an app to Expo's servers and build an iOS App Store `.ipa` and an Android `.aab` file from your Expo project using [Turtle CLI](https://docs.expo.dev/classic/turtle-cli/).
+Publish an app to Expo's servers and build an iOS App Store `.ipa` and an Android `.aab` file from your Expo project using [Turtle CLI](https://docs.expo.dev/eas/cli/).
 
 ## Prerequisites
 
 1. Generate an iOS Distribution Certificate and an App Store Provisioning Profile based on the [Generating iOS code signing files guide](/en/bitrise-ci/code-signing/ios-code-signing/generating-ios-code-signing-files).
 1. Generate an Android Keystore by following the [Android code signing with Android Studio guide](/en/bitrise-ci/code-signing/android-code-signing/android-code-signing-with-android-studio).
-1. Make sure you can [Publish your Expo project](https://docs.expo.dev/classic/turtle-cli/#publish-your-project) locally.
+1. Make sure you can [Publish your Expo project](https://docs.expo.dev/eas/cli/#publish-your-project) locally.
 
 ## Instructions
 

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-idaptive-saml-sso-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-idaptive-saml-sso-for-bitrise.mdx
@@ -11,14 +11,14 @@ import GlossTerm from '@site/src/components/GlossTerm';
 import Partial_SAMLSSOBeforeYouStart from '@site/src/partials/saml-sso-before-you-start.mdx';
 import Partial_CAUTIONSAMLSSORestrictions from '@site/src/partials/caution-saml-sso-restrictions.mdx';
 
-This guide provides step-by-step instructions on setting up Bitrise as a SAML application on [Idaptive](https://www.idaptive.com/).
+This guide provides step-by-step instructions on setting up Bitrise as a SAML application on [Idaptive](https://docs.cyberark.com/remote-access-standard/latest/en/content/admin/settings-idaptive.htm).
 
 <Partial_CAUTIONSAMLSSORestrictions />
 
 Before connecting SAML SSO to your <GlossTerm baseform="workspace">Workspace</GlossTerm>:
 
 - <Partial_SAMLSSOBeforeYouStart />
-- You must be logged into your Admin Portal on [Idaptive](https://www.idaptive.com/) to set up Bitrise as a SAML SSO app and establish the connection between Bitrise and Idaptive. If you are using the **User Portal**, **Switch to** **Admin Portal** by clicking your avatar on Idaptive.
+- You must be logged into your Admin Portal on [Idaptive](https://docs.cyberark.com/remote-access-standard/latest/en/content/admin/settings-idaptive.htm) to set up Bitrise as a SAML SSO app and establish the connection between Bitrise and Idaptive. If you are using the **User Portal**, **Switch to** **Admin Portal** by clicking your avatar on Idaptive.
 
   ![Setting_up_Idaptive_SAML_SSO_for_Bitrise.jpg](/img/_paligo/uuid-27ceb4dd-22a3-a162-b569-73261ba2fef7.jpg)
 

--- a/docs/bitrise-platform/infrastructure/bitrise-on-aws-manual-setup/advanced-options-for-ec2-instances.mdx
+++ b/docs/bitrise-platform/infrastructure/bitrise-on-aws-manual-setup/advanced-options-for-ec2-instances.mdx
@@ -147,7 +147,7 @@ For more information, please refer to the [AWS macOS EC2 documentation](https://
 
 When running a self-hosted agent, one agent executes multiple builds (one after the other). This allows sharing of data between builds on the local filesystem, but it also requires some care in order to avoid one build affecting another.
 
-To avoid this problem, you can clean up your build environment in between builds. To do so, you need to run the [Bitrise CLI](/en/bitrise-ci/bitrise-cli/installing-and-updating-the-bitrise-cli)on the self-hosted machines in agent mode: [Cleaning up persistent build environments](/en/bitrise-platform/infrastructure/cleaning-up-persistent-build-environments)
+To avoid this problem, you can clean up your build environment in between builds. To do so, you need to run the [Bitrise CLI](/en/bitrise-ci/bitrise-cli/installing-and-updating-the-bitrise-cli) on the self-hosted machines in agent mode: [Cleaning up persistent build environments](/en/bitrise-platform/infrastructure/cleaning-up-persistent-build-environments)
 
 ## Using secrets in your builds running on AWS
 

--- a/docs/bitrise-platform/integrations/the-service-credential-user.mdx
+++ b/docs/bitrise-platform/integrations/the-service-credential-user.mdx
@@ -61,7 +61,7 @@ To change the service credential user:
 
    If you receive an error while trying to connect or change the service credential user for your project, make sure that the user has the project access to the GitHub repository and that **Third-party app access policy restrictions** are disabled.
 
-   For more information on how to disable the Third-party app access policy on GitHub, check out [Disabling OAuth project access restrictions for your organization](https://docs.github.com/en/organizations/managing-oauth-access-to-your-organizations-data/disabling-oauth-project-access-restrictions-for-your-organization).
+   For more information on how to disable the Third-party app access policy on GitHub, check out [Disabling OAuth project access restrictions for your organization](https://docs.github.com/en/organizations/managing-oauth-access-to-your-organizations-data/about-oauth-app-access-restrictions).
 
    :::
 1. To confirm, click **Set service credential user**.

--- a/scripts/audit_links.py
+++ b/scripts/audit_links.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""
+Audit hyperlinks in MDX documentation files.
+
+Checks:
+  - Internal links (/en/...) resolve to a real page (slug match).
+  - External links return a 2xx/3xx response.
+
+Skips:
+  - Step source links (validated by the link-steps skill).
+  - bitrise.io, app.bitrise.io, www.bitrise.io.
+  - Fragment-only links (#anchor).
+
+Usage:
+  python3 scripts/audit_links.py                   # audit all MDX files
+  python3 scripts/audit_links.py --pr 123          # files changed in PR
+  python3 scripts/audit_links.py --commit abc123   # files changed in commit
+  python3 scripts/audit_links.py --internal-only   # skip external checks
+  python3 scripts/audit_links.py --external-only   # skip internal checks
+"""
+
+import json
+import re
+import subprocess
+import sys
+import urllib.request
+import urllib.error
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+DOCS_DIR  = REPO_ROOT / 'docs'
+SPEC_URL  = 'https://bitrise-steplib-collection.s3.amazonaws.com/spec.json'
+
+SKIP_DOMAINS = {'bitrise.io', 'app.bitrise.io', 'www.bitrise.io', 'api.bitrise.io'}
+
+# GitHub URL prefixes that are Bitrise steplib repos — skip without fetching spec
+SKIP_URL_PREFIXES = (
+    'https://github.com/bitrise-steplib/',
+    'https://github.com/bitrise-io/steps-',
+    'https://www.bitrise.io/integrations/steps/',
+)
+
+INTERNAL_ONLY = '--internal-only' in sys.argv
+EXTERNAL_ONLY = '--external-only' in sys.argv
+
+
+# ── Target files ──────────────────────────────────────────────────────────────
+
+def get_target_files():
+    args = sys.argv[1:]
+
+    if '--pr' in args:
+        idx = args.index('--pr')
+        result = subprocess.run(
+            ['gh', 'pr', 'diff', '--name-only', args[idx + 1]],
+            capture_output=True, text=True, check=True,
+        )
+        return _mdx_paths(result.stdout.splitlines())
+
+    if '--commit' in args:
+        idx = args.index('--commit')
+        result = subprocess.run(
+            ['git', 'diff-tree', '--no-commit-id', '-r', '--name-only', args[idx + 1]],
+            capture_output=True, text=True, check=True,
+        )
+        return _mdx_paths(result.stdout.splitlines())
+
+    return None
+
+
+def _mdx_paths(names):
+    paths = []
+    for name in names:
+        name = name.strip()
+        if not name.endswith('.mdx'):
+            continue
+        p = REPO_ROOT / name
+        if p.exists():
+            paths.append(p)
+    return paths
+
+
+# ── Internal link validation ──────────────────────────────────────────────────
+
+def build_slug_set() -> set[str]:
+    slugs = set()
+    for mdx in [*DOCS_DIR.rglob('*.mdx'), *DOCS_DIR.rglob('*.md')]:
+        content = mdx.read_text('utf-8')
+        m = re.search(r'^slug:\s*["\']?([^"\'$\n]+)["\']?', content, re.MULTILINE)
+        if m:
+            slugs.add(m.group(1).strip())
+        else:
+            rel = mdx.relative_to(DOCS_DIR).with_suffix('')
+            slug = '/' + str(rel).replace('\\', '/')
+            if slug.endswith('/index'):
+                slug = slug[:-6] or '/'
+            slugs.add(slug)
+    return slugs
+
+
+def normalise_internal(url: str) -> str:
+    path = url.removeprefix('/en').rstrip('/')
+    if path.endswith('.html'):
+        path = path[:-5]
+    return path or '/'
+
+
+# ── External link validation ──────────────────────────────────────────────────
+
+def fetch_step_urls() -> set[str]:
+    print('Fetching steplib spec to identify step links …', flush=True)
+    with urllib.request.urlopen(SPEC_URL, timeout=120) as r:
+        data = json.loads(r.read())
+    urls: set[str] = set()
+    for slug, step in data.get('steps', {}).items():
+        latest = step.get('latest_version_number')
+        if not latest:
+            continue
+        version = step.get('versions', {}).get(latest, {})
+        url = (version.get('source_code_url') or '').strip().rstrip('/')
+        if url:
+            urls.add(url)
+    print(f'  {len(urls)} step URLs loaded.', flush=True)
+    return urls
+
+
+def domain_of(url: str) -> str:
+    m = re.match(r'https?://([^/]+)', url)
+    return m.group(1) if m else ''
+
+
+def should_skip_external(url: str) -> bool:
+    d = domain_of(url)
+    if d in SKIP_DOMAINS:
+        return True
+    for prefix in SKIP_URL_PREFIXES:
+        if url.startswith(prefix):
+            return True
+    return False
+
+
+def check_url(url: str):
+    try:
+        req = urllib.request.Request(
+            url, method='HEAD',
+            headers={'User-Agent': 'Mozilla/5.0 (audit_links)'},
+        )
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return url, r.status
+    except urllib.error.HTTPError as e:
+        if e.code == 405:
+            try:
+                req2 = urllib.request.Request(
+                    url, method='GET',
+                    headers={'User-Agent': 'Mozilla/5.0 (audit_links)'},
+                )
+                with urllib.request.urlopen(req2, timeout=15) as r:
+                    return url, r.status
+            except urllib.error.HTTPError as e2:
+                return url, e2.code
+            except Exception as e2:
+                return url, str(e2)
+        return url, e.code
+    except Exception as e:
+        return url, str(e)
+
+
+# ── Link extraction ───────────────────────────────────────────────────────────
+
+LINK_RE = re.compile(r'\[(?:[^\]]*)\]\(([^)]+)\)')
+HREF_RE = re.compile(r'href=["\']([^"\']+)["\']')
+
+
+def extract_links(filepath: Path):
+    links = []
+    in_fence = False
+    for i, line in enumerate(filepath.read_text('utf-8').splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith('```'):
+            in_fence = not in_fence
+        if in_fence:
+            continue
+        for m in LINK_RE.finditer(line):
+            links.append((i, m.group(1).strip()))
+        for m in HREF_RE.finditer(line):
+            links.append((i, m.group(1).strip()))
+    return links
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    target_files = get_target_files()
+    files = sorted(target_files if target_files is not None else [*DOCS_DIR.rglob('*.mdx'), *DOCS_DIR.rglob('*.md')])
+    scope = f'{len(files)} file(s)' if target_files is not None else str(DOCS_DIR)
+    print(f'Auditing links in {scope} …\n', flush=True)
+
+    broken = []
+
+    # ── Internal links ────────────────────────────────────────────────────────
+    if not EXTERNAL_ONLY:
+        print('Building slug index …', flush=True)
+        slugs = build_slug_set()
+        print(f'  {len(slugs)} pages indexed.\n', flush=True)
+
+        print('Checking internal links …', flush=True)
+        internal_checked = 0
+        for filepath in files:
+            for lineno, url in extract_links(filepath):
+                if not url.startswith('/en/'):
+                    continue
+                slug = normalise_internal(url)
+                internal_checked += 1
+                if slug not in slugs:
+                    broken.append((filepath, lineno, url, 'no matching page'))
+        print(f'  {internal_checked} internal links checked.\n', flush=True)
+
+    # ── External links ────────────────────────────────────────────────────────
+    if not INTERNAL_ONLY:
+        # Collect unique external URLs and where they appear
+        url_locations = {}
+        for filepath in files:
+            for lineno, url in extract_links(filepath):
+                if not url.startswith('http'):
+                    continue
+                if should_skip_external(url):
+                    continue
+                url_locations.setdefault(url, []).append((filepath, lineno))
+
+        print(f'Checking {len(url_locations)} external URLs …', flush=True)
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            futures = {pool.submit(check_url, url): url for url in url_locations}
+            done = 0
+            for future in as_completed(futures):
+                url, status = future.result()
+                done += 1
+                print(f'  [{done}/{len(url_locations)}] {status}  {url}', flush=True)
+                if isinstance(status, int) and 200 <= status < 400:
+                    continue
+                for filepath, lineno in url_locations[url]:
+                    broken.append((filepath, lineno, url, str(status)))
+
+    # ── Report ────────────────────────────────────────────────────────────────
+    print()
+    if not broken:
+        print('✓ No broken links found.')
+        return
+
+    print(f'✗ {len(broken)} broken link(s) found:\n')
+    for filepath, lineno, url, reason in sorted(broken, key=lambda x: (x[0], x[1])):
+        try:
+            rel = filepath.relative_to(REPO_ROOT)
+        except ValueError:
+            rel = filepath
+        print(f'  {rel}:{lineno}  {reason}  {url}')
+
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- Fixed broken/moved external URLs across 18 files:
  - `docs.codecov.io` → `docs.codecov.com`
  - `docs.expo.io` → `docs.expo.dev` (8 occurrences across 4 files)
  - Turtle CLI links → `docs.expo.dev/eas/cli/`
  - `schemastore.org/json/` → `schemastore.org/bitrise.json`
  - `yaml.org/faq.html` → `github.com/yaml/yaml-spec`
  - `docs.deploygate.com/reference` → `docs.deploygate.com/docs/api/`
  - `applivery.com/docs/api/authentication/` → correct path
  - `idaptive.com` → CyberArk docs
  - GitHub OAuth org doc → updated URL
  - `prosperllc/bitrise-step-set-git-credentials` (deleted repo) → `bitrise.io/integrations/steps/set-git-credentials`
  - `project.bitrise.io` → `app.bitrise.io`
  - Malformed stacks URL (`http:// https://`) fixed
- Fixed missing spaces before/after markdown link text in 5 files
- Added `scripts/audit_links.py` for future external link auditing

## Test plan

- [ ] Spot-check updated links in a browser
- [ ] Verify preview renders correctly for affected pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)