### PR TITLE
[ER-2773] MCP OAuth as primary authn

### DIFF
--- a/docs/bitrise-platform/ai/bitrise-mcp.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp.md
@@ -11,7 +11,7 @@ The Bitrise Model Context Protocol (MCP) Server lets you talk to Bitrise via an 
 - Optimize configurations by instructing the AI to suggest improvements. You will receive instant insights and practical suggestions.
 - Automate manual tasks such as handling permissions, inviting members to a project, or looking for old builds. Tell the AI agent about your requirements: it will send you the proposed steps for review and ask for permission before executing each action. You can review the results at each step of the process.
 
-The remote MCP server is hosted at mcp.bitrise.io. Most MCP clients (Claude Code, Cursor, VS Code, and others) authenticate via OAuth — point them at the URL and they'll prompt you to sign in to Bitrise on first use. Clients that don't yet support MCP OAuth can still authenticate by passing a Personal Access Token in the Authorization: Bearer <YOUR_BITRISE_PAT> header.
+The remote MCP server is hosted at mcp.bitrise.io. Most MCP clients (Claude Code, Cursor, VS Code, and others) authenticate via OAuth — point them at the URL and they'll prompt you to sign in to Bitrise on first use. Clients that don't yet support MCP OAuth can still authenticate by passing a Personal Access Token in HTTP header `Authorization: Bearer <YOUR_BITRISE_PAT>`.
 
 You can find [the Bitrise MCP repository on GitHub](https://github.com/bitrise-io/bitrise-mcp). Among other things, it includes:
 

--- a/docs/bitrise-platform/ai/bitrise-mcp.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp.md
@@ -11,10 +11,10 @@ The Bitrise Model Context Protocol (MCP) Server lets you talk to Bitrise via an 
 - Optimize configurations by instructing the AI to suggest improvements. You will receive instant insights and practical suggestions.
 - Automate manual tasks such as handling permissions, inviting members to a project, or looking for old builds. Tell the AI agent about your requirements: it will send you the proposed steps for review and ask for permission before executing each action. You can review the results at each step of the process.
 
-The remote MCP server is hosted at mcp.bitrise.io. Most MCP clients (Claude Code, Cursor, VS Code, and others) authenticate via OAuth — point them at the URL and they'll prompt you to sign in to Bitrise on first use. Clients that don't yet support MCP OAuth can still authenticate by passing a Personal Access Token in HTTP header `Authorization: Bearer <YOUR_BITRISE_PAT>`.
+The remote MCP server is hosted at mcp.bitrise.io. Most MCP clients (Claude Code, Cursor, VS Code, and others) authenticate via OAuth: point them at the URL and they'll prompt you to sign in to Bitrise on first use. Clients that don't yet support MCP OAuth can still authenticate by passing a Personal Access Token in an HTTP header `Authorization: Bearer <YOUR_BITRISE_PAT>`.
 
 You can find [the Bitrise MCP repository on GitHub](https://github.com/bitrise-io/bitrise-mcp). Among other things, it includes:
 
 - Install guides for specific MCP clients. The currently supported clients are: VS Code, GitHub Copilot in other IDEs, Claude Applications (Desktop and Code CLI), Cursor, Windsurf, AWS Kiro, and Gemini CLI.
-- How to use local MCP server instead of the remote one.
+- How to use a local MCP server instead of the remote one.
 - What tools are available and how you can limit their usage.

--- a/docs/bitrise-platform/ai/bitrise-mcp.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp.md
@@ -11,7 +11,7 @@ The Bitrise Model Context Protocol (MCP) Server lets you talk to Bitrise via an 
 - Optimize configurations by instructing the AI to suggest improvements. You will receive instant insights and practical suggestions.
 - Automate manual tasks such as handling permissions, inviting members to a project, or looking for old builds. Tell the AI agent about your requirements: it will send you the proposed steps for review and ask for permission before executing each action. You can review the results at each step of the process.
 
-The remote MCP server is hosted at mcp.bitrise.io. You can authenticate by passing the HTTP header `Authorization: Bearer<YOUR_BITRISE_PAT>`.
+The remote MCP server is hosted at mcp.bitrise.io.
 
 You can find [the Bitrise MCP repository on GitHub](https://github.com/bitrise-io/bitrise-mcp). Among other things, it includes:
 

--- a/docs/bitrise-platform/ai/bitrise-mcp.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp.md
@@ -7,14 +7,14 @@ slug: /bitrise-platform/ai/bitrise-mcp
 
 The Bitrise Model Context Protocol (MCP) Server lets you talk to Bitrise via an AI client of your choice. It enables seamless interaction with your existing CI setup:
 
-- Troubleshoot issues by directly asking about failure reasons. The AI analyzes logs and configurations, providing actionble recommendations.
+- Troubleshoot issues by directly asking about failure reasons. The AI analyzes logs and configurations, providing actionable recommendations.
 - Optimize configurations by instructing the AI to suggest improvements. You will receive instant insights and practical suggestions.
 - Automate manual tasks such as handling permissions, inviting members to a project, or looking for old builds. Tell the AI agent about your requirements: it will send you the proposed steps for review and ask for permission before executing each action. You can review the results at each step of the process.
 
-The remote MCP server is hosted at mcp.bitrise.io.
+The remote MCP server is hosted at mcp.bitrise.io. Most MCP clients (Claude Code, Cursor, VS Code, and others) authenticate via OAuth — point them at the URL and they'll prompt you to sign in to Bitrise on first use. Clients that don't yet support MCP OAuth can still authenticate by passing a Personal Access Token in the Authorization: Bearer <YOUR_BITRISE_PAT> header.
 
 You can find [the Bitrise MCP repository on GitHub](https://github.com/bitrise-io/bitrise-mcp). Among other things, it includes:
 
-- Install guides for specific MCP clients. The currently supported clients are: VS Code, GitHub Copilot in other IDEs , Claude Applications (Desktop and Code CLI), Cursor, Windsurf, AWS Kiro, and Gemini CLI.
+- Install guides for specific MCP clients. The currently supported clients are: VS Code, GitHub Copilot in other IDEs, Claude Applications (Desktop and Code CLI), Cursor, Windsurf, AWS Kiro, and Gemini CLI.
 - How to use local MCP server instead of the remote one.
 - What tools are available and how you can limit their usage.


### PR DESCRIPTION
Mention MCP OAuth as the primary auth mechanism

[ER-2773]

[ER-2773]: https://bitrise.atlassian.net/browse/ER-2773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