### PR TITLE
Add changelog feature to Bitrise Docs

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -51,7 +51,14 @@ Generate a changelog entry from the current branch's changes, commit it, then cr
    - **Linking**: if the changes are concentrated in one page, end the summary with a link to that page using its `slug` (e.g. `See [Running Xcode tests](/en/bitrise-ci/testing/running-xcode-tests).`). If changes span multiple pages, include a link to the most relevant one at your discretion — or omit if no single page stands out.
    - One entry per PR even if multiple files changed.
 
-4. **Write and commit** once approved. Prepend the entry after the `<!-- changelog-entries -->` marker in `src/partials/changelog-content.mdx`, then commit:
+4. **Write and commit** once approved. Prepend the entry after the `<!-- changelog-entries -->` marker in `src/partials/changelog-content.mdx` using this format:
+   ```
+   ## <time dateTime="YYYY-MM-DD">YYYY-MM-DD</time> — Title {#YYYY-MM-DD-slug-of-title}
+
+   Summary paragraph.
+
+   ```
+   The `{#anchor}` ID uses the same slug formula as the feed plugin: lowercase the title, replace every run of non-alphanumeric characters with a single hyphen, strip leading/trailing hyphens, then prepend the date: `YYYY-MM-DD-slug`. Then commit:
    ```
    git add src/partials/changelog-content.mdx
    git commit -m "Update changelog"
@@ -107,11 +114,12 @@ Generate entries for all merged PRs not yet covered by the changelog.
 
 4. **Prepend new entries** immediately after `<!-- changelog-entries -->`, newest first. Format:
    ```
