### PR TITLE
Add Bitrise MCP docs synced from source repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,20 @@ Sentence case only. ✓ `Adding a new project` ✗ `Adding a New Project`.
 
 ---
 
+## Syncing MCP docs
+
+When asked to sync, pull, or update the Bitrise MCP docs, run:
+
+```bash
+python3 scripts/sync_mcp_docs.py
+```
+
+This fetches `.md` files from `bitrise-io/bitrise-mcp/docs/` on GitHub and writes them (with injected frontmatter, link rewriting, and list rendering fixes) to `docs/bitrise-platform/ai/bitrise-mcp/`. Set `GITHUB_TOKEN` in the environment for authenticated requests (5,000 req/hr vs 60 req/hr unauthenticated).
+
+The script is idempotent. After running, review the diff and commit if the changes look correct. Never manually edit the synced files — edits belong in the source repo.
+
+---
+
 ## Updating this file
 
 If you discover a new convention or pitfall while editing, **add it here** so the next contributor (human or AI) doesn't relearn it. Keep the file < 400 lines; if a section grows long, link to a deeper page on Confluence instead.

--- a/docs/bitrise-platform/ai/bitrise-mcp/_category_.json
+++ b/docs/bitrise-platform/ai/bitrise-mcp/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Bitrise MCP",
+  "position": 4,
+  "link": null
+}

--- a/docs/bitrise-platform/ai/bitrise-mcp/bitrise-mcp.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp/bitrise-mcp.md
@@ -1,7 +1,7 @@
 ---
 title: "Bitrise MCP"
 description: "The Bitrise Model Context Protocol (MCP) Server lets you talk to Bitrise via an AI client of your choice. It enables seamless interaction with your existing CI setup, including troubleshooting and automation."
-sidebar_position: 4
+sidebar_position: 1
 slug: /bitrise-platform/ai/bitrise-mcp
 ---
 

--- a/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/_category_.json
+++ b/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Installing the Bitrise MCP server",
+  "position": 2,
+  "link": null
+}

