### PR TITLE
Add Onboarding for Agents page

### DIFF
--- a/docs/bitrise-platform/ai/onboarding-for-agents.mdx
+++ b/docs/bitrise-platform/ai/onboarding-for-agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Onboarding for Agents"
+title: "Onboarding for agents"
 description: "Create your Bitrise account and connect to the platform straight from an AI agent through the Bitrise MCP server, with no website sign-up and no browser detour."
 sidebar_position: 5
 slug: /bitrise-platform/ai/onboarding-for-agents
@@ -20,17 +20,17 @@ You want to use Bitrise for CI/CD, app distribution, or getting a local build on
 
 If you'd rather not use an agent, you can also [sign up for Bitrise](/en/bitrise-platform/getting-started/signing-up-for-bitrise) in the browser.
 
-## Before you start
+## Creating an account through the MCP
+
+The flow has five steps: get an MCP-capable client, connect the server, register your email, verify the code, then re-authenticate with the token you receive. You supply the email and the verification code, and your agent does the rest.
+
+### Step 1: Get an AI client that supports MCP
 
 You need an AI client that supports MCP and an email address to register. Each step below gives the configuration for the most common clients: Claude Code, Cursor, VS Code, and Claude Desktop. Bitrise MCP also supports [Windsurf](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-windsurf), the [Google Gemini CLI](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-gemini-cli), [AWS Kiro](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-kiro), and [other Copilot IDEs](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-other-copilot-ides). See each install guide for client-specific details.
 
-## Creating an account through the MCP
+### Step 2: Connect the MCP server
 
-The flow has four steps: connect the server, register your email, verify the code, then re-authenticate with the token you receive. You supply the email and the verification code, and your agent does the rest.
-
-### Step 1: Connect the MCP server
-
-Point your client at the remote server with no token, since the account-creation tools (`register` and `verify_registration`) don't need one. After editing the config, reconnect the client so the change takes effect (see [Reconnecting the MCP client](#reconnecting-the-mcp-client)). For the full setup, follow the install guide linked in each tab.
+Point your client at the remote server with no token — the account-creation tools (`register` and `verify_registration`) don't need one. After editing the config, reconnect the client so the change takes effect (see [Reconnecting the MCP client](#reconnecting-the-mcp-client)). For the full setup, follow the install guide linked in each tab.
 
 <Tabs>
 <TabItem value="claude-code" label="Claude Code" default>
