### PR TITLE
Fix build machine types table

### DIFF
--- a/docs/bitrise-build-hub/infrastructure/build-machine-types.md
+++ b/docs/bitrise-build-hub/infrastructure/build-machine-types.md
@@ -17,22 +17,27 @@ Not all machines are available on all subscription plans. Visit [the pricing pag
 
 Machine types are divided into resource classes. The same resource class offers multiple machine types with broadly similar performances. Bitrise automatically assigns machine types from a resource class, which means that on the same day, your builds might run on different machine types.
 
-| Operating system | Resource class | Hardware types | Specs | Machine type ID for [YAML configuration](/en/bitrise-ci/configure-builds/configuring-build-settings/setting-the-stack-for-your-builds#setting-the-stack-in-the-configuration-yaml) |
-| --- | --- | --- | --- | --- |
-| macOS |  |  |  |  |
-| Medium | - M2 Pro Medium - M4 Medium | - 4 CPU @3.49GHz and 6 GB RAM - 5 CPU @4.4 GHz and 6 GB RAM | `g2.mac.medium` |  |
-| Large | - M2 Pro Large - M4 Large | - 6 CPU @3.49GHz and 14 GB RAM - 5 CPU @4.4 GHz and 14 GB RAM | `g2.mac.large` |  |
-| X Large | - M2 Pro X Large - M4 X Large | - 12 CPU @3.49GHz and 28 GB RAM - 10 CPU @4.4 GHz and 28 GB RAM | `g2.mac.x-large` |  |
-| 4Large | M4 Pro Large | 7 CPU @4.52GHz and 27 GB RAM | `g2.mac.4large` |  |
-| 4X Large | M4 Pro X Large | 14 CPU @4.52GHz and 54 GB RAM | `g2.mac.4x-large` |  |
-| Linux | Medium | 4 vCPU @ 3.1 GHz | 4 vCPU @3.1 GHz and 16 GB RAM | `standard` |
-| Large | 8 vCPU @ 3.1 GHz | 8 vCPU @3.1 GHz and 32 GB RAM | `elite` |  |
-| X Large | 16 vCPU @ 3.1 GHz | 16 vCPU @3.1 GHz and 64 GB RAM | `elite-xl` |  |
-| M | AMD EPYC Zen 4 and Zen 5 | 4 vCPU @3.7 GHz and 16 GB RAM | `g2.linux.medium` |  |
-| 2M | AMD EPYC Zen 4 and Zen 5 | 6 vCPU @3.7 GHz and 24 GB RAM | `g2.linux.2medium` |  |
-| L | AMD EPYC Zen 4 and Zen 5 | 8 vCPU @3.7 GHz and 32 GB RAM | `g2.linux.large` |  |
-| 4L | AMD EPYC Zen 4 and Zen 5 | 14 vCPU @3.7 GHz and 56 GB RAM | `g2.linux.4large` |  |
-| XL | AMD EPYC Zen 4 and Zen 5 | 16 vCPU @3.7 GHz and 64 GB RAM | `g2.linux.x-large` |  |
-| 3XL | AMD EPYC Zen 4 and Zen 5 | 24 vCPU @3.7 GHz and 96 GB RAM | `g2.linux.3x-large` |  |
-| 5XL | AMD EPYC Zen 4 and Zen 5 | 32 vCPU @3.7 GHz and 128 GB RAM | `g2.linux.5x-large` |  |
-| 7XL | AMD EPYC Zen 4 and Zen 5 | 48 vCPU @3.7 GHz and 192 GB RAM | `g2.linux.7x-large` |  |
+:::tip
+
+Use the machine type ID to set the machine type in your [configuration YAML](/en/bitrise-ci/configure-builds/configuring-build-settings/setting-the-stack-for-your-builds#setting-the-stack-in-the-configuration-yaml).
+
+:::
+
+| OS and resource class | Hardware types | Specs | Machine type ID |
+| --- | --- | --- | --- |
+| macOS Medium | M2 Pro Medium<br/>M4 Medium | 4 CPU @3.49GHz and 6 GB RAM<br/>5 CPU @4.4 GHz and 6 GB RAM | `g2.mac.medium` |
+| macOS Large | M2 Pro Large<br/>M4 Large | 6 CPU @3.49GHz and 14 GB RAM<br/>5 CPU @4.4 GHz and 14 GB RAM | `g2.mac.large` |
+| macOS X Large | M2 Pro X Large<br/>M4 X Large | 12 CPU @3.49GHz and 28 GB RAM<br/>10 CPU @4.4 GHz and 28 GB RAM | `g2.mac.x-large` |
+| macOS 4Large | M4 Pro Large | 7 CPU @4.52GHz and 27 GB RAM | `g2.mac.4large` |
+| macOS 4X Large | M4 Pro X Large | 14 CPU @4.52GHz and 54 GB RAM | `g2.mac.4x-large` |
+| Linux Medium | | 4 vCPU @3.1 GHz and 16 GB RAM | `standard` |
+| Linux Large | | 8 vCPU @3.1 GHz and 32 GB RAM | `elite` |
+| Linux X Large | | 16 vCPU @3.1 GHz and 64 GB RAM | `elite-xl` |
+| Linux M | AMD EPYC Zen 4 and Zen 5 | 4 vCPU @3.7 GHz and 16 GB RAM | `g2.linux.medium` |
+| Linux 2M | AMD EPYC Zen 4 and Zen 5 | 6 vCPU @3.7 GHz and 24 GB RAM | `g2.linux.2medium` |
+| Linux L | AMD EPYC Zen 4 and Zen 5 | 8 vCPU @3.7 GHz and 32 GB RAM | `g2.linux.large` |
+| Linux 4L | AMD EPYC Zen 4 and Zen 5 | 14 vCPU @3.7 GHz and 56 GB RAM | `g2.linux.4large` |
+| Linux XL | AMD EPYC Zen 4 and Zen 5 | 16 vCPU @3.7 GHz and 64 GB RAM | `g2.linux.x-large` |
+| Linux 3XL | AMD EPYC Zen 4 and Zen 5 | 24 vCPU @3.7 GHz and 96 GB RAM | `g2.linux.3x-large` |
+| Linux 5XL | AMD EPYC Zen 4 and Zen 5 | 32 vCPU @3.7 GHz and 128 GB RAM | `g2.linux.5x-large` |
+| Linux 7XL | AMD EPYC Zen 4 and Zen 5 | 48 vCPU @3.7 GHz and 192 GB RAM | `g2.linux.7x-large` |

--- a/docs/bitrise-platform/infrastructure/build-machines/build-machine-types.md
+++ b/docs/bitrise-platform/infrastructure/build-machines/build-machine-types.md
@@ -16,22 +16,27 @@ Not all machines are available on all subscription plans. Visit [the pricing pag
 
 Machine types are divided into resource classes. The same resource class offers multiple machine types with broadly similar performances. Bitrise automatically assigns machine types from a resource class, which means that on the same day, your builds might run on different machine types.
 
-| Operating system | Resource class | Hardware types | Specs | Machine type ID for [YAML configuration](/en/bitrise-ci/configure-builds/configuring-build-settings/setting-the-stack-for-your-builds#setting-the-stack-in-the-configuration-yaml) |
-| --- | --- | --- | --- | --- |
-| macOS |  |  |  |  |
-| Medium | - M2 Pro Medium - M4 Medium | - 4 CPU @3.49GHz and 6 GB RAM - 5 CPU @4.4 GHz and 6 GB RAM | `g2.mac.medium` |  |
-| Large | - M2 Pro Large - M4 Large | - 6 CPU @3.49GHz and 14 GB RAM - 5 CPU @4.4 GHz and 14 GB RAM | `g2.mac.large` |  |
-| X Large | - M2 Pro X Large - M4 X Large | - 12 CPU @3.49GHz and 28 GB RAM - 10 CPU @4.4 GHz and 28 GB RAM | `g2.mac.x-large` |  |
-| 4Large | M4 Pro Large | 7 CPU @4.52GHz and 27 GB RAM | `g2.mac.4large` |  |
-| 4X Large | M4 Pro X Large | 14 CPU @4.52GHz and 54 GB RAM | `g2.mac.4x-large` |  |
-| Linux | Medium | 4 vCPU @ 3.1 GHz | 4 vCPU @3.1 GHz and 16 GB RAM | `standard` |
-| Large | 8 vCPU @ 3.1 GHz | 8 vCPU @3.1 GHz and 32 GB RAM | `elite` |  |
-| X Large | 16 vCPU @ 3.1 GHz | 16 vCPU @3.1 GHz and 64 GB RAM | `elite-xl` |  |
-| M | AMD EPYC Zen 4 and Zen 5 | 4 vCPU @3.7 GHz and 16 GB RAM | `g2.linux.medium` |  |
-| 2M | AMD EPYC Zen 4 and Zen 5 | 6 vCPU @3.7 GHz and 24 GB RAM | `g2.linux.2medium` |  |
-| L | AMD EPYC Zen 4 and Zen 5 | 8 vCPU @3.7 GHz and 32 GB RAM | `g2.linux.large` |  |
-| 4L | AMD EPYC Zen 4 and Zen 5 | 14 vCPU @3.7 GHz and 56 GB RAM | `g2.linux.4large` |  |
-| XL | AMD EPYC Zen 4 and Zen 5 | 16 vCPU @3.7 GHz and 64 GB RAM | `g2.linux.x-large` |  |
-| 3XL | AMD EPYC Zen 4 and Zen 5 | 24 vCPU @3.7 GHz and 96 GB RAM | `g2.linux.3x-large` |  |
-| 5XL | AMD EPYC Zen 4 and Zen 5 | 32 vCPU @3.7 GHz and 128 GB RAM | `g2.linux.5x-large` |  |
-| 7XL | AMD EPYC Zen 4 and Zen 5 | 48 vCPU @3.7 GHz and 192 GB RAM | `g2.linux.7x-large` |  |
+:::tip
+
+Use the machine type ID to set the machine type in your [configuration YAML](/en/bitrise-ci/configure-builds/configuring-build-settings/setting-the-stack-for-your-builds#setting-the-stack-in-the-configuration-yaml).
+
+:::
+
+| OS and resource class | Hardware types | Specs | Machine type ID |
+| --- | --- | --- | --- |
+| macOS Medium | M2 Pro Medium<br/>M4 Medium | 4 CPU @3.49GHz and 6 GB RAM<br/>5 CPU @4.4 GHz and 6 GB RAM | `g2.mac.medium` |
+| macOS Large | M2 Pro Large<br/>M4 Large | 6 CPU @3.49GHz and 14 GB RAM<br/>5 CPU @4.4 GHz and 14 GB RAM | `g2.mac.large` |
+| macOS X Large | M2 Pro X Large<br/>M4 X Large | 12 CPU @3.49GHz and 28 GB RAM<br/>10 CPU @4.4 GHz and 28 GB RAM | `g2.mac.x-large` |
+| macOS 4Large | M4 Pro Large | 7 CPU @4.52GHz and 27 GB RAM | `g2.mac.4large` |
+| macOS 4X Large | M4 Pro X Large | 14 CPU @4.52GHz and 54 GB RAM | `g2.mac.4x-large` |
+| Linux Medium | | 4 vCPU @3.1 GHz and 16 GB RAM | `standard` |
+| Linux Large | | 8 vCPU @3.1 GHz and 32 GB RAM | `elite` |
+| Linux X Large | | 16 vCPU @3.1 GHz and 64 GB RAM | `elite-xl` |
+| Linux M | AMD EPYC Zen 4 and Zen 5 | 4 vCPU @3.7 GHz and 16 GB RAM | `g2.linux.medium` |
+| Linux 2M | AMD EPYC Zen 4 and Zen 5 | 6 vCPU @3.7 GHz and 24 GB RAM | `g2.linux.2medium` |
+| Linux L | AMD EPYC Zen 4 and Zen 5 | 8 vCPU @3.7 GHz and 32 GB RAM | `g2.linux.large` |
+| Linux 4L | AMD EPYC Zen 4 and Zen 5 | 14 vCPU @3.7 GHz and 56 GB RAM | `g2.linux.4large` |
+| Linux XL | AMD EPYC Zen 4 and Zen 5 | 16 vCPU @3.7 GHz and 64 GB RAM | `g2.linux.x-large` |
+| Linux 3XL | AMD EPYC Zen 4 and Zen 5 | 24 vCPU @3.7 GHz and 96 GB RAM | `g2.linux.3x-large` |
+| Linux 5XL | AMD EPYC Zen 4 and Zen 5 | 32 vCPU @3.7 GHz and 128 GB RAM | `g2.linux.5x-large` |
+| Linux 7XL | AMD EPYC Zen 4 and Zen 5 | 48 vCPU @3.7 GHz and 192 GB RAM | `g2.linux.7x-large` |


### PR DESCRIPTION
## Summary

- Fix skewed table structure: rows were misaligned due to blank OS rows in the original
- Combine "Operating system" and "Resource class" into a single "OS and resource class" column (e.g. "Linux L", "macOS Medium")
- Shorten last column header to "Machine type ID"; add a tip admonition linking to the YAML configuration docs

## Test plan

- [ ] Check table renders correctly in the preview
- [ ] Verify tip admonition link navigates to the correct section

🤖 Generated with [Claude Code](https://claude.com/claude-code)