### PR TITLE
Fix breadcrumb root links to point to section index pages

### DIFF
--- a/src/theme/DocBreadcrumbs/Items/Home/index.tsx
+++ b/src/theme/DocBreadcrumbs/Items/Home/index.tsx
@@ -2,28 +2,20 @@ import React, {type ReactNode} from 'react';
 import Link from '@docusaurus/Link';
 import {useDocsSidebar} from '@docusaurus/plugin-content-docs/client';
 
-const sidebarLabels: Record<string, string> = {
-  platformSidebar: 'Bitrise as a Platform',
-  ciSidebar: 'Bitrise CI',
-  buildCacheSidebar: 'Build Cache',
-  releaseManagementSidebar: 'Release Management',
-  insightsSidebar: 'Insights',
-  buildHubSidebar: 'Build Hub',
-};
-
-const sidebarHrefs: Record<string, string> = {
-  platformSidebar: '/en/bitrise-platform',
-  ciSidebar: '/en/bitrise-ci',
-  buildCacheSidebar: '/en/bitrise-build-cache',
-  releaseManagementSidebar: '/en/release-management',
-  insightsSidebar: '/en/insights',
-  buildHubSidebar: '/en/bitrise-build-hub',
+const sidebarConfig: Record<string, {label: string; href: string}> = {
+  platformSidebar:          {label: 'Bitrise as a Platform', href: '/en/bitrise-platform'},
+  ciSidebar:                {label: 'Bitrise CI',            href: '/en/bitrise-ci'},
+  buildCacheSidebar:        {label: 'Build Cache',           href: '/en/bitrise-build-cache'},
+  releaseManagementSidebar: {label: 'Release Management',    href: '/en/release-management'},
+  insightsSidebar:          {label: 'Insights',              href: '/en/insights'},
+  buildHubSidebar:          {label: 'Build Hub',             href: '/en/bitrise-build-hub'},
 };
 
 export default function HomeBreadcrumbItem(): ReactNode {
   const sidebar = useDocsSidebar();
-  const label = (sidebar && sidebarLabels[sidebar.name]) || 'Home';
-  const href = (sidebar && sidebarHrefs[sidebar.name]) || '/';
+  const config = sidebar && sidebarConfig[sidebar.name];
+  const label = config?.label ?? 'Home';
+  const href  = config?.href  ?? '/';
 
   return (
     <li className="breadcrumbs__item">

--- a/src/theme/DocBreadcrumbs/Items/Home/index.tsx
+++ b/src/theme/DocBreadcrumbs/Items/Home/index.tsx
@@ -11,13 +11,23 @@ const sidebarLabels: Record<string, string> = {
   buildHubSidebar: 'Build Hub',
 };
 
+const sidebarHrefs: Record<string, string> = {
+  platformSidebar: '/en/bitrise-platform',
+  ciSidebar: '/en/bitrise-ci',
+  buildCacheSidebar: '/en/bitrise-build-cache',
+  releaseManagementSidebar: '/en/release-management',
+  insightsSidebar: '/en/insights',
+  buildHubSidebar: '/en/bitrise-build-hub',
+};
+
 export default function HomeBreadcrumbItem(): ReactNode {
   const sidebar = useDocsSidebar();
   const label = (sidebar && sidebarLabels[sidebar.name]) || 'Home';
+  const href = (sidebar && sidebarHrefs[sidebar.name]) || '/';
 
   return (
     <li className="breadcrumbs__item">
-      <Link className="breadcrumbs__link" href="/">
+      <Link className="breadcrumbs__link" href={href}>
         <span>{label}</span>
       </Link>
     </li>


### PR DESCRIPTION
## Summary

- The first breadcrumb item on every docs page was labelled with the section name (e.g. "Bitrise CI") but always linked back to `/` (the portal homepage) — confusing UX
- Added a `sidebarConfig` map in the swizzled `HomeBreadcrumbItem` component that maps each sidebar name to both its label and its section index URL
- All six existing product sections are covered: Bitrise as a Platform, Bitrise CI, Build Cache, Release Management, Insights, Build Hub
- Falls back to `Home` / `/` for any sidebar not in the map (safe default)

## Test plan

- [ ] Navigate to any doc page in each section and confirm the first breadcrumb shows the section name and links to that section's index page
- [ ] Confirm pages on sidebars not in the map still show "Home" linking to `/`
- [ ] No console errors or broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)