--- a/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-claude.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-claude.md
@@ -1,0 +1,223 @@
+---
+title: "Install Bitrise MCP Server in Claude Applications"
+sidebar_label: "Claude Applications"
+sidebar_position: 1
+slug: /bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-claude
+---
+# Install Bitrise MCP Server in Claude Applications
+
+## Claude Code CLI
+
+### Prerequisites
+- Claude Code CLI installed (recent version, with MCP OAuth support)
+- A Bitrise account
+- Open Claude Code inside the directory for your project (recommended for best experience and clear scope of configuration)
+
+### Remote Server Setup (Streamable HTTP) — Recommended
+
+The remote server uses OAuth to authenticate you against your Bitrise account. No token to copy or paste.
+
+1. Add the server:
+   ```bash
+   claude mcp add --transport http bitrise https://mcp.bitrise.io
+   ```
+2. Restart Claude Code.
+3. On the first tool use, Claude Code will open your browser to sign in. Log in to Bitrise (or confirm your existing session) and approve the consent screen.
+4. Run `claude mcp list` to confirm the server is configured.
+
+#### Fallback: PAT-based authentication
+
+If you're on a Claude Code version without MCP OAuth support, or you'd prefer to use a Personal Access Token:
+
+1. [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security).
+2. Add the server with the token as a Bearer header:
+   ```bash
+   claude mcp add --transport http bitrise https://mcp.bitrise.io -H "Authorization: Bearer YOUR_BITRISE_PAT"
+   ```
+
+<details>
+<summary><b>Storing Your PAT Securely</b></summary>
+<br>
+
+For security, avoid hardcoding your token. One common approach:
+
+1. Store your token in `.env` file
+
+   ```
+   BITRISE_PAT=your_token_here
+   ```
+
+2. Add to .gitignore
+
+   ```bash
+   echo -e ".env\n.mcp.json" >> .gitignore
+   ```
+
+3. Reference it when adding:
+
+   ```bash
+   claude mcp add --transport http bitrise https://mcp.bitrise.io -H "Authorization: Bearer $(grep BITRISE_PAT .env | cut -d '=' -f2)"
+   ```
+
+</details>
+
+### Local Server Setup (Go required)
+
+The local server runs in stdio mode and authenticates with a Personal Access Token (no browser OAuth flow in stdio mode).
+
+Prerequisites: [Go](https://go.dev/) (>=1.25) installed and a Bitrise PAT.
+
+1. Run:
+   ```bash
+   claude mcp add bitrise -e BITRISE_TOKEN=YOUR_BITRISE_PAT -- go run github.com/bitrise-io/bitrise-mcp/v2@v2
+   ```
+
+   With an environment variable:
+   ```bash
+   claude mcp add bitrise -e BITRISE_TOKEN=$(grep BITRISE_PAT .env | cut -d '=' -f2) -- go run github.com/bitrise-io/bitrise-mcp/v2@v2
+   ```
+2. Restart Claude Code.
+3. Run `claude mcp list` to see if the Bitrise server is configured.
+
+### Verification
+```bash
+claude mcp list
+claude mcp get bitrise
+```
+
+## Claude Desktop
+
+### Prerequisites
+- Claude Desktop installed (latest version)
+- A Bitrise account
+
+### Configuration File Location
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux**: `~/.config/Claude/claude_desktop_config.json`
+
+### Remote Server setup (Streamable HTTP) — Recommended
+
+Recent Claude Desktop versions support MCP OAuth natively. See [Claude | Connecting to a Remote MCP Server](https://modelcontextprotocol.io/docs/develop/connect-remote-servers#connecting-to-a-remote-mcp-server). On first connection, Claude Desktop opens your browser to authenticate with Bitrise — no token needed.
+
+If your Claude Desktop version doesn't yet support remote MCP servers natively, you can use [mcp-remote](https://www.npmjs.com/package/mcp-remote) as an adapter:
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp.bitrise.io"
+      ]
+    }
+  }
+}
+```
+
+`mcp-remote` will handle the OAuth flow on your behalf. If your version of `mcp-remote` doesn't yet support OAuth, you can fall back to providing a PAT:
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp.bitrise.io",
+        "--header",
+        "Authorization: Bearer YOUR_BITRISE_PAT"
+      ]
+    }
+  }
+}
+```
+
+Save the config file and restart Claude Desktop. If everything is set up correctly, you should see a hammer icon next to the message composer.
+
+In case `npx` is not found by Claude (`ENOENT`), specify the path to the `npx` binary in the `env` section:
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      ...
+      "env": {
+        "PATH": "PATH to bin of npx"
+      }
+    }
+  }
+}
+```
+
+### Local Server Setup (Go required)
+
+The local server uses stdio with a Personal Access Token:
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "command": "go",
+      "args": [
+        "run",
+        "github.com/bitrise-io/bitrise-mcp/v2@v2"
+      ],
+      "env": {
+        "BITRISE_TOKEN": "YOUR_BITRISE_PAT",
+        "PATH": "PATH to bin directory of go:PATH to directory of git",
+        "GOPATH": "your GOPATH",
+        "GOCACHE": "your GOCACHE"
+      }
+    }
+  }
+}
+```
+
+### Manual Setup Steps
+1. Open Claude Desktop
+2. Go to Settings → Developer → Edit Config
+3. Paste the code block above in your configuration file
+4. If you're navigating to the configuration file outside of the app:
+   - **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+5. Open the file in a text editor
+6. Paste one of the code blocks above, based on your chosen configuration (remote or local)
+7. Save the file
+8. Restart Claude Desktop
+9. If using OAuth: complete the sign-in flow in your browser the first time you use a tool
+
+### Advanced configuration
+
+See [Tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for enabling/disabling specific API groups.
+
+## Troubleshooting
+
+**OAuth flow doesn't open browser:**
+- Make sure your Claude version supports MCP OAuth (recent builds only)
+- Try falling back to PAT-based authentication
+
+**Authentication Failed:**
+- For OAuth: re-authenticate via `/mcp` command in Claude Code, or by deleting and re-adding the server
+- For PAT: check token hasn't expired or been revoked
+
+**Remote Server:**
+- Verify URL: `https://mcp.bitrise.io`
+
+**Server Not Starting / Tools Not Showing:**
+- Run `claude mcp list` to view currently configured MCP servers
+- Validate JSON syntax
+- Restart Claude Code and check `/mcp` command
+- Delete the Bitrise server by running `claude mcp remove bitrise` and repeating the setup process with a different method
+- Check logs:
+  - Claude Code: Use `/mcp` command
+  - Claude Desktop: `ls ~/Library/Logs/Claude/` and `cat ~/Library/Logs/Claude/mcp-server-*.log` (macOS) or `%APPDATA%\Claude\logs\` (Windows)
+
+## Important Notes
+
+- Remote server requires Streamable HTTP support (check your Claude version). OAuth requires a more recent build than basic Streamable HTTP.
+- Configuration scopes for Claude Code:
+  - `-s user`: Available across all projects
+  - `-s project`: Shared via `.mcp.json` file
+  - Default: `local` (current project only)

--- a/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-cursor.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-cursor.md
@@ -1,0 +1,121 @@
+---
+title: "Install Bitrise MCP Server in Cursor"
+sidebar_label: "Cursor"
+sidebar_position: 2
+slug: /bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-cursor
+---
+# Install Bitrise MCP Server in Cursor
+
+## Prerequisites
+
+1. [Cursor](https://cursor.com/download) IDE installed (latest version, with MCP OAuth support — Cursor v0.48.0+ for Streamable HTTP, recent builds for OAuth)
+2. A Bitrise account
+3. For local setup: [Go](https://go.dev/) (>=1.25) installed and a Bitrise PAT
+
+## Remote Server Setup (Recommended)
+
+Recent Cursor versions support MCP OAuth — on first tool use Cursor opens your browser to sign in to Bitrise; no token to paste.
+
+### Install steps
+
+1. Open your global MCP configuration file at `~/.cursor/mcp.json` (or use a project-local `.cursor/mcp.json`) and add the configuration below
+2. Save the file
+3. Restart Cursor
+4. On first tool invocation, complete the browser-based sign-in flow
+
+### Streamable HTTP Configuration
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "url": "https://mcp.bitrise.io"
+    }
+  }
+}
+```
+
+### Fallback: PAT-based authentication
+
+If your Cursor version doesn't yet support MCP OAuth, you can use a Personal Access Token. [Create one](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security), then:
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "url": "https://mcp.bitrise.io",
+      "headers": {
+        "Authorization": "Bearer YOUR_BITRISE_PAT"
+      }
+    }
+  }
+}
+```
+
+## Local Server Setup
+
+The local Bitrise MCP server runs via Go and uses a Personal Access Token (stdio mode, no OAuth).
+
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=bitrise&config=eyJlbnYiOnsiQklUUklTRV9UT0tFTiI6IllPVVJfQklUUklTRV9QQVQifSwiY29tbWFuZCI6ImdvIHJ1biBnaXRodWIuY29tL2JpdHJpc2UtaW8vYml0cmlzZS1tY3AvdjJAdjIifQo%3D)
+
+### Install steps
+
+1. Click the install button above and follow the flow, or open `~/.cursor/mcp.json` and add the configuration below
+2. In Tools & Integrations > MCP tools, click the pencil icon next to "bitrise"
+3. Replace `YOUR_BITRISE_PAT` with your actual Personal Access Token
+4. Save the file
+5. Restart Cursor
+
+### Local Configuration
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "command": "go",
+      "args": [
+        "run",
+        "github.com/bitrise-io/bitrise-mcp/v2@v2"
+      ],
+      "env": {
+        "BITRISE_TOKEN": "YOUR_BITRISE_PAT"
+      }
+    }
+  }
+}
+```
+
+## Configuration Files
+
+- **Global (all projects)**: `~/.cursor/mcp.json`
+- **Project-specific**: `.cursor/mcp.json` in project root
+
+## Verify Installation
+
+1. Restart Cursor completely
+2. Check for green dot in Settings → Tools & Integrations → MCP Tools
+3. In chat/composer, check "Available Tools"
+4. Test with: "List my Bitrise apps" (the first tool call will trigger the OAuth flow if you're not already signed in)
+
+## Advanced configuration
+
+See [Tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for enabling/disabling specific API groups.
+
+## Troubleshooting
+
+### Remote Server Issues
+
+- **OAuth flow doesn't open browser**: Update Cursor to a recent build. Older builds with Streamable HTTP but without OAuth support can use the PAT-based fallback above.
+- **Streamable HTTP not working**: Ensure you're using Cursor v0.48.0 or later
+- **Connection errors**: Check firewall/proxy settings
+
+### General Issues
+
+- **MCP not loading**: Restart Cursor completely after configuration
+- **Invalid JSON**: Validate that json format is correct
+- **Tools not appearing**: Check server shows green dot in MCP settings
+- **Check logs**: Look for MCP-related errors in Cursor logs
+
+## Important Notes
+
+- **Cursor specifics**: Supports both project and global configurations, uses `mcpServers` key

--- a/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-gemini-cli.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-gemini-cli.md
@@ -1,0 +1,153 @@
+---
+title: "Install Bitrise MCP Server in Google Gemini CLI"
+sidebar_label: "Google Gemini CLI"
+sidebar_position: 3
+slug: /bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-gemini-cli
+---
+# Install Bitrise MCP Server in Google Gemini CLI
+
+## Prerequisites
+
+1. The latest version of Google Gemini CLI installed (see [official Gemini CLI documentation](https://github.com/google-gemini/gemini-cli))
+2. A Bitrise account
+3. For local setup: [Go](https://go.dev/) (>=1.25) installed and a Bitrise PAT
+
+## Bitrise MCP Server Configuration
+
+MCP servers for Gemini CLI are configured in its settings JSON under an `mcpServers` key.
+
+- **Global configuration**: `~/.gemini/settings.json` where `~` is your home directory
+- **Project-specific**: `.gemini/settings.json` in your project directory
+
+You may need to restart the Gemini CLI for changes to take effect.
+
+### Method 1: Gemini Extension (Recommended)
+
+The simplest way is to use Bitrise's hosted MCP server via our Gemini extension:
+
+```
+gemini extensions install https://github.com/bitrise-io/bitrise-mcp
+```
+
+The extension handles the OAuth flow automatically on first use — you'll be prompted to sign in to Bitrise in your browser.
+
+### Method 2: Remote Server
+
+You can also connect to the hosted MCP server directly:
+
+```json
+// ~/.gemini/settings.json
+{
+    "mcpServers": {
+        "bitrise": {
+            "httpUrl": "https://mcp.bitrise.io"
+        }
+    }
+}
+```
+
+On first tool use, Gemini CLI will open your browser for the Bitrise OAuth sign-in.
+
+#### Fallback: PAT-based authentication
+
+For Gemini CLI builds that don't yet support MCP OAuth, [create a Bitrise PAT](https://devcenter.bitrise.io/api/authentication) and pass it as a header:
+
+```json
+// ~/.gemini/settings.json
+{
+    "mcpServers": {
+        "bitrise": {
+            "httpUrl": "https://mcp.bitrise.io",
+            "headers": {
+                "Authorization": "Bearer $BITRISE_PAT"
+            }
+        }
+    }
+}
+```
+
+<details>
+<summary><b>Storing Your PAT Securely</b></summary>
+<br>
+
+For security, avoid hardcoding your token. Create or update `~/.gemini/.env` (where `~` is your home or project directory) with your PAT:
+
+```bash
+# ~/.gemini/.env
+BITRISE_PAT=your_token_here
+```
+
+</details>
+
+### Method 3: Local Server Setup (Go Required)
+
+The local server uses stdio with a Personal Access Token:
+
+```json
+// ~/.gemini/settings.json
+{
+    "mcpServers": {
+        "bitrise": {
+            "command": "go",
+            "args": [
+                "run",
+                "github.com/bitrise-io/bitrise-mcp/v2@v2"
+            ],
+            "env": {
+                "BITRISE_TOKEN": "$BITRISE_PAT"
+            }
+        }
+    }
+}
+```
+
+## Verification
+
+To verify that the Bitrise MCP server has been configured, start Gemini CLI in your terminal with `gemini`, then:
+
+1. **Check MCP server status**:
+
+    ```
+    /mcp list
+    ```
+
+    ```
+    ℹ Configured MCP servers:
+
+    🟢 bitrise - Ready (62 tools)
+        - abort_build
+        - abort_pipeline
+        - add_member_to_group
+        ...
+    ```
+
+2. **Test with a prompt**
+    ```
+    List my Bitrise apps
+    ```
+
+    The first tool call will trigger the OAuth sign-in flow if you're using the remote server without a PAT.
+
+## Advanced configuration
+
+See [Tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for enabling/disabling specific API groups.
+
+You can find more MCP configuration options for Gemini CLI here: [MCP Configuration Structure](https://google-gemini.github.io/gemini-cli/docs/tools/mcp-server.html#configuration-structure). For example, bypassing tool confirmations or excluding specific tools.
+
+## Troubleshooting
+
+### Authentication Issues
+
+- **OAuth flow doesn't open**: Update Gemini CLI to a recent build, or fall back to PAT-based auth
+- **Token expired (PAT)**: Generate a new Bitrise token
+
+### Configuration Issues
+
+- **Invalid JSON**: Validate your configuration:
+    ```bash
+    cat ~/.gemini/settings.json | jq .
+    ```
+- **MCP connection issues**: Check logs for connection errors:
+    ```bash
+    gemini --debug "test command"
+    ```

--- a/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-kiro.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-kiro.md
@@ -1,0 +1,149 @@
+---
+title: "Install Bitrise MCP Server in AWS Kiro"
+sidebar_label: "AWS Kiro"
+sidebar_position: 4
+slug: /bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-kiro
+---
+# Install Bitrise MCP Server in AWS Kiro
+
+## Prerequisites
+- AWS Kiro IDE installed
+
+## Authentication
+
+Kiro currently uses environment-variable-based authentication for MCP servers, so the standard Power installation uses a Bitrise Personal Access Token (PAT). [Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security).
+
+If you're running a Kiro build that supports MCP OAuth and prefer to use it, see the [OAuth-based Kiro configuration](#oauth-based-configuration-experimental) section below.
+
+## Installation via Kiro Power
+
+AWS Kiro supports installing the Bitrise MCP server as a Power, which provides automatic activation based on context and keywords.
+
+### Steps
+
+1. **Open the Powers Panel**
+   - In Kiro IDE, open the Powers panel from the sidebar
+
+2. **Add Power from GitHub**
+   - Click on "Add power from GitHub"
+
+3. **Enter the Repository URL**
+   ```
+   https://github.com/bitrise-io/bitrise-mcp/tree/main/kiro-powers/bitrise-ci
+   ```
+
+4. **Set Up Authentication**
+   - Before starting Kiro, set the `BITRISE_TOKEN` environment variable in your shell profile (`.zshrc` or `.bashrc`):
+     ```bash
+     export BITRISE_TOKEN="your-actual-token-here"
+     ```
+   - Restart your terminal or run `source ~/.zshrc` (or `source ~/.bashrc`)
+   - Start Kiro - it will read the environment variable on startup
+   - When Kiro starts, a popup may ask if you trust the environment variable - accept it to allow access
+
+5. **Verify Installation**
+   - The Bitrise Power should now appear in your Powers list
+   - It will automatically activate when you mention keywords like "bitrise", "build", "ci", "cd", "mobile", "ios", "android", etc.
+
+## Usage
+
+Once installed, the Bitrise Power will automatically activate when relevant. You can:
+
+- Manage Bitrise apps
+- Trigger and monitor builds
+- Handle build artifacts
+- Manage workspaces and teams
+- Configure pipelines
+- Set up release management
+
+The power provides access to all 63 Bitrise tools. For a complete list of available tools and their parameters, refer to the [tools documentation](/en/bitrise-platform/ai/bitrise-mcp/tools).
+
+## OAuth-based Configuration (experimental)
+
+For Kiro builds that support MCP OAuth, you can drop the `BITRISE_TOKEN` requirement entirely. Edit `~/.kiro/settings/mcp.json` (user level) or `.kiro/settings/mcp.json` (workspace level) and remove the `headers` block:
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "type": "http",
+      "url": "https://mcp.bitrise.io"
+    }
+  }
+}
+```
+
+On first tool use, Kiro will open your browser for the Bitrise sign-in flow.
+
+## Advanced Configuration
+
+You can limit the tools exposed by configuring API groups. This is useful for optimizing token usage or focusing on specific functionality.
+
+Available API groups:
+- `apps` - App management
+- `builds` - Build operations
+- `artifacts` - Artifact management
+- `workspaces` - Workspace management
+- `pipelines` - Pipeline operations
+- `outgoing-webhooks` - Webhook configuration
+- `cache-items` - Cache management
+- `release-management` - Release and distribution
+- `group-roles` - Role management
+- `account` - User account operations
+- `read-only` - Read-only operations
+
+By default, all groups are enabled. To customize, modify the Power configuration after installation.
+
+## Troubleshooting
+
+### Environment Variable Not Working
+
+Kiro IDE can only read environment variables that are set in your shell profile (`.zshrc` or `.bashrc`) **before** Kiro starts. Unlike VS Code, Kiro does not prompt you to enter the token value - it expects the environment variable to already be available.
+
+**Option 1: Set in Shell Profile (Recommended)**
+1. Add the export to your shell profile:
+   ```bash
+   # Add to ~/.zshrc or ~/.bashrc
+   export BITRISE_TOKEN="your-actual-token-here"
+   ```
+2. Restart your terminal or source the profile: `source ~/.zshrc`
+3. **Restart Kiro** - this is required for Kiro to pick up the new environment variable
+4. When prompted, accept the popup asking if you trust the environment variable
+
+**Option 2: Manual Configuration**
+If the environment variable approach doesn't work, you can hardcode the token:
+1. Open `~/.kiro/settings/mcp.json` (user level) or `.kiro/settings/mcp.json` (workspace level)
+2. Find the Bitrise server entry
+3. Replace `${BITRISE_TOKEN}` with your actual token value
+4. Save the file and restart Kiro
+
+**Option 3: Use OAuth**
+If your Kiro build supports MCP OAuth, see the [OAuth-based Configuration](#oauth-based-configuration-experimental) section above.
+
+**Note on Environment Variable Syntax**
+The syntax for environment variables differs between Kiro CLI and IDE:
+- **Kiro CLI**: Use `${env:BITRISE_TOKEN}` (with `env:` prefix)
+- **Kiro IDE**: Use `${BITRISE_TOKEN}` (without prefix)
+
+This inconsistency is a known issue. The Power is configured with `${BITRISE_TOKEN}` which works for the IDE.
+
+### Power Not Activating
+- Ensure you've entered the correct repository URL with `/tree/main/power` path
+- Check that your `BITRISE_TOKEN` is valid
+- Try mentioning explicit keywords like "bitrise" in your conversation
+
+### Authentication Issues
+- Verify your Personal Access Token is still valid
+- Check token permissions in your Bitrise account settings
+- Regenerate the token if necessary
+
+### Connection Problems
+- The power connects to `https://mcp.bitrise.io`
+- Ensure you have internet connectivity
+- Check if there are any firewall restrictions
+
+## Additional Resources
+
+- [Bitrise API Documentation](https://devcenter.bitrise.io/api/api-index/)
+- [Kiro Powers Documentation](https://kiro.dev/docs/powers/)
+- [MCP Protocol Documentation](https://modelcontextprotocol.io/)

--- a/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-other-copilot-ides.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-other-copilot-ides.md
@@ -1,0 +1,285 @@
+---
+title: "Install Bitrise MCP Server in Copilot IDEs"
+sidebar_label: "Copilot IDEs"
+sidebar_position: 5
+slug: /bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-other-copilot-ides
+---
+# Install Bitrise MCP Server in Copilot IDEs
+
+Quick setup guide for the Bitrise MCP server in GitHub Copilot across different IDEs. For VS Code instructions, refer to the [Install Bitrise MCP Server in VS Code](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-vscode)
+
+### Requirements:
+1. GitHub Copilot License: Any Copilot plan (Free, Pro, Pro+, Business, Enterprise) for Copilot access
+2. Bitrise Account: Bitrise account for Bitrise MCP server access
+3. MCP Servers in Copilot Policy: Organizations assigning Copilot seats must enable this policy for all MCP access in Copilot for VS Code and Copilot Coding Agent – all other Copilot IDEs will migrate to this policy in the coming months
+4. For local setup: [Go](https://go.dev/) (>=1.23) installed and a Bitrise Personal Access Token
+
+The remote setups below use OAuth — your IDE opens a browser on first tool use, you sign in to Bitrise, no token to paste. For older Copilot IDE builds without MCP OAuth, a PAT-based fallback configuration is included for each IDE.
+
+## Visual Studio
+
+Requires Visual Studio 2022 version 17.14.9 or later.
+
+### Remote Server (Recommended)
+
+The remote Bitrise MCP server is hosted by Bitrise and provides automatic updates with no local setup required.
+
+#### Configuration
+1. Create an `.mcp.json` file in your solution or %USERPROFILE% directory.
+2. Add this configuration:
+
+   ```json
+   {
+     "servers": {
+       "bitrise": {
+         "url": "https://mcp.bitrise.io"
+       }
+     }
+   }
+   ```
+3. Save the file. Wait for CodeLens to update to offer a way to authenticate to the new server, activate that and complete the Bitrise sign-in in your browser.
+4. In the GitHub Copilot Chat window, switch to Agent mode.
+5. Activate the tool picker in the Chat window and enable one or more tools from the "bitrise" MCP server.
+
+#### Fallback: PAT-based authentication
+
+```json
+{
+  "servers": {
+    "bitrise": {
+      "url": "https://mcp.bitrise.io",
+      "headers": {
+        "Authorization": "Bearer YOUR_BITRISE_PAT"
+      }
+    }
+  }
+}
+```
+
+[Create a PAT](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security).
+
+### Local Server (Go required)
+
+#### Configuration
+1. Create an `.mcp.json` file in your solution or %USERPROFILE% directory.
+2. Add this configuration:
+
+   ```json
+   {
+     "servers": {
+       "bitrise": {
+         "type": "stdio",
+         "command": "go",
+         "args": ["run", "github.com/bitrise-io/bitrise-mcp/v2@v2"],
+         "env": {
+           "BITRISE_TOKEN": "YOUR_BITRISE_PAT"
+         }
+       }
+     }
+   }
+   ```
+3. Save the file. Wait for CodeLens to update to offer a way to provide user inputs, activate that and paste in a PAT you generate from your [Bitrise Account Settings/Security](https://app.bitrise.io/me/account/security).
+4. In the GitHub Copilot Chat window, switch to Agent mode.
+5. Activate the tool picker in the Chat window and enable one or more tools from the "bitrise" MCP server.
+
+**Documentation:** [Visual Studio MCP Guide](https://learn.microsoft.com/visualstudio/ide/mcp-servers)
+
+## JetBrains IDEs
+
+Agent mode and MCP support available in public preview across IntelliJ IDEA, PyCharm, WebStorm, and other JetBrains IDEs.
+
+### Remote Server (Recommended)
+
+#### Configuration Steps
+1. Install/update the GitHub Copilot plugin
+2. Click **GitHub Copilot icon in the status bar** → **Edit Settings** → **Model Context Protocol** → **Configure**
+3. Add configuration:
+
+   ```json
+   {
+     "servers": {
+       "bitrise": {
+         "url": "https://mcp.bitrise.io"
+       }
+     }
+   }
+   ```
+4. Press `Ctrl + S` or `Command + S` to save, or close the `mcp.json` file. On first tool use the IDE will open your browser for Bitrise sign-in.
+
+#### Fallback: PAT-based authentication
+
+```json
+{
+  "servers": {
+    "bitrise": {
+      "url": "https://mcp.bitrise.io",
+      "requestInit": {
+        "headers": {
+          "Authorization": "Bearer YOUR_BITRISE_PAT"
+        }
+      }
+    }
+  }
+}
+```
+
+### Local Server (Go required)
+
+```json
+{
+  "servers": {
+    "bitrise": {
+      "command": "go",
+      "args": [
+        "run",
+        "github.com/bitrise-io/bitrise-mcp/v2@v2"
+      ],
+      "env": {
+        "BITRISE_TOKEN": "YOUR_BITRISE_PAT"
+      }
+    }
+  }
+}
+```
+
+**Documentation:** [JetBrains Copilot Guide](https://plugins.jetbrains.com/plugin/17718-github-copilot)
+
+## Xcode
+
+Agent mode and MCP support now available in public preview for Xcode.
+
+### Remote Server (Recommended)
+
+#### Configuration Steps
+1. Install/update [GitHub Copilot for Xcode](https://github.com/github/CopilotForXcode)
+2. Open **GitHub Copilot for Xcode app** → **Agent Mode** → **🛠️ Tool Picker** → **Edit Config**
+3. Configure your MCP servers:
+
+   ```json
+   {
+     "servers": {
+       "bitrise": {
+         "url": "https://mcp.bitrise.io"
+       }
+     }
+   }
+   ```
+4. On first tool use, complete the Bitrise sign-in flow in your browser.
+
+#### Fallback: PAT-based authentication
+
+```json
+{
+  "servers": {
+    "bitrise": {
+      "url": "https://mcp.bitrise.io",
+      "requestInit": {
+        "headers": {
+          "Authorization": "Bearer YOUR_BITRISE_PAT"
+        }
+      }
+    }
+  }
+}
+```
+
+### Local Server (Go required)
+
+```json
+{
+  "servers": {
+    "bitrise": {
+      "command": "go",
+      "args": [
+        "run",
+        "github.com/bitrise-io/bitrise-mcp/v2@v2"
+      ],
+      "env": {
+        "BITRISE_TOKEN": "YOUR_BITRISE_PAT"
+      }
+    }
+  }
+}
+```
+
+**Documentation:** [Xcode Copilot Guide](https://devblogs.microsoft.com/xcode/github-copilot-exploring-agent-mode-and-mcp-support-in-public-preview-for-xcode/)
+
+## Eclipse
+
+MCP support available with Eclipse 2024-03+ and latest version of the GitHub Copilot plugin.
+
+### Remote Server (Recommended)
+
+#### Configuration Steps
+1. Install GitHub Copilot extension from Eclipse Marketplace
+2. Click the **GitHub Copilot icon** → **Edit Preferences** → **MCP** (under **GitHub Copilot**)
+3. Add Bitrise MCP server configuration:
+
+   ```json
+   {
+     "servers": {
+       "bitrise": {
+         "url": "https://mcp.bitrise.io"
+       }
+     }
+   }
+   ```
+4. Click the "Apply and Close" button. On first tool use, complete the Bitrise sign-in in your browser.
+
+#### Fallback: PAT-based authentication
+
+```json
+{
+  "servers": {
+    "bitrise": {
+      "url": "https://mcp.bitrise.io",
+      "requestInit": {
+        "headers": {
+          "Authorization": "Bearer YOUR_BITRISE_PAT"
+        }
+      }
+    }
+  }
+}
+```
+
+### Local Server (Go required)
+
+```json
+{
+  "servers": {
+    "bitrise": {
+      "command": "go",
+      "args": [
+        "run",
+        "github.com/bitrise-io/bitrise-mcp/v2@v2"
+      ],
+      "env": {
+        "BITRISE_TOKEN": "YOUR_BITRISE_PAT",
+        "PATH": "PATH to bin directory of go:PATH to directory of git"
+      }
+    }
+  }
+}
+```
+
+**Documentation:** [Eclipse Copilot plugin](https://marketplace.eclipse.org/content/github-copilot)
+
+## Usage
+
+After setup:
+1. Restart your IDE completely
+2. Open Agent mode in Copilot Chat
+3. Try: *"List my Bitrise apps"* — first call triggers OAuth sign-in for the remote server
+4. Copilot can now access Bitrise data and perform operations
+
+## Advanced configuration
+
+See [Tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for enabling/disabling specific API groups.
+
+## Troubleshooting
+
+- **OAuth flow doesn't open browser**: Make sure your Copilot integration is on a build that supports MCP OAuth. Fall back to PAT-based auth in older versions.
+- **Connection issues**: Verify IDE version compatibility
+- **Authentication errors**: Check if your organization has enabled the MCP policy for Copilot
+- **Tools not appearing**: Restart IDE after configuration changes and check error logs

--- a/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-vscode.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-vscode.md
@@ -1,0 +1,93 @@
+---
+title: "Install Bitrise MCP Server in VS Code"
+sidebar_label: "VS Code"
+sidebar_position: 6
+slug: /bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-vscode
+---
+# Install Bitrise MCP Server in VS Code
+
+## Prerequisites
+- [VS Code](https://code.visualstudio.com/Download) installed (recent version, with MCP OAuth support)
+- A Bitrise account
+- For local setup: [Go](https://go.dev/) (>=1.25) installed and a Bitrise PAT
+
+## Remote Server Setup (Streamable HTTP) — Recommended
+
+VS Code's MCP integration handles OAuth automatically. On first connection it'll open your browser to sign you in to Bitrise — no token needed.
+
+Follow [VS Code | Add an MCP server](https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_add-an-mcp-server) and add the following to your settings:
+
+```json
+{
+  "servers": {
+    "bitrise": {
+      "type": "http",
+      "url": "https://mcp.bitrise.io"
+    }
+  }
+}
+```
+
+Save the configuration. VS Code will recognize the change, prompt you to sign in via your browser on first tool use, and load the tools into Copilot Chat.
+
+### Fallback: PAT-based authentication
+
+If your VS Code build doesn't support MCP OAuth yet, you can use a Personal Access Token:
+
+```json
+{
+  "servers": {
+    "bitrise": {
+      "type": "http",
+      "url": "https://mcp.bitrise.io",
+      "headers": {
+        "Authorization": "Bearer ${input:bitrise-token}"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "id": "bitrise-token",
+      "type": "promptString",
+      "description": "Bitrise token",
+      "password": true
+    }
+  ]
+}
+```
+
+[Create a Bitrise API Token](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security) when prompted.
+
+## Local Server Setup (Go required)
+
+Local stdio mode authenticates with a Personal Access Token:
+
+```json
+{
+  "servers": {
+    "bitrise-local": {
+      "type": "stdio",
+      "command": "go",
+      "args": [
+        "run",
+        "github.com/bitrise-io/bitrise-mcp/v2@v2"
+      ],
+      "env": {
+        "BITRISE_TOKEN": "${input:bitrise-token}"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "id": "bitrise-token",
+      "type": "promptString",
+      "description": "Bitrise token",
+      "password": true
+    }
+  ]
+}
+```
+
+## Advanced configuration
+
+See [Tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for enabling/disabling specific API groups.

--- a/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-windsurf.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-windsurf.md
@@ -1,0 +1,108 @@
+---
+title: "Install Bitrise MCP Server in Windsurf"
+sidebar_label: "Windsurf"
+sidebar_position: 7
+slug: /bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-windsurf
+---
+# Install Bitrise MCP Server in Windsurf
+
+## Prerequisites
+1. [Windsurf IDE](https://windsurf.com/) installed (latest version)
+2. A Bitrise account
+3. For local setup: [Go](https://go.dev/) (>=1.25) installed and a Bitrise PAT
+
+## Remote Server Setup (Recommended)
+
+The remote Bitrise MCP server is hosted by Bitrise at `https://mcp.bitrise.io` and supports Streamable HTTP. Recent Windsurf builds support MCP OAuth — the first tool use opens your browser to sign in to Bitrise; no token to paste.
+
+### Streamable HTTP Configuration
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "serverUrl": "https://mcp.bitrise.io"
+    }
+  }
+}
+```
+
+### Fallback: PAT-based authentication
+
+If your Windsurf build doesn't yet support MCP OAuth, [create a Bitrise PAT](https://devcenter.bitrise.io/api/authentication) under [Account Settings → Security](https://app.bitrise.io/me/account/security) and add it as a header:
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "serverUrl": "https://mcp.bitrise.io",
+      "headers": {
+        "Authorization": "Bearer YOUR_BITRISE_PAT"
+      }
+    }
+  }
+}
+```
+
+## Local Server Setup (Go required)
+
+```json
+{
+  "mcpServers": {
+    "bitrise": {
+      "command": "go",
+      "args": [
+        "run",
+        "github.com/bitrise-io/bitrise-mcp/v2@v2"
+      ],
+      "env": {
+        "BITRISE_TOKEN": "YOUR_BITRISE_PAT"
+      }
+    }
+  }
+}
+```
+
+## Installation Steps
+
+### Manual Configuration
+1. Click the hammer icon (🔨) in Cascade
+2. Click **Configure** to open `~/.codeium/windsurf/mcp_config.json`
+3. Add your chosen configuration from above
+4. Save the file
+5. Click **Refresh** (🔄) in the MCP toolbar
+6. On the first tool call, complete the browser-based sign-in flow (OAuth setup only)
+
+## Configuration Details
+
+- **File path**: `~/.codeium/windsurf/mcp_config.json`
+- **Scope**: Global configuration only (no per-project support)
+- **Format**: Must be valid JSON (use a linter to verify)
+
+## Verification
+
+After installation:
+1. Look for "1 available MCP server" in the MCP toolbar
+2. Click the hammer icon to see available Bitrise tools
+3. Test with: "List my Bitrise apps" (first call triggers OAuth sign-in if using the remote server)
+4. Check for green dot next to the server name
+
+## Advanced configuration
+
+See [Tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for enabling/disabling specific API groups.
+
+## Troubleshooting
+
+### Remote Server Issues
+- **OAuth flow doesn't open browser**: Update Windsurf to a recent build. Fall back to PAT-based auth in older versions.
+- **Authentication failures (PAT)**: Verify the PAT hasn't expired or been revoked
+- **Connection errors**: Check firewall/proxy settings for HTTPS connections
+- **Streamable HTTP not working**: Ensure you're using the correct `serverUrl` field format
+
+### General Issues
+- **Invalid JSON**: Validate with [jsonlint.com](https://jsonlint.com)
+- **Tools not appearing**: Restart Windsurf completely
+- **Check logs**: `~/.codeium/windsurf/logs/`
+
+## Important Notes
+- **Windsurf limitations**: No environment variable interpolation, global config only

--- a/docs/bitrise-platform/ai/bitrise-mcp/tools.md
+++ b/docs/bitrise-platform/ai/bitrise-mcp/tools.md
@@ -1,0 +1,689 @@
+---
+title: "Tools"
+sidebar_label: "Tools"
+sidebar_position: 3
+slug: /bitrise-platform/ai/bitrise-mcp/tools
+---
+## Advanced configuration
+
+You can limit the number of tools exposed to the MCP client. This is useful if you want to optimize token usage or your MCP client has a limit on the number of tools.
+
+Tools are grouped by their "API group", and you can pass the groups you want to expose as tools. Possible values: `apps, builds, workspaces, outgoing-webhooks, artifacts, group-roles, cache-items, pipelines, account, read-only, release-management, configuration, release-management-code-push`.
+
+We recommend using the `release-management` API group separately to avoid any confusion with the `apps` API group.
+
+By default, all API groups are enabled. You can specify which groups to enable using the `ENABLED_API_GROUPS` environment variable for local (stdio) servers or the `x-bitrise-enabled-api-groups` HTTP header for remote (Streamable HTTP) servers with a comma-separated list of group names.
+
+## Tools
+
+### Apps
+
+1. `list_apps`
+   - List all the apps available for the authenticated account
+   - Arguments:
+     - `sort_by` (optional): Order of the apps: last_build_at (default) or created_at
+     - `next` (optional): Slug of the first app in the response
+     - `limit` (optional): Max number of elements per page (default: 50)
+
+2. `register_app`
+   - Add a new app to Bitrise
+   - Arguments:
+     - `repo_url`: Repository URL
+     - `is_public`: Whether the app's builds visibility is "public"
+     - `organization_slug`: The organization (aka workspace) the app to add to
+     - `project_type` (optional): Type of project (ios, android, etc.)
+     - `provider` (optional): github
+
+3. `finish_bitrise_app`
+   - Finish the setup of a Bitrise app
+   - Arguments:
+     - `app_slug`: The slug of the Bitrise app to finish setup for
+     - `project_type` (optional): The type of project (e.g., android, ios, flutter, etc.)
+     - `stack_id` (optional): The stack ID to use for the app
+     - `mode` (optional): The mode of setup
+     - `config` (optional): The configuration to use for the app
+
+4. `get_app`
+   - Get the details of a specific app
+   - Arguments:
+     - `app_slug`: Identifier of the Bitrise app
+
+5. `delete_app`
+   - Delete an app from Bitrise
+   - Arguments:
+     - `app_slug`: Identifier of the Bitrise app
+
+6. `update_app`
+   - Update an app
+   - Arguments:
+     - `app_slug`: Identifier of the Bitrise app
+     - `is_public`: Whether the app's builds visibility is "public"
+     - `project_type`: Type of project
+     - `provider`: Repository provider
+     - `repo_url`: Repository URL
+
+7. `get_bitrise_yml`
+   - Get the current Bitrise YML config file of a specified Bitrise app
+   - Arguments:
+     - `app_slug`: Identifier of the Bitrise app
+
+8. `update_bitrise_yml`
+   - Update the Bitrise YML config file of a specified Bitrise app
+   - Arguments:
+     - `app_slug`: Identifier of the Bitrise app
+     - `bitrise_yml_as_json`: The new Bitrise YML config file content
+
+9. `list_branches`
+   - List the branches with existing builds of an app's repository
+   - Arguments:
+     - `app_slug`: Identifier of the Bitrise app
+
+10. `register_ssh_key`
+    - Add an SSH-key to a specific app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `auth_ssh_private_key`: Private SSH key
+      - `auth_ssh_public_key`: Public SSH key
+      - `is_register_key_into_provider_service`: Register the key in the provider service
+
+11. `register_webhook`
+    - Register an incoming webhook for a specific application
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+
+### Builds
+
+12. `list_builds`
+    - List all the builds of a specified Bitrise app or all accessible builds
+    - Arguments:
+      - `app_slug` (optional): Identifier of the Bitrise app
+      - `sort_by` (optional): Order of builds: created_at (default), running_first
+      - `branch` (optional): Filter builds by branch
+      - `workflow` (optional): Filter builds by workflow
+      - `status` (optional): Filter builds by status (0: not finished, 1: successful, 2: failed, 3: aborted, 4: in-progress)
+      - `next` (optional): Slug of the first build in the response
+      - `limit` (optional): Max number of elements per page (default: 50)
+
+13. `trigger_bitrise_build`
+    - Trigger a new build/pipeline for a specified Bitrise app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `branch` (optional): The branch to build (default: main)
+      - `pipeline_id` (optional): The pipeline to build
+      - `workflow_id` (optional): The workflow to build
+      - `pipeline_id` (optional): The pipeline to build
+      - `commit_message` (optional): The commit message for the build
+      - `commit_hash` (optional): The commit hash for the build
+      - `environments` (optional): Custom environment variables for the build (array of objects with `mapped_to`, `value`, and optional `is_expand` properties)
+
+14. `get_build`
+    - Get a specific build of a given app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `build_slug`: Identifier of the build
+
+15. `abort_build`
+    - Abort a specific build
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `build_slug`: Identifier of the build
+      - `reason` (optional): Reason for aborting the build
+
+16. `get_build_log`
+    - Get the build log of a specified build of a Bitrise app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `build_slug`: Identifier of the Bitrise build
+
+17. `get_build_bitrise_yml`
+    - Get the bitrise.yml of a build
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `build_slug`: Identifier of the build
+
+18. `list_build_workflows`
+    - List the workflows of an app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+
+19. `get_build_steps`
+    - Get step statuses of a specific build of a given app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `build_slug`: Identifier of the build
+
+### Artifacts
+
+20. `list_artifacts`
+    - Get a list of all build artifacts
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `build_slug`: Identifier of the build
+      - `next` (optional): Slug of the first artifact in the response
+      - `limit` (optional): Max number of elements per page (default: 50)
+
+20. `get_artifact`
+    - Get a specific build artifact
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `build_slug`: Identifier of the build
+      - `artifact_slug`: Identifier of the artifact
+
+21. `delete_artifact`
+    - Delete a build artifact
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `build_slug`: Identifier of the build
+      - `artifact_slug`: Identifier of the artifact
+
+22. `update_artifact`
+    - Update a build artifact
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `build_slug`: Identifier of the build
+      - `artifact_slug`: Identifier of the artifact
+      - `is_public_page_enabled`: Enable public page for the artifact
+
+### Outgoing Webhooks
+
+24. `list_outgoing_webhooks`
+    - List the outgoing webhooks of an app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+
+25. `delete_outgoing_webhook`
+    - Delete the outgoing webhook of an app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `webhook_slug`: Identifier of the webhook
+
+26. `update_outgoing_webhook`
+    - Update an outgoing webhook for an app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `webhook_slug`: Identifier of the webhook
+      - `events`: List of events to trigger the webhook
+      - `url`: URL of the webhook
+      - `headers` (optional): Headers to be sent with the webhook
+
+27. `create_outgoing_webhook`
+    - Create an outgoing webhook for an app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `events`: List of events to trigger the webhook
+      - `url`: URL of the webhook
+      - `headers` (optional): Headers to be sent with the webhook
+
+### Cache Items
+
+28. `list_cache_items`
+    - List the key-value cache items belonging to an app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+
+29. `delete_all_cache_items`
+    - Delete all key-value cache items belonging to an app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+
+30. `delete_cache_item`
+    - Delete a key-value cache item
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `cache_item_id`: Identifier of the cache item
+
+31. `get_cache_item_download_url`
+    - Get the download URL of a key-value cache item
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `cache_item_id`: Identifier of the cache item
+
+### Pipelines
+
+32. `list_pipelines`
+    - List all pipelines and standalone builds of an app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+
+33. `get_pipeline`
+    - Get a pipeline of a given app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `pipeline_id`: Identifier of the pipeline
+
+34. `abort_pipeline`
+    - Abort a pipeline
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `pipeline_id`: Identifier of the pipeline
+      - `reason` (optional): Reason for aborting the pipeline
+
+35. `rebuild_pipeline`
+    - Rebuild a pipeline
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `pipeline_id`: Identifier of the pipeline
+
+### Group Roles
+
+36. `list_group_roles`
+    - List group roles for an app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `role_name`: Name of the role
+
+37. `replace_group_roles`
+    - Replace group roles for an app
+    - Arguments:
+      - `app_slug`: Identifier of the Bitrise app
+      - `role_name`: Name of the role
+      - `group_slugs`: List of group slugs
+
+### Workspaces
+
+38. `list_workspaces`
+    - List the workspaces the user has access to
+
+39. `get_workspace`
+    - Get details for one workspace
+    - Arguments:
+      - `workspace_slug`: Slug of the Bitrise workspace
+
+40. `get_workspace_groups`
+    - Get the groups in a workspace
+    - Arguments:
+      - `workspace_slug`: Slug of the Bitrise workspace
+
+41. `create_workspace_group`
+    - Create a group in a workspace
+    - Arguments:
+      - `workspace_slug`: Slug of the Bitrise workspace
+      - `group_name`: Name of the group
+
+42. `get_workspace_members`
+    - Get the members in a workspace
+    - Arguments:
+      - `workspace_slug`: Slug of the Bitrise workspace
+
+43. `invite_member_to_workspace`
+    - Invite a member to a workspace
+    - Arguments:
+      - `workspace_slug`: Slug of the Bitrise workspace
+      - `email`: Email address of the user
+
+44. `add_member_to_group`
+    - Add a member to a group
+    - Arguments:
+      - `group_slug`: Slug of the group
+      - `user_slug`: Slug of the user
+
+### Account
+
+45. `me`
+    - Get info from the currently authenticated user account
+
+### Release Management
+
+46. `create_connected_app`
+   - Add a new Release Management connected app to Bitrise.
+   - Arguments:
+     - `platform`: The mobile platform for the connected app (ios/android).
+     - `store_app_id`: The app store identifier for the connected app.
+     - `workspace_slug`: Identifier of the Bitrise workspace.
+     - `id`: (Optional) An uuidV4 identifier for your new connected app.
+     - `manual_connection`: (Optional) Indicates a manual connection.
+     - `project_id`: (Optional) Specifies which Bitrise Project to associate with.
+     - `store_app_name`: (Optional) App name for manual connections.
+     - `store_credential_id`: (Optional) Selection of credentials added on Bitrise.
+
+47. `list_connected_apps`
+   - List Release Management connected apps available for the authenticated account within a workspace.
+   - Arguments:
+     - `workspace_slug`: Identifier of the Bitrise workspace.
+     - `items_per_page`: (Optional) Maximum number of connected apps per page.
+     - `page`: (Optional) Page number to return.
+     - `platform`: (Optional) Filter for a specific mobile platform.
+     - `project_id`: (Optional) Filter for a specific Bitrise Project.
+     - `search`: (Optional) Search by bundle ID, package name, or app title.
+
+48. `get_connected_app`
+   - Gives back a Release Management connected app for the authenticated account.
+   - Arguments:
+     - `id`: Identifier of the Release Management connected app.
+
+49. `update_connected_app`
+   - Updates a connected app.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier for your connected app.
+     - `store_app_id`: The store identifier for your app.
+     - `connect_to_store`: (Optional) Check validity against the App Store or Google Play.
+     - `store_credential_id`: (Optional) Selection of credentials added on Bitrise.
+
+50. `list_installable_artifacts`
+   - List Release Management installable artifacts of a connected app.
+   - Arguments:
+     - `connected_app_id`: Identifier of the Release Management connected app.
+     - `after_date`: (Optional) Start of the interval for artifact creation/upload.
+     - `artifact_type`: (Optional) Filter for a specific artifact type.
+     - `before_date`: (Optional) End of the interval for artifact creation/upload.
+     - `branch`: (Optional) Filter for the Bitrise CI branch.
+     - `distribution_ready`: (Optional) Filter for distribution ready artifacts.
+     - `items_per_page`: (Optional) Maximum number of artifacts per page.
+     - `page`: (Optional) Page number to return.
+     - `platform`: (Optional) Filter for a specific mobile platform.
+     - `search`: (Optional) Search by version, filename or build number.
+     - `source`: (Optional) Filter for the source of installable artifacts.
+     - `store_signed`: (Optional) Filter for store ready installable artifacts.
+     - `version`: (Optional) Filter for a specific version.
+     - `workflow`: (Optional) Filter for a specific Bitrise CI workflow.
+
+51. `generate_installable_artifact_upload_url`
+   - Generates a signed upload URL for an installable artifact to be uploaded to Bitrise.
+   - Arguments:
+     - `connected_app_id`: Identifier of the Release Management connected app.
+     - `installable_artifact_id`: An uuidv4 identifier for the installable artifact.
+     - `file_name`: The name of the installable artifact file.
+     - `file_size_bytes`: The byte size of the installable artifact file.
+     - `branch`: (Optional) Name of the CI branch.
+     - `with_public_page`: (Optional) Enable public install page.
+     - `workflow`: (Optional) Name of the CI workflow.
+
+52. `get_installable_artifact_upload_and_processing_status`
+   - Gets the processing and upload status of an installable artifact.
+   - Arguments:
+     - `connected_app_id`: Identifier of the Release Management connected app.
+     - `installable_artifact_id`: The uuidv4 identifier for the installable artifact.
+
+53. `set_installable_artifact_public_install_page`
+   - Changes whether public install page should be available for the installable artifact.
+   - Arguments:
+     - `connected_app_id`: Identifier of the Release Management connected app.
+     - `installable_artifact_id`: The uuidv4 identifier for the installable artifact.
+     - `with_public_page`: Boolean flag for enabling/disabling public install page.
+
+54. `list_build_distribution_versions`
+   - Lists Build Distribution versions available for testers.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `items_per_page`: (Optional) Maximum number of versions per page.
+     - `page`: (Optional) Page number to return.
+
+55. `list_build_distribution_version_test_builds`
+   - Gives back a list of test builds for the given build distribution version.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `version`: The version of the build distribution.
+     - `items_per_page`: (Optional) Maximum number of test builds per page.
+     - `page`: (Optional) Page number to return.
+
+56. `create_tester_group`
+   - Creates a tester group for a Release Management connected app.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `name`: The name for the new tester group.
+     - `auto_notify`: (Optional) Indicates automatic notifications for the group.
+
+57. `notify_tester_group`
+   - Notifies a tester group about a new test build.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `id`: The uuidV4 identifier of the tester group.
+     - `test_build_id`: The unique identifier of the test build.
+
+58. `add_testers_to_tester_group`
+   - Adds testers to a tester group of a connected app.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `id`: The uuidV4 identifier of the tester group.
+     - `user_slugs`: The list of users identified by slugs to be added.
+
+59. `update_tester_group`
+   - Updates the given tester group settings.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `id`: The uuidV4 identifier of the tester group.
+     - `auto_notify`: (Optional) Setting for automatic email notifications.
+     - `name`: (Optional) The new name for the tester group.
+
+60. `list_tester_groups`
+   - Gives back a list of tester groups related to a specific connected app.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `items_per_page`: (Optional) Maximum number of tester groups per page.
+     - `page`: (Optional) Page number to return.
+
+61. `get_tester_group`
+   - Gives back the details of the selected tester group.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `id`: The uuidV4 identifier of the tester group.
+
+62. `get_potential_testers`
+   - Gets a list of potential testers who can be added to a specific tester group.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `id`: The uuidV4 identifier of the tester group.
+     - `items_per_page`: (Optional) Maximum number of potential testers per page.
+     - `page`: (Optional) Page number to return.
+     - `search`: (Optional) Search for testers by email or username.
+
+63. `get_testers`
+   - Gets a list of testers that have been associated with a tester group related to a specific connected app.
+   - Arguments:
+     - `connected_app_id`: The uuidV4 identifier of the connected app.
+     - `tester_group_id`: (Optional) The uuidV4 identifier of a tester group. If given, only testers within this specific tester group will be returned.
+     - `items_per_page`: (Optional) Maximum number of testers per page (default: 10).
+     - `page`: (Optional) Page number to return (default: 1).
+
+### Configuration
+
+64. `validate_bitrise_yml`
+    - Validate a Bitrise YML config file. This endpoint checks if the provided bitrise.yml is valid.
+    - Arguments:
+      - `bitrise_yml`: The Bitrise YML config file content to be validated. It must be a string.
+      - `app_slug` (optional): Slug of a Bitrise app. Specifying this value allows for validating the YML against workspace-specific settings like available stacks, machine types, license pools etc.
+
+65. `step_search`
+    - Find steps for building workflows or step bundles in a Bitrise YML config file. Finds steps based on name, description, tags or maintainers.
+    - Arguments:
+      - `query`: The phrase to search steps for like `clone`, `npm`, `deploy` etc.
+      - `categories` (optional): Categories to filter steps. Available values: `build`, `code-sign`, `test`, `deploy`, `notification`, `access-control`, `artifact-info`, `installer`, `dependency`, `utility`
+      - `maintainers` (optional): Filter steps by maintainers. Available values: `bitrise`, `verified`, `community`
+
+66. `step_inputs`
+    - List inputs of a step with their defaults, allowed values etc.
+    - Arguments:
+      - `step_ref`: Step reference formatted as `step_lib_source::step_id@version`. `step_id` and an exact `version` are required, `step_lib_source` is only necessary for custom step sources.
+
+67. `list_available_stacks`
+    - List available stacks with their machine configurations and version information. When a workspace_slug is provided, returns stacks available for that workspace including any custom stacks. When omitted, returns globally available stacks.
+    - Arguments:
+      - `workspace_slug` (optional): Slug of the Bitrise workspace. When provided, lists stacks available for that workspace (including custom stacks). When omitted, lists globally available stacks.
+
+### CodePush
+
+68. `codepush_list_deployments`
+   - List CodePush deployments for a Bitrise app.
+   - Arguments:
+     - `app_id`: Identifier of the Bitrise app.
+     - `search`: (Optional) Search deployments by name. The filter is case-sensitive.
+     - `items_per_page`: (Optional) Maximum number of deployments per page (default: 10).
+     - `page`: (Optional) Page number to return (default: 1).
+
+69. `codepush_get_deployment`
+   - Get a specific CodePush deployment by its ID.
+   - Arguments:
+     - `id`: Identifier (UUID) of the CodePush deployment.
+
+70. `codepush_create_deployment`
+   - Create a new CodePush deployment for a Bitrise app.
+   - Arguments:
+     - `name`: Name for the new deployment.
+     - `app_id`: Identifier of the Bitrise app.
+     - `key`: (Optional) Deployment key. Auto-generated if not provided.
+
+71. `codepush_update_deployment`
+   - Update the name of an existing CodePush deployment.
+   - Arguments:
+     - `id`: Identifier (UUID) of the CodePush deployment.
+     - `name`: New name for the deployment.
+
+72. `codepush_delete_deployment`
+   - Delete a CodePush deployment. This action is irreversible.
+   - Arguments:
+     - `id`: Identifier (UUID) of the CodePush deployment to delete.
+
+73. `codepush_promote_deployment`
+   - Promote a package from a source deployment to a target deployment. The most recent package in the source deployment is promoted unless package_id is specified.
+   - Arguments:
+     - `id`: Identifier (UUID) of the source deployment.
+     - `target_deployment_id`: Identifier (UUID) of the target deployment.
+     - `package_id`: (Optional) UUID of a specific package to promote. Defaults to most recent.
+     - `app_version`: (Optional) Semver app version constraint for the promoted package.
+     - `description`: (Optional) Description for the promoted package.
+     - `disabled`: (Optional) If true, clients will not download this update.
+     - `mandatory`: (Optional) If true, clients must install immediately.
+     - `rollout`: (Optional) Percentage (0-100) of users who receive this update.
+
+74. `codepush_rollback_deployment`
+   - Rollback a CodePush deployment to its previous version.
+   - Arguments:
+     - `id`: Identifier (UUID) of the CodePush deployment to rollback.
+     - `package_id`: (Optional) UUID of a specific package to rollback to. Defaults to the previous package.
+
+75. `codepush_list_updates`
+   - List CodePush updates for a specific deployment.
+   - Arguments:
+     - `deployment_id`: Identifier (UUID) of the CodePush deployment.
+     - `search`: (Optional) Search updates by label or description. The filter is case-sensitive.
+     - `items_per_page`: (Optional) Maximum number of updates per page (default: 10).
+     - `page`: (Optional) Page number to return (default: 1).
+
+76. `codepush_get_update`
+   - Get a specific CodePush update by its ID.
+   - Arguments:
+     - `id`: Identifier (UUID) of the CodePush update.
+
+77. `codepush_patch_update`
+   - Patch a CodePush update to change its disabled state, mandatory flag, or rollout percentage. Only include fields you want to change — omitted fields are left unchanged.
+   - Arguments:
+     - `id`: Identifier (UUID) of the CodePush update.
+     - `disabled`: (Optional) Set to 'true' to disable or 'false' to re-enable.
+     - `mandatory`: (Optional) Set to 'true' to make mandatory or 'false' to make optional.
+     - `rollout`: (Optional) Percentage (0-100) of users who receive this update.
+
+78. `codepush_delete_update`
+   - Delete a CodePush update. This action is irreversible.
+   - Arguments:
+     - `id`: Identifier (UUID) of the CodePush update to delete.
+
+79. `codepush_get_update_status`
+   - Get the processing status of a CodePush update (e.g. pending, ready, failed).
+   - Arguments:
+     - `id`: Identifier (UUID) of the CodePush update.
+
+80. `codepush_generate_update_upload_url`
+   - Generate a signed upload URL (valid 1 hour) for uploading a CodePush update bundle. The response contains the URL, HTTP method, and headers needed for a direct upload. After uploading, check status with `codepush_get_update_status`.
+   - Arguments:
+     - `id`: Client-generated UUID for the new update.
+     - `deployment_id`: Identifier (UUID) of the deployment this update belongs to.
+     - `app_version`: Semver version of the app this update targets (e.g. '1.2.3').
+     - `file_name`: File name of the update bundle to be uploaded (with extension).
+     - `file_size_bytes`: Byte size of the update bundle file as a string.
+     - `description`: (Optional) Description for this update.
+     - `disabled`: (Optional) If true, clients will not download this update after upload.
+     - `mandatory`: (Optional) If true, clients must install this update immediately.
+     - `rollout`: (Optional) Percentage (0-100) of users who receive this update. Defaults to 100.
+
+81. `codepush_get_metrics`
+   - Get workspace-level CodePush usage metrics including data transfer, storage, and monthly active users, along with their limits and billing cycle information.
+   - Arguments:
+     - `workspace_slug`: Slug of the Bitrise workspace.
+
+## API Groups
+
+The Bitrise MCP server organizes tools into API groups that can be enabled or disabled via command-line arguments. The table below shows which API groups each tool belongs to:
+
+| Tool | apps | builds | workspaces | outgoing-webhooks | artifacts | group-roles | cache-items | pipelines | account | read-only | release-management | configuration | release-management-code-push |
+|------|------|--------|------------|-------------------|-----------|-------------|-------------|-----------|---------|-----------|--------------------|--------------|------------------------------|
+| list_apps | ✅ | | | | | | | | | ✅ | | | |
+| register_app | ✅ | | | | | | | | | | | | |
+| finish_bitrise_app | ✅ | | | | | | | | | | | | |
+| get_app | ✅ | | | | | | | | | ✅ | | | |
+| delete_app | ✅ | | | | | | | | | | | | |
+| update_app | ✅ | | | | | | | | | | | | |
+| get_bitrise_yml | ✅ | | | | | | | | | ✅ | | | |
+| update_bitrise_yml | ✅ | | | | | | | | | | | | |
+| list_branches | ✅ | | | | | | | | | ✅ | | | |
+| register_ssh_key | ✅ | | | | | | | | | | | | |
+| register_webhook | ✅ | | | | | | | | | | | | |
+| list_builds | | ✅ | | | | | | | | ✅ | | | |
+| trigger_bitrise_build | | ✅ | | | | | | | | | | | |
+| get_build | | ✅ | | | | | | | | ✅ | | | |
+| abort_build | | ✅ | | | | | | | | | | | |
+| get_build_log | | ✅ | | | | | | | | ✅ | | | |
+| get_build_bitrise_yml | | ✅ | | | | | | | | ✅ | | | |
+| list_build_workflows | | ✅ | | | | | | | | ✅ | | | |
+| get_build_steps | | ✅ | | | | | | | | ✅ | | | |
+| list_artifacts | | | | | ✅ | | | | | ✅ | | | |
+| get_artifact | | | | | ✅ | | | | | ✅ | | | |
+| delete_artifact | | | | | ✅ | | | | | | | | |
+| update_artifact | | | | | ✅ | | | | | | | | |
+| list_outgoing_webhooks | | | | ✅ | | | | | | ✅ | | | |
+| delete_outgoing_webhook | | | | ✅ | | | | | | | | | |
+| update_outgoing_webhook | | | | ✅ | | | | | | | | | |
+| create_outgoing_webhook | | | | ✅ | | | | | | | | | |
+| list_cache_items | | | | | | | ✅ | | | ✅ | | | |
+| delete_all_cache_items | | | | | | | ✅ | | | | | | |
+| delete_cache_item | | | | | | | ✅ | | | | | | |
+| get_cache_item_download_url | | | | | | | ✅ | | | ✅ | | | |
+| list_pipelines | | | | | | | | ✅ | | ✅ | | | |
+| get_pipeline | | | | | | | | ✅ | | ✅ | | | |
+| abort_pipeline | | | | | | | | ✅ | | | | | |
+| rebuild_pipeline | | | | | | | | ✅ | | | | | |
+| list_group_roles | | | | | | ✅ | | | | ✅ | | | |
+| replace_group_roles | | | | | | ✅ | | | | | | | |
+| list_workspaces | | | ✅ | | | | | | | ✅ | | | |
+| get_workspace | | | ✅ | | | | | | | ✅ | | | |
+| get_workspace_groups | | | ✅ | | | | | | | ✅ | | | |
+| create_workspace_group | | | ✅ | | | | | | | | | | |
+| get_workspace_members | | | ✅ | | | | | | | ✅ | | | |
+| invite_member_to_workspace | | | ✅ | | | | | | | | | | |
+| add_member_to_group | | | ✅ | | | | | | | | | | |
+| me | | | | | | | | | ✅ | ✅ | | | |
+| create_connected_app | | | | | | | | | | | ✅ | | |
+| list_connected_apps | | | | | | | | | | ✅ | ✅ | | |
+| get_connected_app | | | | | | | | | | ✅ | ✅ | | |
+| update_connected_app | | | | | | | | | | | ✅ | | |
+| list_installable_artifacts | | | | | | | | | | ✅ | ✅ | | |
+| generate_installable_artifact_upload_url | | | | | | | | | | | ✅ | | |
+| get_installable_artifact_upload_and_processing_status | | | | | | | | | | ✅ | ✅ | | |
+| set_installable_artifact_public_install_page | | | | | | | | | | | ✅ | | |
+| list_build_distribution_versions | | | | | | | | | | ✅ | ✅ | | |
+| list_build_distribution_version_test_builds | | | | | | | | | | ✅ | ✅ | | |
+| create_tester_group | | | | | | | | | | | ✅ | | |
+| notify_tester_group | | | | | | | | | | | ✅ | | |
+| add_testers_to_tester_group | | | | | | | | | | | ✅ | | |
+| update_tester_group | | | | | | | | | | | ✅ | | |
+| list_tester_groups | | | | | | | | | | ✅ | ✅ | | |
+| get_tester_group | | | | | | | | | | ✅ | ✅ | | |
+| get_potential_testers | | | | | | | | | | ✅ | ✅ | | |
+| get_testers | | | | | | | | | | ✅ | ✅ | | |
+| validate_bitrise_yml | | | | | | | | | | ✅ | | ✅ | |
+| step_search | | | | | | | | | | ✅ | | ✅ | |
+| step_inputs | | | | | | | | | | ✅ | | ✅ | |
+| list_available_stacks | | | | | | | | | | ✅ | | ✅ | |
+| codepush_list_deployments | | | | | | | | | | ✅ | ✅ | | ✅ |
+| codepush_get_deployment | | | | | | | | | | ✅ | ✅ | | ✅ |
+| codepush_create_deployment | | | | | | | | | | | ✅ | | ✅ |
+| codepush_update_deployment | | | | | | | | | | | ✅ | | ✅ |
+| codepush_delete_deployment | | | | | | | | | | | ✅ | | ✅ |
+| codepush_promote_deployment | | | | | | | | | | | ✅ | | ✅ |
+| codepush_rollback_deployment | | | | | | | | | | | ✅ | | ✅ |
+| codepush_list_updates | | | | | | | | | | ✅ | ✅ | | ✅ |
+| codepush_get_update | | | | | | | | | | ✅ | ✅ | | ✅ |
+| codepush_patch_update | | | | | | | | | | | ✅ | | ✅ |
+| codepush_delete_update | | | | | | | | | | | ✅ | | ✅ |
+| codepush_get_update_status | | | | | | | | | | ✅ | ✅ | | ✅ |
+| codepush_generate_update_upload_url | | | | | | | | | | | ✅ | | ✅ |
+| codepush_get_metrics | | | | | | | | | | ✅ | ✅ | | ✅ |

--- a/scripts/sync_mcp_docs.py
+++ b/scripts/sync_mcp_docs.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+Sync .md files from bitrise-io/bitrise-mcp/docs into the devcenter.
+
+Usage:
+  python3 scripts/sync_mcp_docs.py            # sync all files
+  python3 scripts/sync_mcp_docs.py --dry-run  # preview without writing
+
+What it does:
+  1. Fetches the file list from the GitHub API for bitrise-io/bitrise-mcp/docs.
+  2. For each .md file (skipping bitrise-mcp.md if it ever appears):
+     a. Downloads the raw content.
+     b. Strips any existing frontmatter.
+     c. Derives title (from H1), sidebar_label, slug, and sidebar_position.
+     d. Writes to the correct destination:
+        - install-*.md → docs/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/
+        - everything else → docs/bitrise-platform/ai/bitrise-mcp/
+  3. Idempotent: re-running produces no changes if the source is unchanged.
+
+Authentication:
+  Set GITHUB_TOKEN in the environment to use authenticated requests
+  (5000 req/hr vs 60 req/hr unauthenticated).
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Dict, List, Optional
+
+REPO_ROOT    = Path(__file__).parent.parent
+BASE_DIR     = REPO_ROOT / "docs/bitrise-platform/ai/bitrise-mcp"
+INSTALL_DIR  = BASE_DIR / "installing-the-bitrise-mcp-server"
+API_URL      = "https://api.github.com/repos/bitrise-io/bitrise-mcp/contents/docs"
+RAW_BASE     = "https://raw.githubusercontent.com/bitrise-io/bitrise-mcp/main/docs"
+SLUG_BASE    = "/bitrise-platform/ai/bitrise-mcp"
+SLUG_INSTALL = f"{SLUG_BASE}/installing-the-bitrise-mcp-server"
+SKIP_FILES   = {"bitrise-mcp.md"}
+DRY_RUN      = "--dry-run" in sys.argv
+
+# sidebar_position within the install subcategory
+INSTALL_POSITIONS: Dict[str, int] = {
+    "install-claude":             1,
+    "install-cursor":             2,
+    "install-gemini-cli":         3,
+    "install-kiro":               4,
+    "install-other-copilot-ides": 5,
+    "install-vscode":             6,
+    "install-windsurf":           7,
+}
+
+# sidebar_position within bitrise-mcp/ (top-level siblings of the install category)
+ROOT_POSITIONS: Dict[str, int] = {
+    "tools": 3,
+}
+
+
+def gh_request(url: str) -> bytes:
+    token = os.environ.get("GITHUB_TOKEN")
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "sync-mcp-docs"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        return resp.read()
+
+
+def list_source_files() -> List[str]:
+    data = json.loads(gh_request(API_URL))
+    return [e["name"] for e in data if e["type"] == "file" and e["name"].endswith(".md")]
+
+
+def fetch_raw(filename: str) -> str:
+    return gh_request(f"{RAW_BASE}/{filename}").decode("utf-8")
+
+
+def strip_frontmatter(content: str) -> str:
+    if content.startswith("---"):
+        end = content.find("\n---", 3)
+        if end != -1:
+            return content[end + 4:].lstrip("\n")
+    return content
+
+
+def extract_h1(content: str) -> Optional[str]:
+    for line in content.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return None
+
+
+def is_install_file(stem: str) -> bool:
+    return stem.startswith("install-")
+
+
+def derive_sidebar_label(stem: str, h1: Optional[str]) -> str:
+    if stem == "tools":
+        return "Tools"
+    if h1:
+        prefix = "Install Bitrise MCP Server in "
+        if h1.startswith(prefix):
+            return h1[len(prefix):]
+        return h1
+    return stem.replace("-", " ").capitalize()
+
+
+def derive_position(stem: str, install_stems: List[str], root_stems: List[str]) -> int:
+    if is_install_file(stem):
+        if stem in INSTALL_POSITIONS:
+            return INSTALL_POSITIONS[stem]
+        known_max = max(INSTALL_POSITIONS.values(), default=0)
+        unknown = sorted(s for s in install_stems if s not in INSTALL_POSITIONS)
+        return known_max + 1 + (unknown.index(stem) if stem in unknown else len(unknown))
+    else:
+        if stem in ROOT_POSITIONS:
+            return ROOT_POSITIONS[stem]
+        known_max = max(ROOT_POSITIONS.values(), default=2)
+        unknown = sorted(s for s in root_stems if s not in ROOT_POSITIONS)
+        return known_max + 1 + (unknown.index(stem) if stem in unknown else len(unknown))
+
+
+def rewrite_internal_links(content: str) -> str:
+    """
+    Rewrite links that use the source repo's path (/docs/<file>.md) to the
+    equivalent devcenter slug (/en/bitrise-platform/ai/bitrise-mcp/...).
+    """
+    def replace(m: re.Match) -> str:
+        stem = m.group(1)
+        anchor = m.group(2) or ""  # e.g. "#section" or ""
+        if is_install_file(stem):
+            slug = f"{SLUG_INSTALL}/{stem}"
+        else:
+            slug = f"{SLUG_BASE}/{stem}"
+        return f"(/en{slug}{anchor})"
+
+    # Matches (/docs/<stem>.md) or (/docs/<stem>.md#anchor)
+    return re.sub(r'\(/docs/([^)#]+?)\.md(#[^)]*)?\)', replace, content)
+
+
+def fix_list_code_blocks(content: str) -> str:
+    """
+    Indent code fences that follow ordered list items so they are parsed as
+    list item content rather than terminating the list.
+
+    Without this, each list item followed by an unindented code fence becomes
+    its own <ol>, causing all items to render as step 1.
+
+    Before:
+        1. Do thing
+        ```bash
+        code
+        ```
+
+        2. Do next thing
+
+    After:
+        1. Do thing
+
+           ```bash
+           code
+           ```
+
+        2. Do next thing
+    """
+    lines = content.split('\n')
+    out = []
+    i = 0
+    content_col = None  # indentation level for code blocks in the current list item
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Ordered list item — record the content column ("1. " = 3, "10. " = 4, etc.)
+        m = re.match(r'^( *)(\d+)\. ', line)
+        if m:
+            content_col = len(m.group(1)) + len(m.group(2)) + 2
+            out.append(line)
+            i += 1
+            continue
+
+        # Blank line — keep list context, pass through
+        if not line.strip():
+            out.append(line)
+            i += 1
+            continue
+
+        # Unindented code fence inside a list context — indent the whole block
+        if content_col is not None and line.startswith('```'):
+            pad = ' ' * content_col
+            if out and out[-1].strip():  # ensure a blank line precedes the fence
+                out.append('')
+            out.append(pad + line)
+            i += 1
+            while i < len(lines):
+                out.append(pad + lines[i])
+                i += 1
+                if lines[i - 1].startswith('```'):
+                    break
+            continue
+
+        # Any other non-blank, non-indented line resets list context
+        if not line.startswith(' '):
+            content_col = None
+
+        out.append(line)
+        i += 1
+
+    return '\n'.join(out)
+
+
+def build_frontmatter(stem: str, h1: Optional[str], sidebar_label: str, position: int) -> str:
+    title = h1 if h1 else stem.replace("-", " ").capitalize()
+    slug  = f"{SLUG_INSTALL}/{stem}" if is_install_file(stem) else f"{SLUG_BASE}/{stem}"
+    return "\n".join([
+        "---",
+        f'title: "{title}"',
+        f'sidebar_label: "{sidebar_label}"',
+        f"sidebar_position: {position}",
+        f"slug: {slug}",
+        "---",
+        "",
+    ])
+
+
+def sync():
+    filenames = [f for f in list_source_files() if f not in SKIP_FILES]
+    install_stems = [Path(f).stem for f in filenames if is_install_file(Path(f).stem)]
+    root_stems    = [Path(f).stem for f in filenames if not is_install_file(Path(f).stem)]
+
+    changed = 0
+    for filename in sorted(filenames):
+        stem = Path(filename).stem
+        raw  = fetch_raw(filename)
+        body = strip_frontmatter(raw)
+        h1   = extract_h1(body)
+        label    = derive_sidebar_label(stem, h1)
+        position = derive_position(stem, install_stems, root_stems)
+        body = rewrite_internal_links(body)
+        new_content = build_frontmatter(stem, h1, label, position) + fix_list_code_blocks(body)
+
+        dest = (INSTALL_DIR if is_install_file(stem) else BASE_DIR) / filename
+        existing = dest.read_text(encoding="utf-8") if dest.exists() else None
+
+        if existing == new_content:
+            print(f"  unchanged  {filename}")
+            continue
+
+        print(f"  {'(dry-run) ' if DRY_RUN else ''}write      {filename}")
+        if not DRY_RUN:
+            dest.write_text(new_content, encoding="utf-8")
+        changed += 1
+
+    print(f"\n{changed} file(s) {'would be ' if DRY_RUN else ''}written.")
+
+
+if __name__ == "__main__":
+    sync()


### PR DESCRIPTION
## Summary

- Converts `docs/bitrise-platform/ai/bitrise-mcp.md` into a folder so the overview page, install guides, and tools doc can live together under `/bitrise-platform/ai/bitrise-mcp/`
- Install guides are grouped under an **"Installing the Bitrise MCP server"** subcategory; sidebar labels show only the app name (VS Code, Cursor, Claude Applications, etc.)
- Adds `scripts/sync_mcp_docs.py` to fetch `.md` files from `bitrise-io/bitrise-mcp/docs` on GitHub, with post-processing:
  - Frontmatter injection (title, sidebar_label, sidebar_position, slug)
  - Internal link rewriting (`/docs/*.md` → devcenter slugs)
  - Ordered list fix (indents code fences that follow list items so they don't restart numbering)
- Documents the sync command in `CLAUDE.md` so future contributors can run it with a natural-language request

## Test plan

- [ ] Check sidebar structure renders correctly in preview
- [ ] Verify install guide pages are grouped under "Installing the Bitrise MCP server"
- [ ] Verify "See Tools" links in install guides point to the correct devcenter URL
- [ ] Verify ordered list steps in "Storing Your PAT Securely" render as 1, 2, 3
- [ ] Re-run `python3 scripts/sync_mcp_docs.py` and confirm no files change (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)