### PR TITLE
Document workspace role management via SCIM

### DIFF
--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-scim.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-scim.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuring SCIM"
-description: "The System for Cross-domain Identity Management (SCIM) specification is designed to make managing user identities in cloud-based applications and services easier. On Bitrise, SCIM provisioning is supported for [Okta](https://www.okta.com/) and [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/)."
+description: "The System for Cross-domain Identity Management (SCIM) specification is designed to make managing user identities in cloud-based applications and services easier. On Bitrise, SCIM provisioning is supported for Okta and Microsoft Entra ID."
 sidebar_position: 3
 slug: /bitrise-platform/accounts/saml-sso-in-bitrise/configuring-scim
 ---
@@ -29,3 +29,82 @@ SCIM provisioning requires a verified domain, and SCIM credentials: a SCIM base 
    Copy and save both. You need them for SCIM provisioning.
 
    For Okta, check out our [SCIM provisioning guide](/en/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-okta-sso-for-bitrise#setting-up-scim-provisioning-in-okta).
+
+## Managing workspace roles via SCIM
+
+By default, all SCIM-provisioned users receive the Viewer role. If your IdP supports the SCIM `roles` attribute, you can automate <GlossTerm baseform="workspace">Workspace</GlossTerm> role assignment so that users are provisioned with the correct role from the start.
+
+### Available workspace roles
+
+| SCIM value | Workspace role | Description |
+|---|---|---|
+| `workspace:workspace_viewer` | Viewer | Can view Workspace resources. This is the default role for new members. |
+| `workspace:workspace_contributor` | Contributor | Can trigger builds and manage apps they have access to. |
+| `workspace:workspace_manager` | Manager | Can access and modify Workspace settings and manage members. |
+
+For a detailed breakdown of permissions, see [Roles and permissions in Workspaces](/en/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/roles-and-permissions-in-workspaces).
+
+### How role assignment works
+
+Each role entry's `value` field uses the format `workspace:<role_name>`. Configure your IdP to include the `roles` attribute in SCIM requests using one of the following formats.
+
+**User creation and full update (POST and PUT):**
+
+Include `roles` as a top-level attribute in the request body:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+  "userName": "user@example.com",
+  "roles": [
+    { "value": "workspace:workspace_manager" }
+  ]
+}
+```
+
+**Partial update (PATCH, roles in value object):**
+
+Some IdPs, such as Okta, send roles nested inside the `value` object without an explicit `path`:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+  "Operations": [
+    {
+      "op": "replace",
+      "value": {
+        "roles": [
+          { "value": "workspace:workspace_contributor" }
+        ]
+      }
+    }
+  ]
+}
+```
+
+**Partial update (PATCH, explicit path):**
+
+Other IdPs, such as Microsoft Entra ID, use an explicit `path` field. The `type` field is optional and ignored by Bitrise:
+
+```json
+{
+  "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+  "Operations": [
+    {
+      "op": "replace",
+      "path": "roles",
+      "value": [
+        { "value": "workspace:workspace_manager" }
+      ]
+    }
+  ]
+}
+```
+
+Bitrise handles all three formats automatically.
+
+:::important
+
+If the `roles` attribute is present in a SCIM request, Bitrise treats it as the complete role assignment and replaces the user's current workspace role. If `roles` is absent from the request entirely, existing role assignments are left untouched. An empty `roles` array reverts the user to the default Viewer role.
+
+:::

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-scim.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-scim.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuring SCIM"
-description: "The System for Cross-domain Identity Management (SCIM) specification is designed to make managing user identities in cloud-based applications and services easier. On Bitrise, SCIM provisioning is supported for Okta and Microsoft Entra ID."
+description: "The System for Cross-domain Identity Management (SCIM) specification is designed to make managing user identities in cloud-based applications and services easier. On Bitrise, SCIM provisioning is supported for [Okta](https://www.okta.com/) and [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity/)."
 sidebar_position: 3
 slug: /bitrise-platform/accounts/saml-sso-in-bitrise/configuring-scim
 ---

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-scim.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-scim.mdx
@@ -38,9 +38,9 @@ By default, all SCIM-provisioned users receive the Viewer role. If your IdP supp
 
 | SCIM value | Workspace role | Description |
 |---|---|---|