-   ## YYYY-MM-DD — Title
+   ## <time dateTime="YYYY-MM-DD">YYYY-MM-DD</time> — Title {#YYYY-MM-DD-slug-of-title}
 
    Summary paragraph.
 
    ```
+   The `{#anchor}` ID must use the same slug formula as the feed plugin: lowercase the title, replace every run of non-alphanumeric characters with a single hyphen, strip leading/trailing hyphens, then prepend the date with a single hyphen: `YYYY-MM-DD-slug`.
 
 5. **Report** how many entries were added and list any skipped PRs with reasons.
 

--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -1,0 +1,120 @@
+# Update changelog
+
+Update `src/partials/changelog-content.mdx` with changelog entries for doc changes not yet covered.
+
+The changelog is a shared partial imported by every hub's `changelog.mdx`. Only update the partial — the hub pages update automatically.
+
+## Choosing the right mode
+
+Run in **current-branch mode** when:
+- The user is about to create a PR, or asks to create a PR
+- The user says "generate a changelog entry for this branch / these changes"
+- There are local commits on the current branch not yet on `main`
+
+Run in **retroactive mode** when:
+- The user says "update the changelog" or "catch up the changelog"
+- The current branch has no relevant doc changes
+- You need to cover PRs that were merged without a changelog entry
+
+---
+
+## Current-branch mode
+
+Generate a changelog entry from the current branch's changes, commit it, then create a PR.
+
+### Steps
+
+1. **Find doc changes on this branch.**
+   ```
+   git diff main...HEAD --name-only
+   ```
+   Filter to files under `docs/` ending in `.md` or `.mdx`. If there are none, skip to step 4 (no entry needed).
+
+2. **Decide whether to write an entry.** Read the diff:
+   ```
+   git diff main...HEAD -- 'docs/**/*.md' 'docs/**/*.mdx'
+   ```
+   Truncate to ~6 000 characters if needed. **Skip changelog generation** if all changes are:
+   - Changes only to `src/partials/changelog-content.mdx` or `docs/changelogs/` (changelog infrastructure)
+   - Formatting or cleanup (syntax highlighting, whitespace, list numbering)
+   - Broken link or image path corrections
+   - Navigation or sidebar changes
+   - Glossary tooltips or internal cross-references
+   - Corrections with no new information
+   - File moves or renames with identical content
+
+   If in doubt, skip.
+
+3. **Draft the changelog entry** and show it in chat for review. Wait for approval or edits before writing anything to disk.
+   - **Title**: 5–8 words from the reader's perspective.
+   - **Summary**: 1–2 sentences. Write from the reader's perspective ("You can now…", "The X guide now covers…"), not the author's ("We added…"). Use today's date.
+   - **Linking**: if the changes are concentrated in one page, end the summary with a link to that page using its `slug` (e.g. `See [Running Xcode tests](/en/bitrise-ci/testing/running-xcode-tests).`). If changes span multiple pages, include a link to the most relevant one at your discretion — or omit if no single page stands out.
+   - One entry per PR even if multiple files changed.
+
+4. **Write and commit** once approved. Prepend the entry after the `<!-- changelog-entries -->` marker in `src/partials/changelog-content.mdx`, then commit:
+   ```
+   git add src/partials/changelog-content.mdx
+   git commit -m "Update changelog"
+   ```
+
+5. **Create the PR.** Show a draft title and body in chat and wait for approval before running `gh pr create`. Base branch is `main` unless the user says otherwise.
+
+---
+
+## Retroactive mode
+
+Generate entries for all merged PRs not yet covered by the changelog.
+
+### Steps
+
+1. **Find the cutoff date.** Read `src/partials/changelog-content.mdx` and extract the date from the first line matching `## YYYY-MM-DD`. That date is the cutoff; generate entries for PRs merged *after* it. If the changelog has no entries, use `2026-06-03` (the Docusaurus migration date).
+
+2. **Find uncovered PRs.**
+   ```
+   gh pr list --state merged --limit 100 --json number,title,mergedAt,files
+   ```
+   Filter to PRs where:
+   - `mergedAt` is strictly after the cutoff date
+   - at least one file path starts with `docs/` and ends with `.md` or `.mdx`
+
+   Sort ascending by `mergedAt` (oldest first — you'll prepend in reverse so newest ends up on top).
+
+3. **For each uncovered PR**, ascending order:
+   a. Fetch the diff:
+      ```
+      gh pr diff <number>
+      ```
+      Extract only hunks for `.md`/`.mdx` files under `docs/`. Truncate to ~6 000 characters if needed.
+
+   b. Read title and body:
+      ```
+      gh pr view <number> --json title,body
+      ```
+
+   c. **Skip the PR entirely** if all changes are:
+      - Changes only to `src/partials/changelog-content.mdx` or `docs/changelogs/` (changelog infrastructure)
+      - Formatting or cleanup
+      - Broken link or image path corrections
+      - Navigation or sidebar changes
+      - Glossary tooltips or internal cross-references
+      - Corrections with no new information
+      - File moves or renames with identical content
+
+   d. If keeping, write:
+      - **Title**: 5–8 words from the reader's perspective.
+      - **Summary**: 1–2 sentences. Reader's perspective, not the author's.
+      - **Linking**: if the changes are concentrated in one page, end the summary with a link to that page using its `slug`. If changes span multiple pages, link to the most relevant one at your discretion — or omit if no single page stands out.
+
+4. **Prepend new entries** immediately after `<!-- changelog-entries -->`, newest first. Format:
+   ```
+   ## YYYY-MM-DD — Title
+
+   Summary paragraph.
+
+   ```
+
+5. **Report** how many entries were added and list any skipped PRs with reasons.
+
+### Notes
+- If there are no uncovered PRs, say so and make no changes.
+- Do not commit or push — leave that to the user.

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,10 +2,10 @@
   "version": "0.0.1",
   "configurations": [
     {
-      "name": "docusaurus",
+      "name": "Docusaurus",
       "runtimeExecutable": "npm",
-      "runtimeArgs": ["start"],
-      "port": 3000,
+      "runtimeArgs": ["start", "--", "--port", "3001"],
+      "port": 3001,
       "env": {
         "GEN_SEARCH_WIDGET_ID": "3ad20ce4-5537-48df-a876-ac370c5be471"
       }

--- a/docs/changelogs/bitrise-build-cache.mdx
+++ b/docs/changelogs/bitrise-build-cache.mdx
@@ -1,0 +1,13 @@
+---
+title: "Changelog"
+description: "A record of documentation updates on the Bitrise docs site."
+slug: /bitrise-build-cache/changelog
+sidebar_position: 999
+displayed_sidebar: buildCacheSidebar
+---
+
+import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
+
+This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
+
+<Partial_ChangelogContent />

--- a/docs/changelogs/bitrise-build-cache.mdx
+++ b/docs/changelogs/bitrise-build-cache.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Changelog"
+title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /bitrise-build-cache/changelog
 sidebar_position: 999

--- a/docs/changelogs/bitrise-build-hub.mdx
+++ b/docs/changelogs/bitrise-build-hub.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Changelog"
+title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /bitrise-build-hub/changelog
 sidebar_position: 999

--- a/docs/changelogs/bitrise-build-hub.mdx
+++ b/docs/changelogs/bitrise-build-hub.mdx
@@ -1,0 +1,13 @@
+---
+title: "Changelog"
+description: "A record of documentation updates on the Bitrise docs site."
+slug: /bitrise-build-hub/changelog
+sidebar_position: 999
+displayed_sidebar: buildHubSidebar
+---
+
+import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
+
+This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
+
+<Partial_ChangelogContent />

--- a/docs/changelogs/bitrise-ci.mdx
+++ b/docs/changelogs/bitrise-ci.mdx
@@ -1,0 +1,13 @@
+---
+title: "Changelog"
+description: "A record of documentation updates on the Bitrise docs site."
+slug: /bitrise-ci/changelog
+sidebar_position: 999
+displayed_sidebar: ciSidebar
+---
+
+import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
+
+This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
+
+<Partial_ChangelogContent />

--- a/docs/changelogs/bitrise-ci.mdx
+++ b/docs/changelogs/bitrise-ci.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Changelog"
+title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /bitrise-ci/changelog
 sidebar_position: 999

--- a/docs/changelogs/bitrise-platform.mdx
+++ b/docs/changelogs/bitrise-platform.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Changelog"
+title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /bitrise-platform/changelog
 sidebar_position: 999

--- a/docs/changelogs/bitrise-platform.mdx
+++ b/docs/changelogs/bitrise-platform.mdx
@@ -1,0 +1,13 @@
+---
+title: "Changelog"
+description: "A record of documentation updates on the Bitrise docs site."
+slug: /bitrise-platform/changelog
+sidebar_position: 999
+displayed_sidebar: platformSidebar
+---
+
+import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
+
+This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
+
+<Partial_ChangelogContent />

--- a/docs/changelogs/insights.mdx
+++ b/docs/changelogs/insights.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Changelog"
+title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /insights/changelog
 sidebar_position: 999

--- a/docs/changelogs/insights.mdx
+++ b/docs/changelogs/insights.mdx
@@ -1,0 +1,13 @@
+---
+title: "Changelog"
+description: "A record of documentation updates on the Bitrise docs site."
+slug: /insights/changelog
+sidebar_position: 999
+displayed_sidebar: insightsSidebar
+---
+
+import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
+
+This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
+
+<Partial_ChangelogContent />

--- a/docs/changelogs/release-management.mdx
+++ b/docs/changelogs/release-management.mdx
@@ -1,0 +1,13 @@
+---
+title: "Changelog"
+description: "A record of documentation updates on the Bitrise docs site."
+slug: /release-management/changelog
+sidebar_position: 999
+displayed_sidebar: releaseManagementSidebar
+---
+
+import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
+
+This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
+
+<Partial_ChangelogContent />

--- a/docs/changelogs/release-management.mdx
+++ b/docs/changelogs/release-management.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Changelog"
+title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /release-management/changelog
 sidebar_position: 999

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,6 +3,7 @@ import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import changelogFeedPlugin from './src/plugins/changelog-feed';
 
 // Build-time expansion for list-context partial references.
 //
@@ -255,6 +256,7 @@ const config: Config = {
   },
 
   plugins: [
+    changelogFeedPlugin,
     function webpackFallbacks() {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const webpack = require('webpack');

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -225,6 +225,54 @@
   display: none;
 }
 
+
+/* Bottom sidebar links (Changelog, Integration Steps, Workflow Recipes) */
+.sidebar-bottom-links {
+  border-top: 1px solid var(--pal-neutral-90);
+  padding: 12px 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-bottom-link {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  color: var(--pal-purple-10);
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  padding: 8px 20px 8px 24px;
+  transition: background 0.15s;
+}
+
+.sidebar-bottom-link--active,
+.sidebar-bottom-link--active:hover {
+  background: var(--pal-purple-95);
+  border-right: 2px solid var(--pal-purple-50);
+  font-weight: 600;
+  color: var(--pal-purple-10);
+}
+
+.sidebar-bottom-link:hover {
+  color: var(--pal-purple-10);
+  background: var(--pal-neutral-95);
+  text-decoration: none;
+}
+
+.sidebar-bottom-link svg {
+  flex-shrink: 0;
+  color: #6B6279;
+}
+
+.sidebar-bottom-link-arrow {
+  margin-left: auto;
+}
+
+.sidebar-bottom-link > svg:first-child {
+  margin-right: 8px;
+}
+
 /* Sidebar icons */
 .theme-doc-sidebar-item-category-level-1 svg,
 .theme-doc-sidebar-item-link-level-1 svg {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -635,6 +635,39 @@ article:has([data-product-overview]) > .markdown {
   }
 }
 
+/* ---- Changelog subscribe button ---- */
+
+.changelog-subscribe-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid var(--pal-neutral-80);
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--pal-purple-10);
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.changelog-subscribe-btn svg {
+  display: block;
+  flex-shrink: 0;
+}
+
+.changelog-subscribe-btn p {
+  margin: 0;
+}
+
+.changelog-subscribe-btn:hover {
+  background: var(--pal-neutral-95);
+  border-color: var(--pal-neutral-60);
+  color: var(--pal-purple-10);
+  text-decoration: none;
+}
+
 /* ---- Swagger UI ---- */
 
 /* Version badges ("0.1", "OAS 2.0"): the <pre class="version"> has a near-white

--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -14,6 +14,15 @@
   inside the correct month's H2 section.
 -->
 
+<head>
+  <link rel="alternate" type="application/rss+xml" title="Bitrise Docs changelog" href="https://docs.bitrise.io/changelog.xml" />
+</head>
+
+<a href="https://docs.bitrise.io/changelog.xml" className="changelog-subscribe-btn" target="_blank" rel="noopener noreferrer">
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19.01 7.38 20 6.18 20 4.98 20 4 19.01 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/></svg>
+  Subscribe to RSS
+</a>
+
 <!-- changelog-entries -->
 
 ## <time dateTime="2026-06-15">2026-06-15</time> — Bitrise MCP: new registration tools and API group

--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -1,3 +1,19 @@
+<!--
+  CHANGELOG STRUCTURE PLAN
+
+  Current year entries live in this file, grouped by month:
+  - ## YYYY Month           → H2, appears in the ToC (toc_max_heading_level: 2 is set on all changelog pages)
+  - ### YYYY-MM-DD — Title  → H3, does NOT appear in the ToC
+
+  When a new year begins:
+  - Archive the previous year's entries to a separate file (e.g. src/partials/changelog-2026.mdx)
+  - Create matching hub pages under docs/changelogs/ for that year
+  - Add a button pointing to the archived year
+
+  New entries are prepended by the /update-changelog skill after the changelog-entries marker,
+  inside the correct month's H2 section.
+-->
+
 <!-- changelog-entries -->
 
 ## 2026-06-15 — Bitrise MCP: new registration tools and API group

--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -16,30 +16,30 @@
 
 <!-- changelog-entries -->
 
-## 2026-06-15 — Bitrise MCP: new registration tools and API group
+## <time dateTime="2026-06-15">2026-06-15</time> — Bitrise MCP: new registration tools and API group
 
 The Bitrise MCP server now includes a `registration` API group with two unauthenticated tools — `register` and `verify_registration` — that let an AI agent onboard a brand-new Bitrise user without a token. The agent sends a one-time password to the user's email via `register`, then calls `verify_registration` with the OTP to receive a personal access token. These tools are most useful with the remote (HTTP) MCP server. See [Bitrise MCP tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for the full reference.
 
-## 2026-06-15 — Bitrise MCP: install guides added for six tools
+## <time dateTime="2026-06-15">2026-06-15</time> — Bitrise MCP: install guides added for six tools
 
 Step-by-step install guides for the Bitrise MCP server are now available for VS Code, Cursor, Claude, Windsurf, Kiro, Gemini CLI, and other Copilot-compatible IDEs. Each guide covers how to configure the MCP server and authenticate with your Bitrise token. See [Installing the Bitrise MCP server](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server) to get started.
 
-## 2026-06-11 — Workflow Editor can now push bitrise.yml directly to the repository
+## <time dateTime="2026-06-11">2026-06-11</time> — Workflow Editor can now push bitrise.yml directly to the repository
 
 The Workflow Editor now supports pushing changes to a repository-stored `bitrise.yml` directly from the editor — either to the current branch or a new branch — without manually copying and committing. See [Managing a project's configuration YAML file](/en/bitrise-ci/configure-builds/configuration-yaml/managing-a-project-s-configuration-yaml-file) for the updated flow.
 
-## 2026-06-10 — Build Hub: Gradle dependency mirroring explained
+## <time dateTime="2026-06-10">2026-06-10</time> — Build Hub: Gradle dependency mirroring explained
 
 The Build Hub documentation now includes an explanation of how Gradle dependency mirroring works, giving you a clearer picture of caching behaviour for Gradle projects running on Build Hub.
 
-## 2026-06-09 — Configuration YAML docs updated for YAML/Visual mode switcher
+## <time dateTime="2026-06-09">2026-06-09</time> — Configuration YAML docs updated for YAML/Visual mode switcher
 
 References throughout the docs have been updated to reflect the new toggle between YAML and Visual editing modes in the Workflow Editor. Where instructions previously referred to the left navigation menu, they now point to the **YAML** toggle at the top of the editor.
 
-## 2026-06-08 — New guide: Maven Central repository manager
+## <time dateTime="2026-06-08">2026-06-08</time> — New guide: Maven Central repository manager
 
 A new guide covering the Maven Central repository manager is now available under [Build Cache getting started](/en/bitrise-build-cache/getting-started-with-the-build-cache/maven-central-repository-manager). It explains how Bitrise's proxy cache works for Maven dependencies, covers special cases like dependency verification and custom Docker images, and documents the opt-out process.
 
-## 2026-06-08 — Bitrise MCP server: OAuth is now the primary authentication method
+## <time dateTime="2026-06-08">2026-06-08</time> — Bitrise MCP server: OAuth is now the primary authentication method
 
 The Bitrise MCP server now uses OAuth as the primary authentication method. See [Bitrise MCP](/en/bitrise-platform/ai/bitrise-mcp) for the updated setup steps.

--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -1,54 +1,40 @@
-<!--
-  CHANGELOG STRUCTURE PLAN
-
-  Current year entries live in this file, grouped by month:
-  - ## YYYY Month           → H2, appears in the ToC (toc_max_heading_level: 2 is set on all changelog pages)
-  - ### YYYY-MM-DD — Title  → H3, does NOT appear in the ToC
-
-  When a new year begins:
-  - Archive the previous year's entries to a separate file (e.g. src/partials/changelog-2026.mdx)
-  - Create matching hub pages under docs/changelogs/ for that year
-  - Add a button pointing to the archived year
-
-  New entries are prepended by the /update-changelog skill after the changelog-entries marker,
-  inside the correct month's H2 section.
--->
+<!-- Future structure (monthly grouping): https://github.com/bitrise-io/docs/issues/47 -->
 
 <head>
-  <link rel="alternate" type="application/rss+xml" title="Bitrise Docs changelog" href="https://docs.bitrise.io/changelog.xml" />
+  <link rel="alternate" type="application/rss+xml" title="Bitrise Docs changelog" href="/changelog.xml" />
 </head>
 
-<a href="https://docs.bitrise.io/changelog.xml" className="changelog-subscribe-btn" target="_blank" rel="noopener noreferrer">
+<a href="/changelog.xml" className="changelog-subscribe-btn" target="_blank" rel="noopener noreferrer">
   <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19.01 7.38 20 6.18 20 4.98 20 4 19.01 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/></svg>
   Subscribe to RSS
 </a>
 
 <!-- changelog-entries -->
 
-## <time dateTime="2026-06-15">2026-06-15</time> — Bitrise MCP: new registration tools and API group
+## <time dateTime="2026-06-15">2026-06-15</time> — Bitrise MCP: new registration tools and API group {#2026-06-15-bitrise-mcp-new-registration-tools-and-api-group}
 
 The Bitrise MCP server now includes a `registration` API group with two unauthenticated tools — `register` and `verify_registration` — that let an AI agent onboard a brand-new Bitrise user without a token. The agent sends a one-time password to the user's email via `register`, then calls `verify_registration` with the OTP to receive a personal access token. These tools are most useful with the remote (HTTP) MCP server. See [Bitrise MCP tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for the full reference.
 
-## <time dateTime="2026-06-15">2026-06-15</time> — Bitrise MCP: install guides added for six tools
+## <time dateTime="2026-06-15">2026-06-15</time> — Bitrise MCP: install guides added for six tools {#2026-06-15-bitrise-mcp-install-guides-added-for-six-tools}
 
 Step-by-step install guides for the Bitrise MCP server are now available for VS Code, Cursor, Claude, Windsurf, Kiro, Gemini CLI, and other Copilot-compatible IDEs. Each guide covers how to configure the MCP server and authenticate with your Bitrise token. See [Installing the Bitrise MCP server](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server) to get started.
 
-## <time dateTime="2026-06-11">2026-06-11</time> — Workflow Editor can now push bitrise.yml directly to the repository
+## <time dateTime="2026-06-11">2026-06-11</time> — Workflow Editor can now push bitrise.yml directly to the repository {#2026-06-11-workflow-editor-can-now-push-bitrise-yml-directly-to-the-repository}
 
 The Workflow Editor now supports pushing changes to a repository-stored `bitrise.yml` directly from the editor — either to the current branch or a new branch — without manually copying and committing. See [Managing a project's configuration YAML file](/en/bitrise-ci/configure-builds/configuration-yaml/managing-a-project-s-configuration-yaml-file) for the updated flow.
 
-## <time dateTime="2026-06-10">2026-06-10</time> — Build Hub: Gradle dependency mirroring explained
+## <time dateTime="2026-06-10">2026-06-10</time> — Build Hub: Gradle dependency mirroring explained {#2026-06-10-build-hub-gradle-dependency-mirroring-explained}
 
 The Build Hub documentation now includes an explanation of how Gradle dependency mirroring works, giving you a clearer picture of caching behaviour for Gradle projects running on Build Hub.
 
-## <time dateTime="2026-06-09">2026-06-09</time> — Configuration YAML docs updated for YAML/Visual mode switcher
+## <time dateTime="2026-06-09">2026-06-09</time> — Configuration YAML docs updated for YAML/Visual mode switcher {#2026-06-09-configuration-yaml-docs-updated-for-yaml-visual-mode-switcher}
 
 References throughout the docs have been updated to reflect the new toggle between YAML and Visual editing modes in the Workflow Editor. Where instructions previously referred to the left navigation menu, they now point to the **YAML** toggle at the top of the editor.
 
-## <time dateTime="2026-06-08">2026-06-08</time> — New guide: Maven Central repository manager
+## <time dateTime="2026-06-08">2026-06-08</time> — New guide: Maven Central repository manager {#2026-06-08-new-guide-maven-central-repository-manager}
 
 A new guide covering the Maven Central repository manager is now available under [Build Cache getting started](/en/bitrise-build-cache/getting-started-with-the-build-cache/maven-central-repository-manager). It explains how Bitrise's proxy cache works for Maven dependencies, covers special cases like dependency verification and custom Docker images, and documents the opt-out process.
 
-## <time dateTime="2026-06-08">2026-06-08</time> — Bitrise MCP server: OAuth is now the primary authentication method
+## <time dateTime="2026-06-08">2026-06-08</time> — Bitrise MCP server: OAuth is now the primary authentication method {#2026-06-08-bitrise-mcp-server-oauth-is-now-the-primary-authentication-method}
 
 The Bitrise MCP server now uses OAuth as the primary authentication method. See [Bitrise MCP](/en/bitrise-platform/ai/bitrise-mcp) for the updated setup steps.

--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -1,0 +1,29 @@
+<!-- changelog-entries -->
+
+## 2026-06-15 — Bitrise MCP: new registration tools and API group
+
+The Bitrise MCP server now includes a `registration` API group with two unauthenticated tools — `register` and `verify_registration` — that let an AI agent onboard a brand-new Bitrise user without a token. The agent sends a one-time password to the user's email via `register`, then calls `verify_registration` with the OTP to receive a personal access token. These tools are most useful with the remote (HTTP) MCP server. See [Bitrise MCP tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for the full reference.
+
+## 2026-06-15 — Bitrise MCP: install guides added for six tools
+
+Step-by-step install guides for the Bitrise MCP server are now available for VS Code, Cursor, Claude, Windsurf, Kiro, Gemini CLI, and other Copilot-compatible IDEs. Each guide covers how to configure the MCP server and authenticate with your Bitrise token. See [Installing the Bitrise MCP server](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server) to get started.
+
+## 2026-06-11 — Workflow Editor can now push bitrise.yml directly to the repository
+
+The Workflow Editor now supports pushing changes to a repository-stored `bitrise.yml` directly from the editor — either to the current branch or a new branch — without manually copying and committing. See [Managing a project's configuration YAML file](/en/bitrise-ci/configure-builds/configuration-yaml/managing-a-project-s-configuration-yaml-file) for the updated flow.
+
+## 2026-06-10 — Build Hub: Gradle dependency mirroring explained
+
+The Build Hub documentation now includes an explanation of how Gradle dependency mirroring works, giving you a clearer picture of caching behaviour for Gradle projects running on Build Hub.
+
+## 2026-06-09 — Configuration YAML docs updated for YAML/Visual mode switcher
+
+References throughout the docs have been updated to reflect the new toggle between YAML and Visual editing modes in the Workflow Editor. Where instructions previously referred to the left navigation menu, they now point to the **YAML** toggle at the top of the editor.
+
+## 2026-06-08 — New guide: Maven Central repository manager
+
+A new guide covering the Maven Central repository manager is now available under [Build Cache getting started](/en/bitrise-build-cache/getting-started-with-the-build-cache/maven-central-repository-manager). It explains how Bitrise's proxy cache works for Maven dependencies, covers special cases like dependency verification and custom Docker images, and documents the opt-out process.
+
+## 2026-06-08 — Bitrise MCP server: OAuth is now the primary authentication method
+
+The Bitrise MCP server now uses OAuth as the primary authentication method. See [Bitrise MCP](/en/bitrise-platform/ai/bitrise-mcp) for the updated setup steps.

--- a/src/plugins/changelog-feed.ts
+++ b/src/plugins/changelog-feed.ts
@@ -22,8 +22,9 @@ function parseEntries(): Entry[] {
   const lines = text.split('\n');
   const entries: Entry[] = [];
 
-  // Match H2 headings: ## YYYY-MM-DD — Title
-  const headingRe = /^## (\d{4}-\d{2}-\d{2}) — (.+)$/;
+  // Match H2 headings: ## <time dateTime="YYYY-MM-DD">YYYY-MM-DD</time> — Title
+  // Also matches plain: ## YYYY-MM-DD — Title
+  const headingRe = /^## (?:<time[^>]*>)?(\d{4}-\d{2}-\d{2})(?:<\/time>)? — (.+)$/;
   let current: Entry | null = null;
   const contentLines: string[] = [];
 

--- a/src/plugins/changelog-feed.ts
+++ b/src/plugins/changelog-feed.ts
@@ -1,0 +1,127 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const CHANGELOG_PARTIAL = path.resolve(
+  __dirname,
+  '../../src/partials/changelog-content.mdx',
+);
+
+const SITE_URL = 'https://docs.bitrise.io';
+const FEED_TITLE = 'Bitrise Docs changelog';
+const FEED_DESCRIPTION = 'A record of documentation updates on the Bitrise docs site.';
+const CHANGELOG_PATH = '/en/bitrise-ci/changelog';
+
+interface Entry {
+  date: string;   // ISO 8601, e.g. "2026-06-16"
+  title: string;
+  content: string;
+}
+
+function parseEntries(): Entry[] {
+  const text = fs.readFileSync(CHANGELOG_PARTIAL, 'utf-8');
+  const lines = text.split('\n');
+  const entries: Entry[] = [];
+
+  // Match H2 headings: ## YYYY-MM-DD — Title
+  const headingRe = /^## (\d{4}-\d{2}-\d{2}) — (.+)$/;
+  let current: Entry | null = null;
+  const contentLines: string[] = [];
+
+  for (const line of lines) {
+    const m = line.match(headingRe);
+    if (m) {
+      if (current) {
+        current.content = contentLines.join('\n').trim();
+        entries.push(current);
+      }
+      current = { date: m[1], title: m[2], content: '' };
+      contentLines.length = 0;
+    } else if (current) {
+      contentLines.push(line);
+    }
+  }
+  if (current) {
+    current.content = contentLines.join('\n').trim();
+    entries.push(current);
+  }
+
+  return entries;
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function toSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function buildRss(entries: Entry[]): string {
+  const items = entries
+    .map((e) => {
+      const pubDate = new Date(`${e.date}T00:00:00Z`).toUTCString();
+      const link = `${SITE_URL}${CHANGELOG_PATH}#${e.date}-${toSlug(e.title)}`;
+      return `  <item>
+    <title>${escapeXml(e.title)}</title>
+    <link>${escapeXml(link)}</link>
+    <guid isPermaLink="false">${escapeXml(link)}</guid>
+    <pubDate>${pubDate}</pubDate>
+    <description>${escapeXml(e.content)}</description>
+  </item>`;
+    })
+    .join('\n');
+
+  const lastBuild = entries[0]
+    ? new Date(`${entries[0].date}T00:00:00Z`).toUTCString()
+    : new Date().toUTCString();
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(FEED_TITLE)}</title>
+    <link>${SITE_URL}${CHANGELOG_PATH}</link>
+    <atom:link href="${SITE_URL}/changelog.xml" rel="self" type="application/rss+xml" />
+    <description>${escapeXml(FEED_DESCRIPTION)}</description>
+    <language>en</language>
+    <lastBuildDate>${lastBuild}</lastBuildDate>
+${items}
+  </channel>
+</rss>`;
+}
+
+function buildJson(entries: Entry[]): string {
+  const feed = {
+    version: 'https://jsonfeed.org/version/1.1',
+    title: FEED_TITLE,
+    description: FEED_DESCRIPTION,
+    home_page_url: `${SITE_URL}${CHANGELOG_PATH}`,
+    feed_url: `${SITE_URL}/changelog.json`,
+    items: entries.map((e) => ({
+      id: `${SITE_URL}${CHANGELOG_PATH}#${e.date}-${toSlug(e.title)}`,
+      url: `${SITE_URL}${CHANGELOG_PATH}#${e.date}-${toSlug(e.title)}`,
+      title: e.title,
+      date_published: `${e.date}T00:00:00Z`,
+      content_text: e.content,
+    })),
+  };
+  return JSON.stringify(feed, null, 2);
+}
+
+export default function changelogFeedPlugin() {
+  return {
+    name: 'changelog-feed',
+    async postBuild({ outDir }: { outDir: string }) {
+      const entries = parseEntries();
+      fs.writeFileSync(path.join(outDir, 'changelog.xml'), buildRss(entries), 'utf-8');
+      fs.writeFileSync(path.join(outDir, 'changelog.json'), buildJson(entries), 'utf-8');
+    },
+  };
+}

--- a/src/plugins/changelog-feed.ts
+++ b/src/plugins/changelog-feed.ts
@@ -6,9 +6,11 @@ const CHANGELOG_PARTIAL = path.resolve(
   '../../src/partials/changelog-content.mdx',
 );
 
+// Duplicates url in docusaurus.config.ts — update both if the domain changes.
 const SITE_URL = 'https://docs.bitrise.io';
 const FEED_TITLE = 'Bitrise Docs changelog';
 const FEED_DESCRIPTION = 'A record of documentation updates on the Bitrise docs site.';
+// Pins feed item links to the Bitrise CI hub changelog. Update if the slug changes.
 const CHANGELOG_PATH = '/en/bitrise-ci/changelog';
 
 interface Entry {

--- a/src/theme/DocSidebar/Desktop/index.tsx
+++ b/src/theme/DocSidebar/Desktop/index.tsx
@@ -1,0 +1,105 @@
+/**
+ * Swizzled from @docusaurus/theme-classic DocSidebar/Desktop.
+ * Adds bottom links (Changelog, Integration Steps, Workflow Recipes) as a
+ * sibling of Content so they sit at the foot of the sidebar flex column,
+ * outside the scrollable nav area.
+ */
+
+import React from 'react';
+import clsx from 'clsx';
+import {useThemeConfig} from '@docusaurus/theme-common';
+import Logo from '@theme/Logo';
+import CollapseButton from '@theme/DocSidebar/Desktop/CollapseButton';
+import Content from '@theme/DocSidebar/Desktop/Content';
+import type {Props} from '@theme/DocSidebar/Desktop';
+
+import styles from './styles.module.css';
+
+const IconBook = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path fillRule="evenodd" clipRule="evenodd" d="M2.75 3.5C2.75 2.25736 3.75736 1.25 5 1.25H12.5C12.9142 1.25 13.25 1.58579 13.25 2V13C13.25 13.4142 12.9142 13.75 12.5 13.75H10V12.25H11.75V10.75H5C4.58579 10.75 4.25 11.0858 4.25 11.5C4.25 11.9142 4.58579 12.25 5 12.25V13.75C3.75736 13.75 2.75 12.7426 2.75 11.5V3.5ZM11.75 2.75V9.25H5C4.73702 9.25 4.48458 9.29512 4.25 9.37803V3.5C4.25 3.08579 4.58579 2.75 5 2.75H11.75Z" fill="currentColor"/>
+    <path d="M6 15V12H9L9 15L7.5 14.1L6 15Z" fill="currentColor"/>
+  </svg>
+);
+
+const IconStep = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path fillRule="evenodd" clipRule="evenodd" d="M7.24419 1.4409C7.71124 1.16846 8.28876 1.16846 8.75581 1.4409L13.2558 4.0659C13.7166 4.33472 14 4.82807 14 5.36157V10.6385C14 11.172 13.7166 11.6653 13.2558 11.9341L8.75581 14.5591C8.28876 14.8316 7.71124 14.8316 7.24419 14.5591L2.74419 11.9341C2.28337 11.6653 2 11.172 2 10.6385V5.36157C2 4.82807 2.28337 4.33472 2.74419 4.0659L7.24419 1.4409ZM11.777 4.93982L8 2.73657L4.22301 4.93982L8.00001 7L11.777 4.93982ZM3.5 6.25408L3.5 10.6385L7.25 12.826V8.29954L3.5 6.25408ZM8.75 12.826L12.5 10.6385L12.5 6.25409L8.75 8.29955V12.826Z" fill="currentColor"/>
+  </svg>
+);
+
+const IconWorkflow = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path fillRule="evenodd" clipRule="evenodd" d="M5.5 7C6.61941 7 7.56698 6.26428 7.88555 5.25H11C12.2426 5.25 13.25 6.25736 13.25 7.5C13.25 8.44951 12.6618 9.26165 11.83 9.59197C11.4666 8.66019 10.5604 8 9.5 8C8.38059 8 7.43302 8.73572 7.11445 9.75H5C2.92893 9.75 1.25 11.4289 1.25 13.5V14H2.75V13.5C2.75 12.2574 3.75736 11.25 5 11.25H7.11445C7.43302 12.2643 8.38059 13 9.5 13C10.6607 13 11.6366 12.2091 11.9182 11.1368C13.5454 10.7272 14.75 9.2543 14.75 7.5C14.75 5.42893 13.0711 3.75 11 3.75H7.88555C7.56698 2.73572 6.61941 2 5.5 2C4.38059 2 3.43302 2.73572 3.11445 3.75H1V5.25H3.11445C3.43302 6.26428 4.38059 7 5.5 7ZM5.5 5.5C6.05228 5.5 6.5 5.05228 6.5 4.5C6.5 3.94772 6.05228 3.5 5.5 3.5C4.94772 3.5 4.5 3.94772 4.5 4.5C4.5 5.05228 4.94772 5.5 5.5 5.5ZM10.5 10.5C10.5 11.0523 10.0523 11.5 9.5 11.5C8.94772 11.5 8.5 11.0523 8.5 10.5C8.5 9.94772 8.94772 9.5 9.5 9.5C10.0523 9.5 10.5 9.94772 10.5 10.5Z" fill="currentColor"/>
+  </svg>
+);
+
+const IconArrowNE = () => (
+  <svg className="sidebar-bottom-link-arrow" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <path d="M12.9999 3H5V4.5H10.4394L2.46973 12.4697L3.53039 13.5303L11.4999 5.56078V11H12.9999V3Z" fill="currentColor"/>
+  </svg>
+);
+
+function SidebarBottomLinks({path}: {path: string}) {
+  // path is like /en/bitrise-ci/... — segment[2] is the hub dirName
+  const dirName = path.split('/')[2] ?? '';
+  const isChangelog = path.endsWith('/changelog');
+
+  return (
+    <div className="sidebar-bottom-links">
+      <a
+        href={`/en/${dirName}/changelog`}
+        className={`sidebar-bottom-link${isChangelog ? ' sidebar-bottom-link--active' : ''}`}
+        aria-current={isChangelog ? 'page' : undefined}
+      >
+        <IconBook />
+        Changelog
+      </a>
+      <a
+        href="https://bitrise.io/integrations"
+        className="sidebar-bottom-link"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <IconStep />
+        Bitrise Integration Steps
+        <IconArrowNE />
+      </a>
+      <a
+        href="https://github.com/bitrise-io/workflow-recipes"
+        className="sidebar-bottom-link"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <IconWorkflow />
+        Bitrise Workflow Recipes
+        <IconArrowNE />
+      </a>
+    </div>
+  );
+}
+
+function DocSidebarDesktop({path, sidebar, onCollapse, isHidden}: Props) {
+  const {
+    navbar: {hideOnScroll},
+    docs: {
+      sidebar: {hideable},
+    },
+  } = useThemeConfig();
+
+  return (
+    <div
+      className={clsx(
+        styles.sidebar,
+        hideOnScroll && styles.sidebarWithHideableNavbar,
+        isHidden && styles.sidebarHidden,
+      )}>
+      {hideOnScroll && <Logo tabIndex={-1} className={styles.sidebarLogo} />}
+      <Content path={path} sidebar={sidebar} />
+      <SidebarBottomLinks path={path} />
+      {hideable && <CollapseButton onClick={onCollapse} />}
+    </div>
+  );
+}
+
+export default React.memo(DocSidebarDesktop);

--- a/src/theme/DocSidebar/Desktop/index.tsx
+++ b/src/theme/DocSidebar/Desktop/index.tsx
@@ -53,7 +53,7 @@ function SidebarBottomLinks({path}: {path: string}) {
         aria-current={isChangelog ? 'page' : undefined}
       >
         <IconBook />
-        Changelog
+        Docs changelog
       </a>
       <a
         href="https://bitrise.io/integrations"

--- a/src/theme/DocSidebar/Desktop/styles.module.css
+++ b/src/theme/DocSidebar/Desktop/styles.module.css
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@media (min-width: 997px) {
+  .sidebar {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding-top: var(--ifm-navbar-height);
+    width: var(--doc-sidebar-width);
+  }
+
+  .sidebarWithHideableNavbar {
+    padding-top: 0;
+  }
+
+  .sidebarHidden {
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  .sidebarLogo {
+    display: flex !important;
+    align-items: center;
+    margin: 0 var(--ifm-navbar-padding-horizontal);
+    min-height: var(--ifm-navbar-height);
+    max-height: var(--ifm-navbar-height);
+    color: inherit !important;
+    text-decoration: none !important;
+  }
+
+  .sidebarLogo img {
+    margin-right: 0.5rem;
+    height: 2rem;
+  }
+}
+
+.sidebarLogo {
+  display: none;
+}


### PR DESCRIPTION
## Summary

- Swizzles `DocSidebar/Desktop` to render Changelog, Bitrise Integration Steps, and Bitrise Workflow Recipes links pinned to the bottom of every hub sidebar
- Adds per-hub changelog pages (`docs/changelogs/`) backed by a single shared partial (`src/partials/changelog-content.mdx`) so all hubs always show the same entries
- Adds `.claude/commands/update-changelog.md` — a Claude Code skill that generates changelog entries either from the current branch diff (before creating a PR) or retroactively from merged PRs

## Test plan
- [ ] Verify bottom links appear at the foot of the sidebar on every hub
- [ ] Verify the Changelog link highlights correctly when on a changelog page
- [ ] Verify the shared partial renders correctly on all hub changelog pages
- [ ] Run `/update-changelog` on a branch with doc changes and confirm it drafts an entry for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)