### PR TITLE
Add changelog feature: RSS feed, date badges, sidebar links, and monthly grouping

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -18,6 +18,25 @@ Run in **retroactive mode** when:
 
 ---
 
+## Entry format
+
+The changelog uses monthly H2 sections with H3 entries:
+
+```
+## YYYY Month
+
+### <time dateTime="YYYY-MM-DD">YYYY-MM-DD</time> Title {#YYYY-MM-DD-slug-of-title}
+
+Summary paragraph.
+
+```
+
+The `{#anchor}` ID uses the same slug formula as the feed plugin: lowercase the title, replace every run of non-alphanumeric characters with a single hyphen, strip leading/trailing hyphens, then prepend the date: `YYYY-MM-DD-slug`.
+
+Month headers use the format `## YYYY Month` (e.g. `## 2026 June`).
+
+---
+
 ## Current-branch mode
 
 Generate a changelog entry from the current branch's changes, commit it, then create a PR.
@@ -51,14 +70,12 @@ Generate a changelog entry from the current branch's changes, commit it, then cr
    - **Linking**: if the changes are concentrated in one page, end the summary with a link to that page using its `slug` (e.g. `See [Running Xcode tests](/en/bitrise-ci/testing/running-xcode-tests).`). If changes span multiple pages, include a link to the most relevant one at your discretion — or omit if no single page stands out.
    - One entry per PR even if multiple files changed.
 
-4. **Write and commit** once approved. Prepend the entry after the `<!-- changelog-entries -->` marker in `src/partials/changelog-content.mdx` using this format:
-   ```
-   ## <time dateTime="YYYY-MM-DD">YYYY-MM-DD</time> — Title {#YYYY-MM-DD-slug-of-title}
+4. **Write and commit** once approved. Insert the entry into `src/partials/changelog-content.mdx`:
+   - Find the H2 for the current month (e.g. `## 2026 June`).
+   - Insert the new H3 entry at the top of that section, immediately after the H2 line.
+   - If no H2 exists for the current month yet, create it at the top of the entries (immediately after `<!-- changelog-entries -->`), then add the H3 entry beneath it.
 