@@ -73,21 +73,21 @@ Full setup: [Claude Applications](/en/bitrise-platform/ai/bitrise-mcp/installing
 
 :::note[Expect two reconnects]
 
-You reconnect the client twice: once now while unauthenticated, and once again in Step 4 after you have the token.
+You reconnect the client twice: once now while unauthenticated, and once again in Step 5 after you have the token.
 
 :::
 
-### Step 2: Register your email
+### Step 3: Register your email
 
 Give your agent the email address to register. It calls `register`, and Bitrise emails you a one-time verification code (OTP) and returns a `pending_signup_id`. The code lives only in your inbox, so your agent can't guess it.
 
-### Step 3: Verify the code
+### Step 4: Verify the code
 
 Read the code back to your agent. It calls `verify_registration` with the `pending_signup_id` and your code. On success, Bitrise returns an `api_token` (a personal access token) and a `workspace_slug`: a <GlossTerm baseform="workspace">Workspace</GlossTerm> is created for you automatically. To see how Workspaces organize your apps and team, read the [Workspaces overview](/en/bitrise-platform/workspaces/workspaces-overview).
 
-### Step 4: Authenticate the connection
+### Step 5: Authenticate the connection
 
-Your agent adds the token to the entry from Step 1 and reconnects (the second reconnect), then confirms the connection with the `me` or `list_workspaces` tools.
+Your agent adds the token to the entry from Step 2 and reconnects (the second reconnect), then confirms the connection with the `me` or `list_workspaces` tools.
 
 <Tabs>
 <TabItem value="claude-code" label="Claude Code" default>
@@ -128,7 +128,7 @@ The token from `verify_registration` is valid for 24 hours, which is enough to f
 
 ## Reconnecting the MCP client
 
-Editing the config in Step 1 and Step 4 takes effect only after the client reloads the Bitrise MCP server. How you do that depends on the client:
+Editing the config in Step 2 and Step 5 takes effect only after the client reloads the Bitrise MCP server. How you do that depends on the client:
 
 - **Claude Code (CLI):** Run `/mcp` to view and reconnect the server, or quit and relaunch `claude`.
 - **VS Code (GitHub Copilot):** Open the Command Palette (`Cmd/Ctrl+Shift+P`), run **MCP: List Servers**, select **bitrise**, and choose **Restart**, or run **Developer: Reload Window**.

--- a/docs/bitrise-platform/ai/onboarding-for-agents.mdx
+++ b/docs/bitrise-platform/ai/onboarding-for-agents.mdx
@@ -1,0 +1,164 @@
+---
+title: "Onboarding for Agents"
+description: "Create your Bitrise account and connect to the platform straight from an AI agent through the Bitrise MCP server, with no website sign-up and no browser detour."
+sidebar_position: 5
+slug: /bitrise-platform/ai/onboarding-for-agents
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GlossTerm from '@site/src/components/GlossTerm';
+
+Bitrise is mobile-focused CI/CD and app distribution for iOS and Android, including Flutter and React Native. If you work through an AI agent such as Claude Code, Cursor, or VS Code with GitHub Copilot, it can create your Bitrise account and authenticate you to the platform without leaving the chat, using the [Bitrise MCP server](/en/bitrise-platform/ai/bitrise-mcp). You hand it an email address, read back a one-time code, and you're connected.
+
+## When to use this
+
+You want to use Bitrise for CI/CD, app distribution, or getting a local build onto devices, and one of the following is true:
+
+- You don't have a Bitrise account yet, so your agent creates one in the session.
+- You already have an account, so your agent only authenticates the MCP connection through OAuth or a [personal access token](/en/bitrise-platform/accounts/personal-access-tokens).
+
+If you'd rather not use an agent, you can also [sign up for Bitrise](/en/bitrise-platform/getting-started/signing-up-for-bitrise) in the browser.
+
+## Before you start
+
+You need an AI client that supports MCP and an email address to register. Each step below gives the configuration for the most common clients: Claude Code, Cursor, VS Code, and Claude Desktop. Bitrise MCP also supports [Windsurf](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-windsurf), the [Google Gemini CLI](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-gemini-cli), [AWS Kiro](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-kiro), and [other Copilot IDEs](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-other-copilot-ides). See each install guide for client-specific details.
+
+## Creating an account through the MCP
+
+The flow has four steps: connect the server, register your email, verify the code, then re-authenticate with the token you receive. You supply the email and the verification code, and your agent does the rest.
+
+### Step 1: Connect the MCP server
+
+Point your client at the remote server with no token, since the account-creation tools (`register` and `verify_registration`) don't need one. After editing the config, reconnect the client so the change takes effect (see [Reconnecting the MCP client](#reconnecting-the-mcp-client)). For the full setup, follow the install guide linked in each tab.
+
+<Tabs>
+<TabItem value="claude-code" label="Claude Code" default>
+
+```bash
+claude mcp add --transport http bitrise https://mcp.bitrise.io
+```
+
+Full setup: [Claude Applications](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-claude).
+
+</TabItem>
+<TabItem value="cursor" label="Cursor">
+
+```json
+{ "mcpServers": { "bitrise": { "url": "https://mcp.bitrise.io" } } }
+```
+
+Full setup: [Cursor](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-cursor).
+
+</TabItem>
+<TabItem value="vs-code" label="VS Code">
+
+```json
+{ "servers": { "bitrise": { "type": "http", "url": "https://mcp.bitrise.io" } } }
+```
+
+Full setup: [VS Code](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-vscode).
+
+</TabItem>
+<TabItem value="claude-desktop" label="Claude Desktop">
+
+```json
+{ "mcpServers": { "bitrise": { "command": "npx", "args": ["mcp-remote", "https://mcp.bitrise.io"] } } }
+```
+
+Full setup: [Claude Applications](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server/install-claude).
+
+</TabItem>
+</Tabs>
+
+:::note[Expect two reconnects]
+
+You reconnect the client twice: once now while unauthenticated, and once again in Step 4 after you have the token.
+
+:::
+
+### Step 2: Register your email
+
+Give your agent the email address to register. It calls `register`, and Bitrise emails you a one-time verification code (OTP) and returns a `pending_signup_id`. The code lives only in your inbox, so your agent can't guess it.
+
+### Step 3: Verify the code
+
+Read the code back to your agent. It calls `verify_registration` with the `pending_signup_id` and your code. On success, Bitrise returns an `api_token` (a personal access token) and a `workspace_slug`: a <GlossTerm baseform="workspace">Workspace</GlossTerm> is created for you automatically. To see how Workspaces organize your apps and team, read the [Workspaces overview](/en/bitrise-platform/workspaces/workspaces-overview).
+
+### Step 4: Authenticate the connection
+
+Your agent adds the token to the entry from Step 1 and reconnects (the second reconnect), then confirms the connection with the `me` or `list_workspaces` tools.
+
+<Tabs>
+<TabItem value="claude-code" label="Claude Code" default>
+
+```bash
+claude mcp remove bitrise && claude mcp add --transport http bitrise https://mcp.bitrise.io -H "Authorization: Bearer <api_token>"
+```
+
+</TabItem>
+<TabItem value="cursor" label="Cursor">
+
+```json
+{ "mcpServers": { "bitrise": { "url": "https://mcp.bitrise.io", "headers": { "Authorization": "Bearer <api_token>" } } } }
+```
+
+</TabItem>
+<TabItem value="vs-code" label="VS Code">
+
+```json
+{ "servers": { "bitrise": { "type": "http", "url": "https://mcp.bitrise.io", "headers": { "Authorization": "Bearer <api_token>" } } } }
+```
+
+</TabItem>
+<TabItem value="claude-desktop" label="Claude Desktop">
+
+```json
+{ "mcpServers": { "bitrise": { "command": "npx", "args": ["mcp-remote", "https://mcp.bitrise.io", "--header", "Authorization: Bearer <api_token>"] } } }
+```
+
+</TabItem>
+</Tabs>
+
+:::note[Token lifetime]
+
+The token from `verify_registration` is valid for 24 hours, which is enough to finish onboarding. For long-term use, create a durable [personal access token](/en/bitrise-platform/accounts/personal-access-tokens) at [Account settings → Security](https://app.bitrise.io/me/account/security) and swap it into the same `Authorization` header.
+
+:::
+
+## Reconnecting the MCP client
+
+Editing the config in Step 1 and Step 4 takes effect only after the client reloads the Bitrise MCP server. How you do that depends on the client:
+
+- **Claude Code (CLI):** Run `/mcp` to view and reconnect the server, or quit and relaunch `claude`.
+- **VS Code (GitHub Copilot):** Open the Command Palette (`Cmd/Ctrl+Shift+P`), run **MCP: List Servers**, select **bitrise**, and choose **Restart**, or run **Developer: Reload Window**.
+- **Cursor:** Open **Settings → MCP (Tools)** and toggle the **bitrise** server off and on, or click its refresh icon. Restarting Cursor also works.
+- **Claude Desktop:** Quit the app fully (`Cmd+Q` on macOS, or quit from the system tray on Windows) and reopen it. Closing the window alone doesn't reload it.
+- **Other clients (Windsurf, Gemini CLI, AWS Kiro):** Restart the client, or its MCP connection if it exposes one.
+
+## If something goes wrong
+
+- **The email is already registered:** You already have a Bitrise account, so don't retry registration. Authenticate the existing account with OAuth or a [personal access token](/en/bitrise-platform/accounts/personal-access-tokens), then continue with [After your account is created](#after-your-account-is-created).
+- **The code is rejected as invalid:** It was mistyped or wrong. Re-check the email and try again with the **same** `pending_signup_id`.
+- **The code expired or you hit too many attempts:** The pending signup is no longer usable. Register again to send a fresh code, then verify with the **new** `pending_signup_id`.
+
+## After your account is created
+
+The same MCP connection now drives the rest of Bitrise: [creating apps and connecting repositories](/en/bitrise-ci/getting-started/adding-a-new-project), [configuring `bitrise.yml`](/en/bitrise-ci/configure-builds/configuration-yaml/configuration-yaml-overview), triggering builds, reading logs, and managing artifacts and distribution. You can also limit which tool groups the server exposes, as described in [Tools](/en/bitrise-platform/ai/bitrise-mcp/tools).
+
+For conventions and a guided walkthrough of connecting your repository and running your first build, install the Bitrise agent skill:
+
+```bash
+npx skills add bitrise-io/agent-skills
+```
+
+This installs the `using-bitrise-ci` skill, which loads automatically on Bitrise CI topics. Invoke it explicitly with `/using-bitrise-ci`, or add `--global` to install it across all your projects.
+
+New to Bitrise? Start with [Getting started](/en/bitrise-ci/getting-started/getting-started) and the [key Bitrise concepts](/en/bitrise-ci/getting-started/key-bitrise-concepts). To see what else Bitrise can do with AI, see [AI features on Bitrise](/en/bitrise-platform/ai/ai-features-on-bitrise).
+
+## Related links
+
+- [Bitrise MCP](/en/bitrise-platform/ai/bitrise-mcp): what the MCP server is and how to authenticate.
+- [Tools](/en/bitrise-platform/ai/bitrise-mcp/tools): enable or disable specific tool groups.
+- [Bitrise MCP repository](https://github.com/bitrise-io/bitrise-mcp): source, install guides, and the tool reference.
+- [Bitrise agent skills](https://github.com/bitrise-io/agent-skills): the `using-bitrise-ci` knowledge skill.


### PR DESCRIPTION
## What

Adds a user-facing documentation page, **Onboarding for Agents**, under the AI section (`docs/bitrise-platform/ai/onboarding-for-agents.mdx`, `sidebar_position: 5`, right after Bitrise MCP).

The content is derived from the existing `static/onboarding-for-agents.md` runbook, rewritten into a navigable docs page in Bitrise docs voice (sentence-case headings, present tense, active voice).

## Structure

Intro → *When to use this* → *Before you start* → *Creating an account through the MCP* (Steps 1–4) → *Reconnecting the MCP client* → *If something goes wrong* → *After your account is created* → *Related links*.

- Per-client config (Claude Code, Cursor, VS Code, Claude Desktop) is presented with `<Tabs>` in Steps 1 and 4.
- Each client's full install guide is linked inside its config tab; the four less-common clients (Windsurf, Gemini CLI, AWS Kiro, Copilot IDEs) are linked in *Before you start*, so all 8 install guides are reachable.
- Related docs are woven into the prose throughout: Workspaces overview, personal access tokens, adding a project, `bitrise.yml` configuration, Tools, getting started, key concepts, AI features, and signing up.
- `note` admonitions for the two-reconnects and 24-hour-token callouts; `<GlossTerm>` on the first mention of Workspace.
- No em/en dashes, per house style.

## Verification

- `npm run build` passes (exit 0); the MDX compiles.
- All 17 internal links checked against real page `slug:` declarations.
- Renders correctly in the local dev server with no console errors or broken-link warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)