### PR TITLE
docs: add branch protection note to Push changes section

### DIFF
--- a/docs/bitrise-ci/configure-builds/configuration-yaml/storing-an-apps-configuration-yaml.mdx
+++ b/docs/bitrise-ci/configure-builds/configuration-yaml/storing-an-apps-configuration-yaml.mdx
@@ -139,6 +139,8 @@ When your `bitrise.yml` is stored in your repository, the Workflow Editor can pu
 
    You can only push directly from the Workflow Editor if you use GitHub or GitLab. If you use Bitbucket Cloud, you will need to commit the file manually every time.
 
+   If your repository has branch protection rules that require pull requests before merging, **Push to current branch** can fail with a generic `Failed to push changes. Please try again.` error. If you run into this, branch protection is a likely cause: use **Create a new branch** instead, which commits your changes to a new branch and gives you a link to open a pull request from it.
+
    :::
 1. Write a commit message and click **Push changes**.
 


### PR DESCRIPTION
## What

Adds a note to the "Updating a bitrise.yml stored in the repository" section explaining that branch protection rules requiring PRs will cause the **Push to current branch** option to fail with a `"Could not update file: Changes must be made through a pull request."` error, and that **Create a new branch** should be used instead.

## Why

This is a real user-facing error with no current explanation in the docs. The workaround (use Create a new branch) is already available in the UI but wasn't documented.