-   Summary paragraph.
-
-   ```
-   The `{#anchor}` ID uses the same slug formula as the feed plugin: lowercase the title, replace every run of non-alphanumeric characters with a single hyphen, strip leading/trailing hyphens, then prepend the date: `YYYY-MM-DD-slug`. Then commit:
+   Then commit:
    ```
    git add src/partials/changelog-content.mdx
    git commit -m "Update changelog"
@@ -74,7 +91,7 @@ Generate entries for all merged PRs not yet covered by the changelog.
 
 ### Steps
 
-1. **Find the cutoff date.** Read `src/partials/changelog-content.mdx` and extract the date from the first line matching `## YYYY-MM-DD`. That date is the cutoff; generate entries for PRs merged *after* it. If the changelog has no entries, use `2026-06-03` (the Docusaurus migration date).
+1. **Find the cutoff date.** Read `src/partials/changelog-content.mdx` and extract the date from the first H3 line matching `### ...YYYY-MM-DD...`. That date is the cutoff; generate entries for PRs merged *after* it. If the changelog has no entries, use `2026-06-03` (the Docusaurus migration date).
 
 2. **Find uncovered PRs.**
    ```
@@ -84,7 +101,7 @@ Generate entries for all merged PRs not yet covered by the changelog.
    - `mergedAt` is strictly after the cutoff date
    - at least one file path starts with `docs/` and ends with `.md` or `.mdx`
 
-   Sort ascending by `mergedAt` (oldest first — you'll prepend in reverse so newest ends up on top).
+   Sort ascending by `mergedAt` (oldest first — you'll insert in reverse so newest ends up on top within each month).
 
 3. **For each uncovered PR**, ascending order:
    a. Fetch the diff:
@@ -112,14 +129,12 @@ Generate entries for all merged PRs not yet covered by the changelog.
       - **Summary**: 1–2 sentences. Reader's perspective, not the author's.
       - **Linking**: if the changes are concentrated in one page, end the summary with a link to that page using its `slug`. If changes span multiple pages, link to the most relevant one at your discretion — or omit if no single page stands out.
 
-4. **Prepend new entries** immediately after `<!-- changelog-entries -->`, newest first. Format:
-   ```
-   ## <time dateTime="YYYY-MM-DD">YYYY-MM-DD</time> — Title {#YYYY-MM-DD-slug-of-title}
+4. **Insert new entries** into their respective month sections, newest first within each section. For each entry:
+   - Find the H2 for its month (e.g. `## 2026 June`).
+   - Insert the H3 entry at the top of that section.
+   - If no H2 exists for that month, create it in the correct chronological position.
 
-   Summary paragraph.
-
-   ```
-   The `{#anchor}` ID must use the same slug formula as the feed plugin: lowercase the title, replace every run of non-alphanumeric characters with a single hyphen, strip leading/trailing hyphens, then prepend the date with a single hyphen: `YYYY-MM-DD-slug`.
+   The `{#anchor}` ID must use the same slug formula as the feed plugin: lowercase the title, replace every run of non-alphanumeric characters with a single hyphen, strip leading/trailing hyphens, then prepend the date: `YYYY-MM-DD-slug`.
 
 5. **Report** how many entries were added and list any skipped PRs with reasons.
 

--- a/docs/changelogs/bitrise-build-cache.mdx
+++ b/docs/changelogs/bitrise-build-cache.mdx
@@ -3,6 +3,7 @@ title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /bitrise-build-cache/changelog
 sidebar_position: 999
+toc_max_heading_level: 2
 displayed_sidebar: buildCacheSidebar
 ---
 

--- a/docs/changelogs/bitrise-build-hub.mdx
+++ b/docs/changelogs/bitrise-build-hub.mdx
@@ -3,6 +3,7 @@ title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /bitrise-build-hub/changelog
 sidebar_position: 999
+toc_max_heading_level: 2
 displayed_sidebar: buildHubSidebar
 ---
 

--- a/docs/changelogs/bitrise-ci.mdx
+++ b/docs/changelogs/bitrise-ci.mdx
@@ -3,6 +3,7 @@ title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /bitrise-ci/changelog
 sidebar_position: 999
+toc_max_heading_level: 2
 displayed_sidebar: ciSidebar
 ---
 

--- a/docs/changelogs/bitrise-platform.mdx
+++ b/docs/changelogs/bitrise-platform.mdx
@@ -3,6 +3,7 @@ title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /bitrise-platform/changelog
 sidebar_position: 999
+toc_max_heading_level: 2
 displayed_sidebar: platformSidebar
 ---
 

--- a/docs/changelogs/insights.mdx
+++ b/docs/changelogs/insights.mdx
@@ -3,6 +3,7 @@ title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /insights/changelog
 sidebar_position: 999
+toc_max_heading_level: 2
 displayed_sidebar: insightsSidebar
 ---
 

--- a/docs/changelogs/release-management.mdx
+++ b/docs/changelogs/release-management.mdx
@@ -3,6 +3,7 @@ title: "Docs changelog"
 description: "A record of documentation updates on the Bitrise docs site."
 slug: /release-management/changelog
 sidebar_position: 999
+toc_max_heading_level: 2
 displayed_sidebar: releaseManagementSidebar
 ---
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -668,6 +668,26 @@ article:has([data-product-overview]) > .markdown {
   text-decoration: none;
 }
 
+/* ---- Changelog date badge ---- */
+
+h3 > time {
+  display: inline-block;
+  padding: 2px 8px;
+  background: var(--pal-blue-93);
+  color: var(--pal-blue-30);
+  border-radius: 4px;
+  font-size: 0.8em;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  vertical-align: middle;
+  margin-right: 6px;
+}
+
+[data-theme='dark'] h3 > time {
+  background: var(--pal-blue-30);
+  color: var(--pal-blue-90);
+}
+
 /* ---- Swagger UI ---- */
 
 /* Version badges ("0.1", "OAS 2.0"): the <pre class="version"> has a near-white

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -670,7 +670,7 @@ article:has([data-product-overview]) > .markdown {
 
 /* ---- Changelog date badge ---- */
 
-h3 > time {
+article:has(.changelog-subscribe-btn) h3 > time {
   display: inline-block;
   padding: 2px 8px;
   background: var(--pal-blue-93);
@@ -683,7 +683,7 @@ h3 > time {
   margin-right: 6px;
 }
 
-[data-theme='dark'] h3 > time {
+[data-theme='dark'] article:has(.changelog-subscribe-btn) h3 > time {
   background: var(--pal-blue-30);
   color: var(--pal-blue-90);
 }

--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -1,5 +1,3 @@
-<!-- Future structure (monthly grouping): https://github.com/bitrise-io/docs/issues/47 -->
-
 <head>
   <link rel="alternate" type="application/rss+xml" title="Bitrise Docs changelog" href="/changelog.xml" />
 </head>
@@ -11,30 +9,106 @@
 
 <!-- changelog-entries -->
 
-## <time dateTime="2026-06-15">2026-06-15</time> — Bitrise MCP: new registration tools and API group {#2026-06-15-bitrise-mcp-new-registration-tools-and-api-group}
+## 2026 June
+
+### <time dateTime="2026-06-15">2026-06-15</time> Bitrise MCP: new registration tools and API group {#2026-06-15-bitrise-mcp-new-registration-tools-and-api-group}
 
 The Bitrise MCP server now includes a `registration` API group with two unauthenticated tools — `register` and `verify_registration` — that let an AI agent onboard a brand-new Bitrise user without a token. The agent sends a one-time password to the user's email via `register`, then calls `verify_registration` with the OTP to receive a personal access token. These tools are most useful with the remote (HTTP) MCP server. See [Bitrise MCP tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for the full reference.
 
-## <time dateTime="2026-06-15">2026-06-15</time> — Bitrise MCP: install guides added for six tools {#2026-06-15-bitrise-mcp-install-guides-added-for-six-tools}
+### <time dateTime="2026-06-15">2026-06-15</time> Bitrise MCP: install guides added for six tools {#2026-06-15-bitrise-mcp-install-guides-added-for-six-tools}
 
-Step-by-step install guides for the Bitrise MCP server are now available for VS Code, Cursor, Claude, Windsurf, Kiro, Gemini CLI, and other Copilot-compatible IDEs. Each guide covers how to configure the MCP server and authenticate with your Bitrise token. See [Installing the Bitrise MCP server](/en/bitrise-platform/ai/bitrise-mcp/installing-the-bitrise-mcp-server) to get started.
+Step-by-step install guides for the Bitrise MCP server are now available for VS Code, Cursor, Claude, Windsurf, Kiro, Gemini CLI, and other Copilot-compatible IDEs. Each guide covers how to configure the MCP server and authenticate with your Bitrise token. See [Bitrise MCP](/en/bitrise-platform/ai/bitrise-mcp) to get started.
 
-## <time dateTime="2026-06-11">2026-06-11</time> — Workflow Editor can now push bitrise.yml directly to the repository {#2026-06-11-workflow-editor-can-now-push-bitrise-yml-directly-to-the-repository}
+### <time dateTime="2026-06-11">2026-06-11</time> Workflow Editor can now push bitrise.yml directly to the repository {#2026-06-11-workflow-editor-can-now-push-bitrise-yml-directly-to-the-repository}
 
-The Workflow Editor now supports pushing changes to a repository-stored `bitrise.yml` directly from the editor — either to the current branch or a new branch — without manually copying and committing. See [Managing a project's configuration YAML file](/en/bitrise-ci/configure-builds/configuration-yaml/managing-a-project-s-configuration-yaml-file) for the updated flow.
+The Workflow Editor now supports pushing changes to a repository-stored `bitrise.yml` directly from the editor — either to the current branch or a new branch — without manually copying and committing. See [Storing an app's configuration YAML](/en/bitrise-ci/configure-builds/configuration-yaml/storing-an-apps-configuration-yaml) for the updated flow.
 
-## <time dateTime="2026-06-10">2026-06-10</time> — Build Hub: Gradle dependency mirroring explained {#2026-06-10-build-hub-gradle-dependency-mirroring-explained}
+### <time dateTime="2026-06-10">2026-06-10</time> Build Hub: Gradle dependency mirroring explained {#2026-06-10-build-hub-gradle-dependency-mirroring-explained}
 
 The Build Hub documentation now includes an explanation of how Gradle dependency mirroring works, giving you a clearer picture of caching behaviour for Gradle projects running on Build Hub.
 
-## <time dateTime="2026-06-09">2026-06-09</time> — Configuration YAML docs updated for YAML/Visual mode switcher {#2026-06-09-configuration-yaml-docs-updated-for-yaml-visual-mode-switcher}
+### <time dateTime="2026-06-09">2026-06-09</time> Configuration YAML docs updated for YAML/Visual mode switcher {#2026-06-09-configuration-yaml-docs-updated-for-yaml-visual-mode-switcher}
 
 References throughout the docs have been updated to reflect the new toggle between YAML and Visual editing modes in the Workflow Editor. Where instructions previously referred to the left navigation menu, they now point to the **YAML** toggle at the top of the editor.
 
-## <time dateTime="2026-06-08">2026-06-08</time> — New guide: Maven Central repository manager {#2026-06-08-new-guide-maven-central-repository-manager}
+### <time dateTime="2026-06-08">2026-06-08</time> New guide: Maven Central repository manager {#2026-06-08-new-guide-maven-central-repository-manager}
 
 A new guide covering the Maven Central repository manager is now available under [Build Cache getting started](/en/bitrise-build-cache/getting-started-with-the-build-cache/maven-central-repository-manager). It explains how Bitrise's proxy cache works for Maven dependencies, covers special cases like dependency verification and custom Docker images, and documents the opt-out process.
 
-## <time dateTime="2026-06-08">2026-06-08</time> — Bitrise MCP server: OAuth is now the primary authentication method {#2026-06-08-bitrise-mcp-server-oauth-is-now-the-primary-authentication-method}
+### <time dateTime="2026-06-08">2026-06-08</time> Bitrise MCP server: OAuth is now the primary authentication method {#2026-06-08-bitrise-mcp-server-oauth-is-now-the-primary-authentication-method}
 
 The Bitrise MCP server now uses OAuth as the primary authentication method. See [Bitrise MCP](/en/bitrise-platform/ai/bitrise-mcp) for the updated setup steps.
+
+## 2026 May
+
+### <time dateTime="2026-05-29">2026-05-29</time> Build distribution: custom access links for installable artifacts {#2026-05-29-build-distribution-custom-access-links-for-installable-artifacts}
+
+In Release Management, you can now create shareable install links. See [Custom access links](/en/release-management/build-distribution/distributing-builds-to-testers#custom-access-link) for details.
+
+### <time dateTime="2026-05-28">2026-05-28</time> Modular YAML: increased file and nesting limits for GitHub users {#2026-05-28-modular-yaml-increased-file-and-nesting-limits-for-github-users}
+
+The modular YAML configuration guide has been updated to reflect the new, higher file count and nesting limits for GitHub users. See [Modular YAML configuration](/en/bitrise-ci/configure-builds/configuration-yaml/modular-yaml-configuration) for the updated limits.
+
+### <time dateTime="2026-05-20">2026-05-20</time> Python projects now supported {#2026-05-20-python-projects-now-supported}
+
+Bitrise now detects Python projects automatically and offers default workflows. The [Default workflows](/en/bitrise-ci/workflows-and-pipelines/workflows/default-workflows) and [Getting started with web CI](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci) guides have been updated to include Python.
+
+## 2026 April
+
+### <time dateTime="2026-04-20">2026-04-20</time> Next.js and Flutter Web project types documented {#2026-04-20-next-js-and-flutter-web-project-types-documented}
+
+The [Getting started with web CI](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci) guide and [Default workflows](/en/bitrise-ci/workflows-and-pipelines/workflows/default-workflows) page now cover Next.js (as an extension of Node.js) and Flutter Web project types.
+
+## 2026 March
+
+### <time dateTime="2026-03-30">2026-03-30</time> M4 machine type added to build machine docs {#2026-03-30-m4-machine-type-added-to-build-machine-docs}
+
+The [Build machine types](/en/bitrise-platform/infrastructure/build-machines/build-machine-types) page now lists the M4 machine type alongside the existing M4 Pro, M2 Pro, and M1 options, with region availability for each.
+
+### <time dateTime="2026-03-25">2026-03-25</time> Ruby projects now supported {#2026-03-25-ruby-projects-now-supported}
+
+Bitrise now detects Ruby projects automatically and offers default workflows. The [Getting started with web CI](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci) guide has been updated to include Ruby.
+
+### <time dateTime="2026-03-24">2026-03-24</time> Pro Trial: credit card required to access the full trial {#2026-03-24-pro-trial-credit-card-required-to-access-the-full-trial}
+
+New users now need to provide a valid credit card (which won't be charged) to access the full Pro Trial. The [Getting started with Bitrise CI](/en/bitrise-ci/getting-started/getting-started) guide has been updated to explain this.
+
+### <time dateTime="2026-03-20">2026-03-20</time> New page: build artifact retention policy {#2026-03-20-new-page-build-artifact-retention-policy}
+
+A dedicated [Build artifact retention policy](/en/bitrise-ci/run-and-analyze-builds/managing-build-files/artifact-retention-policy) page is now available, covering default retention periods by artifact type, extended retention options for enterprise customers, and the edge case around transferred projects.
+
+### <time dateTime="2026-03-10">2026-03-10</time> Xcode compilation cache: new flag to disable caching without disabling analytics {#2026-03-10-xcode-compilation-cache-new-flag-to-disable-caching-without-disabling-analytics}
+
+The [Xcode compilation cache FAQ](/en/bitrise-build-cache/build-cache-for-xcode/xcode-compilation-cache-faq) now documents the `--no-bitrise-build-cache` flag, which lets you disable caching temporarily while keeping analytics and build history intact.
+
+## 2026 February
+
+### <time dateTime="2026-02-20">2026-02-20</time> Build Cache: clear cache button replaces Settings dropdown {#2026-02-20-build-cache-clear-cache-button-replaces-settings-dropdown}
+
+The [Clearing the Build Cache](/en/bitrise-build-cache/getting-started-with-the-build-cache/clearing-the-build-cache) guide has been updated to reflect the current UI: the Settings dropdown was replaced by a **Clear Cache** button. The guide includes a new screenshot and a note that clearing the cache requires Workspace owner permissions.
+
+### <time dateTime="2026-02-20">2026-02-20</time> New guide: Endpoint Detection and Response (EDR) on Bitrise {#2026-02-20-new-guide-endpoint-detection-and-response-edr-on-bitrise}
+
+A new page under Integrations explains how Bitrise uses Endpoint Detection and Response (EDR) as part of its corporate security program, and clarifies that EDR agents are not deployed on Bitrise-hosted CI runners.
+
+### <time dateTime="2026-02-13">2026-02-13</time> OIDC for AWS guide updated {#2026-02-13-oidc-for-aws-guide-updated}
+
+The [OIDC for AWS](/en/bitrise-platform/integrations/oidc-authentication/oidc-for-aws) guide has been updated with additional clarifications on configuration and usage.
+
+### <time dateTime="2026-02-03">2026-02-03</time> New guide: GitHub App migration API {#2026-02-03-new-guide-github-app-migration-api}
+
+A new guide explains how to use the Bitrise API to bulk-migrate projects from OAuth-based GitHub connections to the GitHub App integration, including caveats about reverting the migration. See [Adding and managing apps](/en/bitrise-ci/api/adding-and-managing-apps) for details.
+
+## 2026 January
+
+### <time dateTime="2026-01-27">2026-01-27</time> Tool setup: new tool versions added {#2026-01-27-tool-setup-new-tool-versions-added}
+
+The [Configuring tool versions](/en/bitrise-ci/configure-builds/configuring-build-settings/configuring-tool-versions) guide has been updated with newly supported tool versions in the tool setup feature.
+
+### <time dateTime="2026-01-19">2026-01-19</time> Build artifact retention policy documented {#2026-01-19-build-artifact-retention-policy-documented}
+
+The [Build artifacts](/en/bitrise-ci/run-and-analyze-builds/managing-build-files/build-artifacts-online) page now includes a section on the artifact retention policy, covering default retention periods by artifact type and options for Enterprise customers. The policy takes effect on March 31, 2026.
+
+### <time dateTime="2026-01-12">2026-01-12</time> Pipeline rebuild: dynamic parallel workflows explained {#2026-01-12-pipeline-rebuild-dynamic-parallel-workflows-explained}
+
+The guide on rebuilding failed pipelines now includes an explanation of how dynamic parallel Workflows affect rebuild options — specifically, when you can rebuild individual Workflows versus all unsuccessful ones. See [Rebuilding a failed build](/en/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/rebuilding-a-failed-build#rebuilding-a-failed-pipeline) for details.

--- a/src/plugins/changelog-feed.ts
+++ b/src/plugins/changelog-feed.ts
@@ -16,6 +16,7 @@ const CHANGELOG_PATH = '/en/bitrise-ci/changelog';
 interface Entry {
   date: string;   // ISO 8601, e.g. "2026-06-16"
   title: string;
+  anchor: string; // explicit {#id} from heading, used as the URL fragment
   content: string;
 }
 
@@ -24,9 +25,9 @@ function parseEntries(): Entry[] {
   const lines = text.split('\n');
   const entries: Entry[] = [];
 
-  // Match H2 headings: ## <time dateTime="YYYY-MM-DD">YYYY-MM-DD</time> — Title
-  // Also matches plain: ## YYYY-MM-DD — Title
-  const headingRe = /^## (?:<time[^>]*>)?(\d{4}-\d{2}-\d{2})(?:<\/time>)? — (.+)$/;
+  // Match H3 headings: ### <time dateTime="YYYY-MM-DD">YYYY-MM-DD</time> — Title {#anchor}
+  // Also matches plain: ### YYYY-MM-DD — Title {#anchor}
+  const headingRe = /^### (?:<time[^>]*>)?(\d{4}-\d{2}-\d{2})(?:<\/time>)?\s+(.+?)(?:\s*\{#([^}]+)\})?$/;
   let current: Entry | null = null;
   const contentLines: string[] = [];
 
@@ -37,9 +38,9 @@ function parseEntries(): Entry[] {
         current.content = contentLines.join('\n').trim();
         entries.push(current);
       }
-      current = { date: m[1], title: m[2], content: '' };
+      current = { date: m[1], title: m[2], anchor: m[3] ?? toSlug(`${m[1]}-${m[2]}`), content: '' };
       contentLines.length = 0;
-    } else if (current) {
+    } else if (current && !line.startsWith('## ')) {
       contentLines.push(line);
     }
   }
@@ -71,7 +72,7 @@ function buildRss(entries: Entry[]): string {
   const items = entries
     .map((e) => {
       const pubDate = new Date(`${e.date}T00:00:00Z`).toUTCString();
-      const link = `${SITE_URL}${CHANGELOG_PATH}#${e.date}-${toSlug(e.title)}`;
+      const link = `${SITE_URL}${CHANGELOG_PATH}#${e.anchor}`;
       return `  <item>
     <title>${escapeXml(e.title)}</title>
     <link>${escapeXml(link)}</link>
@@ -108,8 +109,8 @@ function buildJson(entries: Entry[]): string {
     home_page_url: `${SITE_URL}${CHANGELOG_PATH}`,
     feed_url: `${SITE_URL}/changelog.json`,
     items: entries.map((e) => ({
-      id: `${SITE_URL}${CHANGELOG_PATH}#${e.date}-${toSlug(e.title)}`,
-      url: `${SITE_URL}${CHANGELOG_PATH}#${e.date}-${toSlug(e.title)}`,
+      id: `${SITE_URL}${CHANGELOG_PATH}#${e.anchor}`,
+      url: `${SITE_URL}${CHANGELOG_PATH}#${e.anchor}`,
       title: e.title,
       date_published: `${e.date}T00:00:00Z`,
       content_text: e.content,

--- a/src/theme/DocSidebar/Desktop/index.tsx
+++ b/src/theme/DocSidebar/Desktop/index.tsx
@@ -44,17 +44,22 @@ function SidebarBottomLinks({path}: {path: string}) {
   // path is like /en/bitrise-ci/... — segment[2] is the hub dirName
   const dirName = path.split('/')[2] ?? '';
   const isChangelog = path.endsWith('/changelog');
+  // Only render the changelog link when we can resolve a hub slug.
+  // On /en/ or other non-hub paths dirName is empty, which would produce /en//changelog.
+  const changelogHref = dirName ? `/en/${dirName}/changelog` : null;
 
   return (
     <div className="sidebar-bottom-links">
+      {changelogHref && (
       <a
-        href={`/en/${dirName}/changelog`}
+        href={changelogHref}
         className={`sidebar-bottom-link${isChangelog ? ' sidebar-bottom-link--active' : ''}`}
         aria-current={isChangelog ? 'page' : undefined}
       >
         <IconBook />
         Docs changelog
       </a>
+      )}
       <a
         href="https://bitrise.io/integrations"
         className="sidebar-bottom-link"


### PR DESCRIPTION
## Summary

- Adds RSS and JSON feeds (`/changelog.xml`, `/changelog.json`) generated at build time from `src/partials/changelog-content.mdx`
- Adds a subscribe button and `<link>` autodiscovery tag to the changelog partial
- Adds `<time>` date badges on changelog entry headings (styled blue, scoped to changelog pages only)
- Restructures changelog entries into monthly H2 sections with H3 entries; adds 23 retroactive entries from Jan–Jun 2026
- Adds bottom sidebar links (Docs changelog, Bitrise Integration Steps, Workflow Recipes) to the desktop sidebar via a swizzled component
- Adds `toc_max_heading_level: 2` to all hub changelog pages to hide entry-level headings from the ToC
- Fixes feed anchor IDs to use explicit `{#id}` fragments instead of re-generating slugs from titles
- Fixes broken `/en//changelog` sidebar link on non-hub paths (link now only renders when a hub slug is resolvable)
- Scopes `h3 > time` date-badge CSS to changelog pages only via `:has(.changelog-subscribe-btn)`

## Test plan

- [ ] `/changelog.xml` and `/changelog.json` are present and valid after build
- [ ] Subscribe to RSS button appears on all hub changelog pages
- [ ] Date badges render correctly on changelog entry headings; no badge on non-changelog H3 headings
- [ ] Sidebar bottom links appear on all hub doc pages; changelog link highlights when active
- [ ] Sidebar changelog link does not render on non-hub paths
- [ ] ToC on changelog pages shows only month sections, not individual entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)