### PR TITLE
Add event subscriptions section to GitHub App integration docs

### DIFF
--- a/docs/bitrise-platform/repository-access/github-app-integration.mdx
+++ b/docs/bitrise-platform/repository-access/github-app-integration.mdx
@@ -30,6 +30,27 @@ The GitHub App requires an HTTPS URL for your repository instead of an SSH one. 
 :::
 
 
+## Event subscriptions
+
+When you install the Bitrise GitHub App on a repository or organization, GitHub automatically registers event subscriptions for that installation. These are separate from the repo-level webhooks you can configure manually in GitHub's repository settings.
+
+The Bitrise GitHub App subscribes to the following events:
+
+- `push`: triggers builds on branch pushes and tag pushes.
+- `pull_request`: triggers builds when a pull request is opened, updated, or synchronized.
+- `issue_comment`: enables comment-based build triggers on pull requests.
+
+These subscriptions are managed by GitHub at the app installation level. They do not appear as webhooks under **Settings → Webhooks** in your GitHub repository.
+
+:::warning[Remove manual webhooks after switching to the GitHub App]
+
+If your repository also has manually configured webhooks pointing to `hooks.bitrise.io` — for example, from a previous OAuth-based Bitrise connection — each qualifying event will trigger two builds: one from the GitHub App subscription and one from the manual webhook.
+
+After switching to the GitHub App, remove any manual Bitrise webhooks from your repository's **Settings → Webhooks** page on GitHub to avoid duplicate builds.
+
+:::
+
+
 ## Installing the GitHub app integration
 
 This guide is intended for GitHub Cloud users, including GitHub Enterprise Cloud users, who wish to install the Bitrise GitHub app and connect their Bitrise Workspace to a GitHub account or organization with the app.
@@ -276,7 +297,7 @@ workflows:
     - https://github.com/bitrise-io/bitrise-steplib.git::authenticate-host-with-netrc@0:
 ```
 
-Note that the **[Authenticate host with netrc](https://bitrise.io/integrations/steps/authenticate-host-with-netrc)**Step has [a full source identifier](/en/bitrise-ci/references/steps-reference/step-reference-id-format) to ensure it is pulled from the official Bitrise Step library, not your private library.
+Note that the **[Authenticate host with netrc](https://bitrise.io/integrations/steps/authenticate-host-with-netrc)** Step has [a full source identifier](/en/bitrise-ci/references/steps-reference/step-reference-id-format) to ensure it is pulled from the official Bitrise Step library, not your private library.
 
 Using the Step requires specifying three inputs: the host, the Git username, and the Git password. The Bitrise GitHub App integration uses token-based authentication: each build receives a one time token under the GIT_HTTP_PASSWORD Environment Variable. This Env Var can be used as the password. The username can't be empty because the Step will fail but it is not used so it doesn't matter what you put there.
 

--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -11,6 +11,10 @@
 
 ## 2026 June
 
+### <time dateTime="2026-06-17">2026-06-17</time> GitHub App integration: event subscriptions clarified {#2026-06-17-github-app-integration-event-subscriptions-clarified}
+
+The [GitHub App integration](/en/bitrise-platform/repository-access/github-app-integration) page now has an Event subscriptions section explaining that the Bitrise GitHub App subscribes to `push`, `pull_request`, and `issue_comment` events via GitHub's app installation mechanism, not through repo-level webhooks. The section also warns that any existing manual webhooks pointing to `hooks.bitrise.io` must be removed after switching to the GitHub App to avoid duplicate builds.
+
 ### <time dateTime="2026-06-15">2026-06-15</time> Bitrise MCP: new registration tools and API group {#2026-06-15-bitrise-mcp-new-registration-tools-and-api-group}
 
 The Bitrise MCP server now includes a `registration` API group with two unauthenticated tools — `register` and `verify_registration` — that let an AI agent onboard a brand-new Bitrise user without a token. The agent sends a one-time password to the user's email via `register`, then calls `verify_registration` with the OTP to receive a personal access token. These tools are most useful with the remote (HTTP) MCP server. See [Bitrise MCP tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for the full reference.

--- a/src/partials/switching-from-oauth-connection-to-the-github-app.mdx
+++ b/src/partials/switching-from-oauth-connection-to-the-github-app.mdx
@@ -31,5 +31,5 @@ To switch:
    ![SCR-20260331-prho.png](/img/_paligo/uuid-3de8dcba-e678-997e-20f0-3055cd889bb0.png)
 1. Make sure you remove any pre-existing manual Webhooks from the **Incoming Webhooks** page of the **Webhooks** tab once the GitHub App is configured.
 
-   You can get to this page via **Project Settings** → **Integrations** → **Webhooks** tab → **Incoming Webhooks**. If you fail to do this, duplicate builds will get triggered.
+   You can get to this page via **Project Settings** → **Integrations** → **Webhooks** tab → **Incoming Webhooks**. If you fail to do this, duplicate builds will get triggered. For more information, see [Event subscriptions](/en/bitrise-platform/repository-access/github-app-integration#event-subscriptions).
 1. Optionally, you can remove the service credential user and any SSH keys or personal access tokens used for OAuth connection.


### PR DESCRIPTION
## Summary

- Adds a new "Event subscriptions" section to the GitHub App integration page, explaining that the Bitrise GitHub App subscribes to `push`, `pull_request`, and `issue_comment` events via GitHub's app installation mechanism — not through repo-level webhooks
- Adds a warning admonition explaining that manual webhooks pointing to `hooks.bitrise.io` must be removed after switching to the GitHub App, or duplicate builds will be triggered
- Links from step 6 of the "Switching from OAuth" section to the new Event subscriptions section
- Fixes a minor bold formatting issue in the "Using a private Step library" section

## Test plan

- [ ] New section renders correctly above "Installing the GitHub app integration"
- [ ] Warning admonition displays correctly
- [ ] Link from the switching guide resolves to the correct anchor
- [ ] Preview URL works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)