-| `workspace:workspace_viewer` | Viewer | Can view Workspace resources. This is the default role for new members. |
-| `workspace:workspace_contributor` | Contributor | Can trigger builds and manage apps they have access to. |
-| `workspace:workspace_manager` | Manager | Can access and modify Workspace settings and manage members. |
+| `workspace:workspace_viewer` | Viewer | Default role for new members. Can view Workspace resources but cannot create apps or projects. |
+| `workspace:workspace_contributor` | Contributor | Can create new apps and projects. Cannot modify Workspace settings or manage members. |
+| `workspace:workspace_manager` | Manager | Can modify Workspace settings, manage members, and manage integrations and infrastructure. |
 
 For a detailed breakdown of permissions, see [Roles and permissions in Workspaces](/en/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/roles-and-permissions-in-workspaces).
 

--- a/docs/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/roles-and-permissions-in-workspaces.mdx
+++ b/docs/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/roles-and-permissions-in-workspaces.mdx
@@ -20,8 +20,8 @@ There are four main roles in a workspace:
 
 - **Owner**: The workspace owner has access to all CI projects and Release Management apps and have full control over them.
 - **Manager**: The user can access and modify workspace settings such as connected service accounts, can manage members but can't access billing details and can't delete the workspace. Workspace Managers can create new Bitrise <GlossTerm baseform="project">projects</GlossTerm>. Within projects they have created, they can create CI configurations and/or Release Management connected apps. They cannot access or modify CI configurations or connected apps in Bitrise projects that they haven’t been given direct access to via user or group access settings.
-- **Contributor**: The user can't access workspace settings and can't add new members or manage existing members. They don't have access to any projects or Release Management apps by default and they can't add new projects or Release Management apps.
-- **Viewer**: The user can't add CI projects or Release Management apps to the workspace.
+- **Contributor**: The user can't access workspace settings and can't add new members or manage existing members. They don't have access to any projects or Release Management apps by default, but they can add new projects and Release Management apps.
+- **Viewer**: The user can't add new projects or Release Management apps to the workspace.
 
 These roles mainly determine the user's permissions within the workspace. However, in the case of the workspace owners and the workspace managers, they provide additional permissions on the project level, as described above. But project access is mostly determined by project-level roles.
 

--- a/docs/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/roles-and-permissions-in-workspaces.mdx
+++ b/docs/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/roles-and-permissions-in-workspaces.mdx
@@ -20,7 +20,7 @@ There are four main roles in a workspace:
 
 - **Owner**: The workspace owner has access to all CI projects and Release Management apps and have full control over them.
 - **Manager**: The user can access and modify workspace settings such as connected service accounts, can manage members but can't access billing details and can't delete the workspace. Workspace Managers can create new Bitrise <GlossTerm baseform="project">projects</GlossTerm>. Within projects they have created, they can create CI configurations and/or Release Management connected apps. They cannot access or modify CI configurations or connected apps in Bitrise projects that they haven’t been given direct access to via user or group access settings.
-- **Contributor**: The user can't access workspace settings and can't add new members or manage existing members. They don't have access to any projects or Release Management apps by default, but they can add new projects and Release Management apps.
+- **Contributor**: The user can't access workspace settings and can't add new members or manage existing members. 
 - **Viewer**: The user can't add new projects or Release Management apps to the workspace.
 
 These roles mainly determine the user's permissions within the workspace. However, in the case of the workspace owners and the workspace managers, they provide additional permissions on the project level, as described above. But project access is mostly determined by project-level roles.


### PR DESCRIPTION
Adds a new section to the Configuring SCIM page documenting how IdPs can assign workspace roles (Viewer, Contributor, Manager) using the SCIM `roles` attribute.

Covers the supported payload formats (POST/PUT and both PATCH variants) and the available role values.

[ER-2785](https://bitrise.atlassian.net/browse/ER-2785)

[ER-2785]: https://bitrise.atlassian.net/browse/ER-2785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