### PR TITLE
Add Release Management API how-to guides

### DIFF
--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -1,0 +1,137 @@
+# Update changelog
+
+Update `src/partials/changelog-content.mdx` with changelog entries for doc changes not yet covered.
+
+The changelog is a shared partial imported by every hub's `changelog.mdx`. Only update the partial — the hub pages update automatically.
+
+## Choosing the right mode
+
+Run in **current-branch mode** when:
+- The user is about to create a PR, or asks to create a PR
+- The user says "generate a changelog entry for this branch / these changes"
+- There are local commits on the current branch not yet on `main`
+
+Run in **retroactive mode** when:
+- The user says "update the changelog" or "catch up the changelog"
+- The current branch has no relevant doc changes
+- You need to cover PRs that were merged without a changelog entry
+
+---
+
+## Entry format
+
+The changelog uses monthly H2 sections with H3 entries:
+
+```
+## YYYY Month
+
+### <time dateTime="YYYY-MM-DD">YYYY-MM-DD</time> Title {#YYYY-MM-DD-slug-of-title}
+
+Summary paragraph.
+
+```
+
+The `{#anchor}` ID uses the same slug formula as the feed plugin: lowercase the title, replace every run of non-alphanumeric characters with a single hyphen, strip leading/trailing hyphens, then prepend the date: `YYYY-MM-DD-slug`.
+
+Month headers use the format `## YYYY Month` (e.g. `## 2026 June`).
+
+---
+
+## Current-branch mode
+
+Generate a changelog entry from the current branch's changes.
+
+### Steps
+
+1. **Find doc changes on this branch.**
+   ```
+   git diff main...HEAD --name-only
+   ```
+   Filter to files under `docs/` ending in `.md` or `.mdx`. If there are none, skip to step 4 (no entry needed).
+
+2. **Decide whether to write an entry.** Read the diff:
+   ```
+   git diff main...HEAD -- 'docs/**/*.md' 'docs/**/*.mdx'
+   ```
+   Truncate to ~6 000 characters if needed. **Skip changelog generation** if all changes are:
+   - Changes only to `src/partials/changelog-content.mdx` or `docs/changelogs/` (changelog infrastructure)
+   - Formatting or cleanup (syntax highlighting, whitespace, list numbering)
+   - Broken link or image path corrections
+   - Navigation or sidebar changes
+   - Glossary tooltips or internal cross-references
+   - Corrections with no new information
+   - File moves or renames with identical content
+
+   If in doubt, skip.
+
+3. **Draft the changelog entry** and show it in chat for review. Wait for explicit approval or edits before writing anything to disk. Do not proceed automatically.
+   - **Title**: 5–8 words from the reader's perspective.
+   - **Summary**: 1–2 sentences. Write from the reader's perspective ("You can now…", "The X guide now covers…"), not the author's ("We added…"). Use today's date.
+   - **Linking**: if the changes are concentrated in one page, end the summary with a link to that page using its `slug` (e.g. `See [Running Xcode tests](/en/bitrise-ci/testing/running-xcode-tests).`). If changes span multiple pages, include a link to the most relevant one at your discretion — or omit if no single page stands out.
+   - One entry per PR even if multiple files changed.
+
+4. **Write to disk** once the user approves. Insert the entry into `src/partials/changelog-content.mdx`:
+   - Find the H2 for the current month (e.g. `## 2026 June`).
+   - Insert the new H3 entry at the top of that section, immediately after the H2 line.
+   - If no H2 exists for the current month yet, create it at the top of the entries (immediately after `<!-- changelog-entries -->`), then add the H3 entry beneath it.
+
+5. **Do not commit or push.** Leave that to the user.
+
+---
+
+## Retroactive mode
+
+Generate entries for all merged PRs not yet covered by the changelog.
+
+### Steps
+
+1. **Find the cutoff date.** Read `src/partials/changelog-content.mdx` and extract the date from the first H3 line matching `### ...YYYY-MM-DD...`. That date is the cutoff; generate entries for PRs merged *after* it. If the changelog has no entries, use `2026-06-03` (the Docusaurus migration date).
+
+2. **Find uncovered PRs.**
+   ```
+   gh pr list --state merged --limit 100 --json number,title,mergedAt,files
+   ```
+   Filter to PRs where:
+   - `mergedAt` is strictly after the cutoff date
+   - at least one file path starts with `docs/` and ends with `.md` or `.mdx`
+
+   Sort ascending by `mergedAt` (oldest first — you'll insert in reverse so newest ends up on top within each month).
+
+3. **For each uncovered PR**, ascending order:
+   a. Fetch the diff:
+      ```
+      gh pr diff <number>
+      ```
+      Extract only hunks for `.md`/`.mdx` files under `docs/`. Truncate to ~6 000 characters if needed.
+
+   b. Read title and body:
+      ```
+      gh pr view <number> --json title,body
+      ```
+
+   c. **Skip the PR entirely** if all changes are:
+      - Changes only to `src/partials/changelog-content.mdx` or `docs/changelogs/` (changelog infrastructure)
+      - Formatting or cleanup
+      - Broken link or image path corrections
+      - Navigation or sidebar changes
+      - Glossary tooltips or internal cross-references
+      - Corrections with no new information
+      - File moves or renames with identical content
+
+   d. If keeping, write:
+      - **Title**: 5–8 words from the reader's perspective.
+      - **Summary**: 1–2 sentences. Reader's perspective, not the author's.
+      - **Linking**: if the changes are concentrated in one page, end the summary with a link to that page using its `slug`. If changes span multiple pages, link to the most relevant one at your discretion — or omit if no single page stands out.
+
+4. **Insert new entries** into their respective month sections, newest first within each section. For each entry:
+   - Find the H2 for its month (e.g. `## 2026 June`).
+   - Insert the H3 entry at the top of that section.
+   - If no H2 exists for that month, create it in the correct chronological position.
+
+   The `{#anchor}` ID must use the same slug formula as the feed plugin: lowercase the title, replace every run of non-alphanumeric characters with a single hyphen, strip leading/trailing hyphens, then prepend the date: `YYYY-MM-DD-slug`.
+
+5. **Report** how many entries were added and list any skipped PRs with reasons.
+
+### Notes
+- If there are no uncovered PRs, say so and make no changes.
+- Do not commit or push — leave that to the user.

--- a/docs/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-app-center-to-bitrise.mdx
+++ b/docs/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-app-center-to-bitrise.mdx
@@ -119,4 +119,4 @@ The App Center Distribute service allows you to manage app distribution across m
 
 To get started, you just need to [connect an app](/en/release-management/getting-started-with-release-management/connecting-an-app). Once you successfully connected an app, you don't have to go through any of the online stores to manage your releases.
 
-We also offer [a fully featured REST API](/en/release-management/release-management-api) to make the most of Release Management.
+We also offer [a fully featured REST API](/en/release-management/api/release-management-api) to make the most of Release Management.

--- a/docs/release-management/api/_category_.json
+++ b/docs/release-management/api/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Release Management API",
+  "position": 7,
+  "link": null,
+  "customProps": {
+    "icon": "Code"
+  }
+}

--- a/docs/release-management/api/adding-and-connecting-an-app.mdx
+++ b/docs/release-management/api/adding-and-connecting-an-app.mdx
@@ -1,0 +1,142 @@
+---
+title: "Adding and connecting an app"
+description: "Add an app to Release Management via the API and connect it to the App Store or Google Play."
+sidebar_position: 2
+slug: /release-management/api/adding-and-connecting-an-app
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Before you can manage releases through the API, you need to add the app to Release Management and connect it to a store.
+
+The Apps sub-API base URL: `https://api.bitrise.io/release-management/v2/apps/v1`
+
+## Adding a new app
+
+| Method | Path | Function | Required role |
+| --- | --- | --- | --- |
+| POST / | Add a new app. | Release manager |
+| GET / | List all apps in a workspace. | Any |
+| GET /\{id\} | Get details of a specific app. | Any |
+| DELETE /\{id\} | Remove an app from Release Management. | Release manager |
+
+To add an app:
+
+1. Call `POST /` with the required fields:
+
+   - `platform`: The app platform: `ios` or `android`.
+   - `store_app_id`: The app's store identifier. For iOS: the App Store Connect numeric app ID. For Android: the package name (e.g. `com.example.myapp`).
+   - `workspace_slug`: The slug of the Bitrise workspace that will own the app.
+
+<Tabs groupId="platform">
+<TabItem value="ios" label="iOS">
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "platform": "ios",
+    "store_app_id": "1234567890",
+    "workspace_slug": "YOUR_WORKSPACE_SLUG",
+    "store_app_name": "My iOS App",
+    "store_credential_id": "YOUR_APPLE_CREDENTIAL_ID",
+    "framework": "native_ios"
+  }'
+```
+
+</TabItem>
+<TabItem value="android" label="Android">
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "platform": "android",
+    "store_app_id": "com.example.myapp",
+    "workspace_slug": "YOUR_WORKSPACE_SLUG",
+    "store_app_name": "My Android App",
+    "store_credential_id": "YOUR_GOOGLE_CREDENTIAL_ID",
+    "framework": "native_android"
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+   The response includes the new app's `id`. Save this value — you'll need it in all subsequent API calls for this app.
+
+:::note[Store credentials]
+
+The `store_credential_id` refers to an Apple or Google service credential configured in your workspace. You can manage credentials in Bitrise from **Workspace settings > Integrations**.
+
+:::
+
+2. (Optional) To register an app without connecting it to the store immediately, set `manual_connection: true`.
+
+   ```bash
+   curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/" \
+     -H "Authorization: YOUR_ACCESS_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "platform": "ios",
+       "store_app_id": "1234567890",
+       "workspace_slug": "YOUR_WORKSPACE_SLUG",
+       "manual_connection": true
+     }'
+   ```
+
+   You can connect the app to the store later using `PATCH /{id}`.
+
+## Connecting an app to the store
+
+| Method | Path | Function | Required role |
+| --- | --- | --- | --- |
+| PATCH /\{id\} | Update app settings, including store connection. | Release manager |
+
+If you added an app with `manual_connection: true` or need to update the store credentials, use `PATCH /{id}`:
+
+```bash
+curl -X PATCH "https://api.bitrise.io/release-management/v2/apps/v1/APP_ID" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "connect_to_store": true,
+    "store_credential_id": "YOUR_CREDENTIAL_ID"
+  }'
+```
+
+You can also update the `store_app_id` via `PATCH /{id}` if the app was initially registered with an incorrect identifier.
+
+## Listing apps
+
+To list all apps in a workspace:
+
+```bash
+curl -X GET "https://api.bitrise.io/release-management/v2/apps/v1/?workspace_slug=YOUR_WORKSPACE_SLUG" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Accept: application/json"
+```
+
+Optional query parameters:
+
+- `platform`: Filter by `ios` or `android`.
+- `project_id`: Filter by an associated Bitrise CI project ID.
+- `search`: Search by app name.
+- `items_per_page`: Results per page (default: 10, max: 50).
+- `page`: Page number (default: 1).
+
+## Removing an app
+
+:::warning[Deletion is permanent]
+
+Removing an app from Release Management deletes all associated releases, artifacts, and configuration. This cannot be undone.
+
+:::
+
+```bash
+curl -X DELETE "https://api.bitrise.io/release-management/v2/apps/v1/APP_ID" \
+  -H "Authorization: YOUR_ACCESS_TOKEN"
+```

--- a/docs/release-management/api/adding-and-connecting-an-app.mdx
+++ b/docs/release-management/api/adding-and-connecting-an-app.mdx
@@ -14,20 +14,19 @@ The Apps sub-API base URL: `https://api.bitrise.io/release-management/v2/apps/v1
 
 ## Adding a new app
 
-| Method | Path | Function | Required role |
-| --- | --- | --- | --- |
+| Endpoint | Function | Required role |
+| --- | --- | --- |
 | POST / | Add a new app. | Release manager |
 | GET / | List all apps in a workspace. | Any |
 | GET /\{id\} | Get details of a specific app. | Any |
 | DELETE /\{id\} | Remove an app from Release Management. | Release manager |
 
-To add an app:
+To add an app, call `POST /` with the required fields:
 
-1. Call `POST /` with the required fields:
-
-   - `platform`: The app platform: `ios` or `android`.
-   - `store_app_id`: The app's store identifier. For iOS: the App Store Connect numeric app ID. For Android: the package name (e.g. `com.example.myapp`).
-   - `workspace_slug`: The slug of the Bitrise workspace that will own the app.
+- `platform`: The app platform: `ios` or `android`.
+- `store_app_id`: The app's store identifier. For iOS: the App Store Connect numeric app ID. For Android: the package name (e.g. `com.example.myapp`).
+- `workspace_slug`: The slug of the Bitrise workspace that will own the app.
+- `store_credential_id`: The numeric integer ID of the Apple or Google service credential configured in your workspace. Required to connect the app to the store immediately. To skip this and connect later, set `manual_connection: true` instead.
 
 <Tabs groupId="platform">
 <TabItem value="ios" label="iOS">
@@ -41,7 +40,7 @@ curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/" \
     "store_app_id": "1234567890",
     "workspace_slug": "YOUR_WORKSPACE_SLUG",
     "store_app_name": "My iOS App",
-    "store_credential_id": "YOUR_APPLE_CREDENTIAL_ID",
+    "store_credential_id": YOUR_APPLE_CREDENTIAL_ID,
     "framework": "native_ios"
   }'
 ```
@@ -58,7 +57,7 @@ curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/" \
     "store_app_id": "com.example.myapp",
     "workspace_slug": "YOUR_WORKSPACE_SLUG",
     "store_app_name": "My Android App",
-    "store_credential_id": "YOUR_GOOGLE_CREDENTIAL_ID",
+    "store_credential_id": YOUR_GOOGLE_CREDENTIAL_ID,
     "framework": "native_android"
   }'
 ```
@@ -66,7 +65,32 @@ curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/" \
 </TabItem>
 </Tabs>
 
-   The response includes the new app's `id`. Save this value — you'll need it in all subsequent API calls for this app.
+The response includes the new app's `id`.
+
+```json
+{
+  "id": "YOUR_APP_ID",
+  "created_at": "2026-01-01T00:00:00.000Z",
+  "platform": "android",
+  "project_id": "YOUR_PROJECT_ID",
+  "workspace_slug": "YOUR_WORKSPACE_SLUG",
+  "icon_id": null,
+  "icon_url": null,
+  "app_name": "My Android App",
+  "current_user_release_management_admin": false,
+  "framework": "native_android",
+  "latest_version": null,
+  "latest_version_date": null,
+  "latest_build_version": "",
+  "latest_build_version_code": "",
+  "license": "basic",
+  "store_app_id": "com.example.myapp",
+  "store_connected": true,
+  "store_credential_id": 12345
+}
+```
+
+Save this value — you'll need it in all subsequent API calls for this app.
 
 :::note[Store credentials]
 
@@ -74,26 +98,12 @@ The `store_credential_id` refers to an Apple or Google service credential config
 
 :::
 
-2. (Optional) To register an app without connecting it to the store immediately, set `manual_connection: true`.
-
-   ```bash
-   curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/" \
-     -H "Authorization: YOUR_ACCESS_TOKEN" \
-     -H "Content-Type: application/json" \
-     -d '{
-       "platform": "ios",
-       "store_app_id": "1234567890",
-       "workspace_slug": "YOUR_WORKSPACE_SLUG",
-       "manual_connection": true
-     }'
-   ```
-
-   You can connect the app to the store later using `PATCH /{id}`.
+You can connect the app to the store later using `PATCH /{id}`.
 
 ## Connecting an app to the store
 
-| Method | Path | Function | Required role |
-| --- | --- | --- | --- |
+| Endpoint | Function | Required role |
+| --- | --- | --- |
 | PATCH /\{id\} | Update app settings, including store connection. | Release manager |
 
 If you added an app with `manual_connection: true` or need to update the store credentials, use `PATCH /{id}`:
@@ -104,7 +114,7 @@ curl -X PATCH "https://api.bitrise.io/release-management/v2/apps/v1/APP_ID" \
   -H "Content-Type: application/json" \
   -d '{
     "connect_to_store": true,
-    "store_credential_id": "YOUR_CREDENTIAL_ID"
+    "store_credential_id": YOUR_CREDENTIAL_ID
   }'
 ```
 

--- a/docs/release-management/api/build-distribution.mdx
+++ b/docs/release-management/api/build-distribution.mdx
@@ -15,8 +15,8 @@ You can upload build artifacts to Release Management and distribute them to inte
 
 ## Uploading a build artifact
 
-| Method | Path | Sub-API | Function |
-| --- | --- | --- | --- |
+| Endpoint | Sub-API | Function |
+| --- | --- | --- |
 | GET /installable-artifacts/\{id\}/upload-url | Apps | Generate a presigned upload URL. |
 | GET /installable-artifacts/\{id\}/status | Apps | Check upload and processing status. |
 | GET /installable-artifacts | Apps | List uploaded artifacts for an app. |
@@ -97,7 +97,13 @@ The `what_to_test` field accepts up to 4,000 characters.
 
 ## Creating custom access links
 
-Custom access links let you share a build with restricted access: optionally protected by a code and with an expiry date.
+Custom access links let you share a build with restricted access: optionally protected by a code and with an expiry date. For more information, see [Custom access links](/en/release-management/build-distribution/distributing-builds-to-testers#custom-access-link).
+
+:::note
+
+A custom access link is different from the [public install page](/en/bitrise-ci/deploying/ios-deployment/installing-an-ipa-file-from-the-public-install-page) link: the public install page is permanent and has no access controls.
+
+:::
 
 ```bash
 curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/installable-artifacts/ARTIFACT_ID/custom-access-links" \
@@ -114,10 +120,10 @@ The `access_code` must be 8–64 characters. Omit `expires_at` to create a link 
 
 ## Managing tester groups
 
-Tester groups let you notify groups of internal testers when a new build is ready.
+Tester groups let you notify groups of internal testers when a new build is ready. For more information, see [Tester groups](/en/release-management/build-distribution/tester-groups).
 
-| Method | Path | Function |
-| --- | --- | --- |
+| Endpoint | Function |
+| --- | --- |
 | POST /tester-groups | Create a tester group. |
 | GET /tester-groups | List tester groups for an app. |
 | PUT /tester-groups/\{id\} | Update a tester group. |

--- a/docs/release-management/api/build-distribution.mdx
+++ b/docs/release-management/api/build-distribution.mdx
@@ -1,0 +1,183 @@
+---
+title: "Distributing builds to testers"
+description: "Upload build artifacts and distribute them to tester groups via the Release Management API."
+sidebar_position: 5
+slug: /release-management/api/build-distribution
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+You can upload build artifacts to Release Management and distribute them to internal tester groups directly via the API. This covers both the artifact upload flow (Apps sub-API) and tester group management (Build Distributions sub-API).
+
+- **Apps sub-API base URL:** `https://api.bitrise.io/release-management/v2/apps/v1`
+- **Build Distributions sub-API base URL:** `https://api.bitrise.io/release-management/v2/build-distributions/v1`
+
+## Uploading a build artifact
+
+| Method | Path | Sub-API | Function |
+| --- | --- | --- | --- |
+| GET /installable-artifacts/\{id\}/upload-url | Apps | Generate a presigned upload URL. |
+| GET /installable-artifacts/\{id\}/status | Apps | Check upload and processing status. |
+| GET /installable-artifacts | Apps | List uploaded artifacts for an app. |
+| GET /installable-artifacts/\{id\} | Apps | Get details of an artifact. |
+| DELETE /installable-artifacts/\{id\} | Apps | Delete an artifact. |
+
+### Step 1: Generate an upload URL
+
+Generate a presigned S3 upload URL for your build artifact. The response includes both the upload URL and confirms the artifact ID.
+
+```bash
+ARTIFACT_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+curl -X GET "https://api.bitrise.io/release-management/v2/apps/v1/installable-artifacts/${ARTIFACT_ID}/upload-url?app_id=APP_ID&file_name=MyApp.ipa&file_size_bytes=52428800" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Accept: application/json"
+```
+
+Required query parameters:
+- `app_id`: The RM app ID.
+- `file_name`: The filename of the artifact (e.g., `MyApp.ipa` or `MyApp.apk`).
+- `file_size_bytes`: The file size in bytes.
+
+Optional query parameters:
+- `with_public_page`: Set to `true` to enable a public install page immediately.
+- `branch`: The source branch this build came from.
+- `workflow`: The CI workflow that produced this build.
+
+### Step 2: Upload the binary
+
+Use the presigned URL from the previous response to upload the file directly to storage:
+
+```bash
+curl -X PUT "PRESIGNED_UPLOAD_URL" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary "@/path/to/MyApp.ipa"
+```
+
+### Step 3: Check processing status
+
+After upload, wait for Bitrise to finish processing the artifact:
+
+```bash
+curl -X GET "https://api.bitrise.io/release-management/v2/apps/v1/installable-artifacts/${ARTIFACT_ID}/status" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Accept: application/json"
+```
+
+The response returns the current `status`. Poll this endpoint until the status indicates the artifact is ready for distribution.
+
+## Enabling a public install page
+
+You can make a build available via a public URL that testers can open directly without a Bitrise account.
+
+```bash
+curl -X PATCH "https://api.bitrise.io/release-management/v2/apps/v1/installable-artifacts/ARTIFACT_ID/public-install-page" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "with_public_page": true
+  }'
+```
+
+## Adding what-to-test notes
+
+Attach test instructions to a build that testers can see when they receive the notification.
+
+```bash
+curl -X PATCH "https://api.bitrise.io/release-management/v2/apps/v1/installable-artifacts/ARTIFACT_ID/what-to-test" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "what_to_test": "Focus on the new onboarding flow. Check that the splash screen animation completes before login."
+  }'
+```
+
+The `what_to_test` field accepts up to 4,000 characters.
+
+## Creating custom access links
+
+Custom access links let you share a build with restricted access: optionally protected by a code and with an expiry date.
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/installable-artifacts/ARTIFACT_ID/custom-access-links" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "External QA team",
+    "expires_at": "2026-07-31T23:59:59Z",
+    "access_code": "qa-team-2026"
+  }'
+```
+
+The `access_code` must be 8–64 characters. Omit `expires_at` to create a link that does not expire.
+
+## Managing tester groups
+
+Tester groups let you notify groups of internal testers when a new build is ready.
+
+| Method | Path | Function |
+| --- | --- | --- |
+| POST /tester-groups | Create a tester group. |
+| GET /tester-groups | List tester groups for an app. |
+| PUT /tester-groups/\{id\} | Update a tester group. |
+| POST /tester-groups/\{id\}/add-testers | Add testers to a group. |
+| POST /tester-groups/\{id\}/notify | Notify a group about a new build. |
+| DELETE /tester-groups/\{id\} | Delete a tester group. |
+
+### Creating a tester group
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/build-distributions/v1/tester-groups" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "app_id": "APP_ID",
+    "name": "iOS Beta Testers",
+    "auto_notify": true
+  }'
+```
+
+Setting `auto_notify: true` means testers are automatically emailed when a new build is uploaded.
+
+### Adding testers to a group
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/build-distributions/v1/tester-groups/GROUP_ID/add-testers" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_slugs": ["USER_SLUG_1", "USER_SLUG_2"]
+  }'
+```
+
+:::tip[Finding user slugs]
+
+To find the user slugs of workspace members, use `GET /tester-groups/{id}/potential-testers?search=name-or-email` to search for eligible testers. The response includes each user's `slug`.
+
+:::
+
+### Notifying a tester group
+
+Send a notification to a tester group about a specific build:
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/build-distributions/v1/tester-groups/GROUP_ID/notify" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "test_build_id": "ARTIFACT_ID"
+  }'
+```
+
+The build must be distribution-ready before you can notify testers. A successful call returns `204 No Content`.
+
+## Listing uploaded builds
+
+To list all builds available for distribution for a specific version:
+
+```bash
+curl -X GET "https://api.bitrise.io/release-management/v2/build-distributions/v1/test-builds?app_id=APP_ID&version=1.5.0" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Accept: application/json"
+```

--- a/docs/release-management/api/creating-a-release.mdx
+++ b/docs/release-management/api/creating-a-release.mdx
@@ -14,8 +14,8 @@ The Store Releases sub-API base URL: `https://api.bitrise.io/release-management/
 
 ## Creating a release
 
-| Method | Path | Function | Required role |
-| --- | --- | --- | --- |
+| Endpoint | Function | Required role |
+| --- | --- | --- |
 | POST /app-versions | Create a new release. | Release manager |
 | GET /app-versions | List releases for an app. | Any |
 | GET /app-versions/\{id\} | Get details of a release. | Any |
@@ -35,44 +35,47 @@ To create a release:
 
    :::
 
-<Tabs groupId="platform">
-<TabItem value="ios" label="iOS">
-
-```bash
-curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions" \
-  -H "Authorization: YOUR_ACCESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "1.5.0",
-    "app_id": "APP_ID",
-    "description": "Spring feature release",
-    "artifact_source": "ci"
-  }'
-```
-
-</TabItem>
-<TabItem value="android" label="Android">
-
-```bash
-curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions" \
-  -H "Authorization: YOUR_ACCESS_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "name": "1.5.0",
-    "app_id": "APP_ID",
-    "description": "Spring feature release",
-    "artifact_source": "ci"
-  }'
-```
-
-</TabItem>
-</Tabs>
+   ```bash
+   curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions" \
+     -H "Authorization: YOUR_ACCESS_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "name": "1.5.0",
+       "app_id": "APP_ID",
+       "description": "Spring feature release",
+       "artifact_source": "ci"
+     }'
+   ```
 
    The response includes the release's `id`, which you'll use in subsequent calls.
 
+   ```json
+   {
+     "id": "YOUR_RELEASE_ID",
+     "name": "1.5.0",
+     "status": "scheduled",
+     "description": "Spring feature release",
+     "connected_app_id": "YOUR_APP_ID",
+     "artifact_source": "ci",
+     "platform": "android",
+     "store_app_id": "com.example.myapp",
+     "created_at": "2026-01-01T00:00:00.000Z",
+     "released_at": null,
+     "release_candidate_id": null,
+     "stages": [
+       { "name": "release-candidate", "status": "pending" },
+       { "name": "approvals", "status": "pending" },
+       { "name": "app-store-review", "status": "pending" },
+       { "name": "release", "status": "pending" }
+     ]
+   }
+   ```
+
 ## Configuring release automation
 
-You can define automation rules that trigger CI builds automatically when a release reaches a certain stage. Set the `automation` field when creating or updating a release:
+You can define automation rules that trigger CI builds automatically when a release reaches a certain stage. For a full overview of how automation works, see [Release automation](/en/release-management/releases/configuring-a-release/release-automation).
+
+Set the `automation` field when creating or updating a release:
 
 ```bash
 curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions" \
@@ -129,13 +132,13 @@ Available `stage` values: `release-candidate`, `approvals`, `testflight-upload`,
 
 ## Adding approval tasks to a release
 
-You can create approval tasks that team members must complete before the release proceeds.
-
-| Method | Path | Function | Required role |
-| --- | --- | --- | --- |
+| Endpoint | Function | Required role |
+| --- | --- | --- |
 | POST /app-versions/\{id\}/approvals | Create an approval task. | Release manager |
 | GET /app-versions/\{id\}/approvals | List approval tasks. | Any |
 | PATCH /app-versions/\{id\}/approvals/\{task\_id\} | Update or complete an approval task. | Assigned user |
+
+You can create approval tasks that team members must complete before the release proceeds.
 
 ```bash
 curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/approvals" \
@@ -174,3 +177,18 @@ curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app
     "presets_id": "PRESET_ID"
   }'
 ```
+
+## Deleting a release
+
+:::warning[Deletion is permanent]
+
+Deleting a release removes it and all associated data. This cannot be undone.
+
+:::
+
+```bash
+curl -X DELETE "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID" \
+  -H "Authorization: YOUR_ACCESS_TOKEN"
+```
+
+A successful response returns `204 No Content` with an empty body.

--- a/docs/release-management/api/creating-a-release.mdx
+++ b/docs/release-management/api/creating-a-release.mdx
@@ -1,0 +1,176 @@
+---
+title: "Creating a release"
+description: "Create and configure a release for your app via the Release Management API."
+sidebar_position: 3
+slug: /release-management/api/creating-a-release
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+A release represents a version of your app going through the release process — from the release candidate stage through approvals, store submission, and production release.
+
+The Store Releases sub-API base URL: `https://api.bitrise.io/release-management/v2/store-releases/v1`
+
+## Creating a release
+
+| Method | Path | Function | Required role |
+| --- | --- | --- | --- |
+| POST /app-versions | Create a new release. | Release manager |
+| GET /app-versions | List releases for an app. | Any |
+| GET /app-versions/\{id\} | Get details of a release. | Any |
+| PATCH /app-versions/\{id\} | Update a release. | Release manager |
+| DELETE /app-versions/\{id\} | Delete a release. | Release manager |
+
+To create a release:
+
+1. Call `POST /app-versions` with the required fields:
+
+   - `name`: The version name for this release.
+   - `app_id`: The ID of the app in Release Management (returned when you [added the app](/en/release-management/api/adding-and-connecting-an-app)).
+
+   :::note[Version format for iOS]
+
+   For iOS apps, `name` is used as the App Store Connect version string and must follow the `X.Y.Z` format (e.g., `1.2.0`).
+
+   :::
+
+<Tabs groupId="platform">
+<TabItem value="ios" label="iOS">
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "1.5.0",
+    "app_id": "APP_ID",
+    "description": "Spring feature release",
+    "artifact_source": "ci"
+  }'
+```
+
+</TabItem>
+<TabItem value="android" label="Android">
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "1.5.0",
+    "app_id": "APP_ID",
+    "description": "Spring feature release",
+    "artifact_source": "ci"
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+   The response includes the release's `id`, which you'll use in subsequent calls.
+
+## Configuring release automation
+
+You can define automation rules that trigger CI builds automatically when a release reaches a certain stage. Set the `automation` field when creating or updating a release:
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "1.5.0",
+    "app_id": "APP_ID",
+    "artifact_source": "ci",
+    "release_branch": "release/1.5.0",
+    "workflow": "release",
+    "automation": [
+      {
+        "event_name": "release_candidate_set",
+        "workflow_name": "run-tests"
+      },
+      {
+        "event_name": "approvals_completed",
+        "workflow_name": "upload-to-store"
+      }
+    ]
+  }'
+```
+
+Available automation `event_name` values:
+
+- `release_candidate_set`: Triggered when a release candidate is assigned.
+- `testflight_upload_finished`: Triggered when the build finishes uploading to TestFlight (iOS only).
+- `approvals_completed`: Triggered when all approval tasks are marked complete.
+- `submitted_for_review`: Triggered when the app is submitted for store review.
+- `release_started`: Triggered when the app is released to the store.
+
+## Setting a release timeline
+
+You can define target dates for each stage of the release process:
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "1.5.0",
+    "app_id": "APP_ID",
+    "timeline": [
+      { "stage": "release-candidate", "target_date": "2026-07-01" },
+      { "stage": "approvals", "target_date": "2026-07-10" },
+      { "stage": "app-store-review", "target_date": "2026-07-15" },
+      { "stage": "release", "target_date": "2026-07-20" }
+    ]
+  }'
+```
+
+Available `stage` values: `release-candidate`, `approvals`, `testflight-upload`, `google-play-upload`, `app-store-review`, `release`.
+
+## Adding approval tasks to a release
+
+You can create approval tasks that team members must complete before the release proceeds.
+
+| Method | Path | Function | Required role |
+| --- | --- | --- | --- |
+| POST /app-versions/\{id\}/approvals | Create an approval task. | Release manager |
+| GET /app-versions/\{id\}/approvals | List approval tasks. | Any |
+| PATCH /app-versions/\{id\}/approvals/\{task\_id\} | Update or complete an approval task. | Assigned user |
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/approvals" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "summary": "QA sign-off",
+    "description": "Verify all test cases pass on the release build",
+    "assigned_user_slug": "USER_SLUG",
+    "due_date": "2026-07-10"
+  }'
+```
+
+To mark an approval task as complete:
+
+```bash
+curl -X PATCH "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/approvals/TASK_ID" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "completed": true
+  }'
+```
+
+## Applying a preset to a release
+
+If you have [release presets](/en/release-management/api/creating-presets) configured, apply one when creating the release to inherit its automation, approvals, and notification settings:
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "1.5.0",
+    "app_id": "APP_ID",
+    "presets_id": "PRESET_ID"
+  }'
+```

--- a/docs/release-management/api/creating-presets.mdx
+++ b/docs/release-management/api/creating-presets.mdx
@@ -11,41 +11,37 @@ The Apps sub-API base URL: `https://api.bitrise.io/release-management/v2/apps/v1
 
 ## Creating a preset
 
-| Method | Path | Function | Required role |
-| --- | --- | --- | --- |
+| Endpoint | Function | Required role |
+| --- | --- | --- |
 | POST /presets | Create a new preset. | Release manager |
 | GET /presets | List presets for an app. | Any |
 | GET /presets/\{id\} | Get a specific preset. | Any |
 | PUT /presets/\{id\} | Update a preset. | Release manager |
 | DELETE /presets/\{id\} | Delete a preset. | Release manager |
 
-To create a preset:
+To create a preset, call `POST /presets` with at least a name and the app it belongs to.
 
-1. Call `POST /presets` with at least a name and the app it belongs to.
+Required fields:
+- `app_id`: The ID of the app in Release Management.
+- `template_name`: A descriptive name for the preset.
 
-   Required fields:
-   - `app_id`: The ID of the app in Release Management.
-   - `template_name`: A descriptive name for the preset.
-
-   ```bash
-   curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/presets" \
-     -H "Authorization: YOUR_ACCESS_TOKEN" \
-     -H "Content-Type: application/json" \
-     -d '{
-       "app_id": "APP_ID",
-       "template_name": "Standard release"
-     }'
-   ```
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/presets" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "app_id": "APP_ID",
+    "template_name": "Standard release"
+  }'
+```
 
 ## Creating a preset with full configuration
 
-A preset can include automation rules, approval tasks, notifications, and CI build settings. The following example creates a preset that:
+A preset can bundle automation rules, approval tasks, Slack notifications, and upload settings into a single reusable template.
 
-- Triggers a `run-tests` workflow when the release candidate is set.
-- Triggers an `upload-to-store` workflow when approvals are complete.
-- Creates a QA approval task for each release.
-- Sends Slack notifications via a configured integration.
-- Enables automatic store upload after the build succeeds.
+### Automation
+
+Automation rules trigger a CI workflow when a release reaches a specific stage. Set the `automation` field to an array of event/workflow pairs:
 
 ```bash
 curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/presets" \
@@ -54,8 +50,6 @@ curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/presets" \
   -d '{
     "app_id": "APP_ID",
     "template_name": "Standard release",
-    "default": true,
-    "auto_upload": true,
     "automation": [
       {
         "event_name": "release_candidate_set",
@@ -65,20 +59,63 @@ curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/presets" \
         "event_name": "approvals_completed",
         "workflow_name": "upload-to-store"
       }
-    ],
+    ]
+  }'
+```
+
+### Approval tasks
+
+Approval tasks are created automatically for every release that uses this preset. Set the `approvals` field to define the tasks:
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/presets" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "app_id": "APP_ID",
+    "template_name": "Standard release",
     "approvals": [
       {
         "summary": "QA sign-off",
         "description": "Verify all test cases pass on the release build"
       }
-    ],
+    ]
+  }'
+```
+
+### Slack notifications
+
+To send Slack notifications at key release stages, pass the ID of a configured Slack integration in the `notifications` field. For more information, see [Slack integration](/en/bitrise-platform/workspaces/workspace-slack-integration).
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/presets" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "app_id": "APP_ID",
+    "template_name": "Standard release",
     "notifications": {
       "slack_notification_integration_id": "YOUR_SLACK_INTEGRATION_ID"
     }
   }'
 ```
 
-Save the `id` from the response — you'll use it when [creating releases](/en/release-management/api/creating-a-release#applying-a-preset-to-a-release).
+### Automatic store upload
+
+Set `auto_upload: true` to automatically upload the build to the store once it's ready, without a manual trigger:
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/presets" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "app_id": "APP_ID",
+    "template_name": "Standard release",
+    "auto_upload": true
+  }'
+```
+
+You can combine any of these settings in a single request. Save the `id` from the response — you'll use it when [creating releases](/en/release-management/api/creating-a-release#applying-a-preset-to-a-release).
 
 :::note[Default preset]
 
@@ -96,7 +133,7 @@ curl -X GET "https://api.bitrise.io/release-management/v2/apps/v1/presets?app_id
 
 ## Updating a preset
 
-Use `PUT /presets/{id}` to replace the preset's configuration. All fields except `template_name` and `app_id` are optional.
+Use `PUT /presets/{id}` to replace the preset's configuration. All fields are optional.
 
 ```bash
 curl -X PUT "https://api.bitrise.io/release-management/v2/apps/v1/presets/PRESET_ID" \

--- a/docs/release-management/api/creating-presets.mdx
+++ b/docs/release-management/api/creating-presets.mdx
@@ -1,0 +1,136 @@
+---
+title: "Creating and managing presets"
+description: "Create reusable release configuration templates (presets) via the Release Management API."
+sidebar_position: 4
+slug: /release-management/api/creating-presets
+---
+
+Presets are reusable release configuration templates. They let you define automation rules, approval tasks, notifications, and CI build settings once and apply them consistently across multiple releases.
+
+The Apps sub-API base URL: `https://api.bitrise.io/release-management/v2/apps/v1`
+
+## Creating a preset
+
+| Method | Path | Function | Required role |
+| --- | --- | --- | --- |
+| POST /presets | Create a new preset. | Release manager |
+| GET /presets | List presets for an app. | Any |
+| GET /presets/\{id\} | Get a specific preset. | Any |
+| PUT /presets/\{id\} | Update a preset. | Release manager |
+| DELETE /presets/\{id\} | Delete a preset. | Release manager |
+
+To create a preset:
+
+1. Call `POST /presets` with at least a name and the app it belongs to.
+
+   Required fields:
+   - `app_id`: The ID of the app in Release Management.
+   - `template_name`: A descriptive name for the preset.
+
+   ```bash
+   curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/presets" \
+     -H "Authorization: YOUR_ACCESS_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "app_id": "APP_ID",
+       "template_name": "Standard release"
+     }'
+   ```
+
+## Creating a preset with full configuration
+
+A preset can include automation rules, approval tasks, notifications, and CI build settings. The following example creates a preset that:
+
+- Triggers a `run-tests` workflow when the release candidate is set.
+- Triggers an `upload-to-store` workflow when approvals are complete.
+- Creates a QA approval task for each release.
+- Sends Slack notifications via a configured integration.
+- Enables automatic store upload after the build succeeds.
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/apps/v1/presets" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "app_id": "APP_ID",
+    "template_name": "Standard release",
+    "default": true,
+    "auto_upload": true,
+    "automation": [
+      {
+        "event_name": "release_candidate_set",
+        "workflow_name": "run-tests"
+      },
+      {
+        "event_name": "approvals_completed",
+        "workflow_name": "upload-to-store"
+      }
+    ],
+    "approvals": [
+      {
+        "summary": "QA sign-off",
+        "description": "Verify all test cases pass on the release build"
+      }
+    ],
+    "notifications": {
+      "slack_notification_integration_id": "YOUR_SLACK_INTEGRATION_ID"
+    }
+  }'
+```
+
+Save the `id` from the response — you'll use it when [creating releases](/en/release-management/api/creating-a-release#applying-a-preset-to-a-release).
+
+:::note[Default preset]
+
+Setting `default: true` marks this preset as the one automatically applied to new releases. Only one preset per app can be the default.
+
+:::
+
+## Listing presets for an app
+
+```bash
+curl -X GET "https://api.bitrise.io/release-management/v2/apps/v1/presets?app_id=APP_ID" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Accept: application/json"
+```
+
+## Updating a preset
+
+Use `PUT /presets/{id}` to replace the preset's configuration. All fields except `template_name` and `app_id` are optional.
+
+```bash
+curl -X PUT "https://api.bitrise.io/release-management/v2/apps/v1/presets/PRESET_ID" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "default": true,
+    "auto_upload": false,
+    "automation": [
+      {
+        "event_name": "release_candidate_set",
+        "workflow_name": "run-extended-tests"
+      }
+    ],
+    "approvals": [
+      {
+        "summary": "QA sign-off"
+      },
+      {
+        "summary": "Security review"
+      }
+    ]
+  }'
+```
+
+## Deleting a preset
+
+```bash
+curl -X DELETE "https://api.bitrise.io/release-management/v2/apps/v1/presets/PRESET_ID" \
+  -H "Authorization: YOUR_ACCESS_TOKEN"
+```
+
+:::important[Existing releases not affected]
+
+Deleting a preset does not affect releases that were created using it. The settings are copied to the release at creation time.
+
+:::

--- a/docs/release-management/api/release-management-api.mdx
+++ b/docs/release-management/api/release-management-api.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Release Management API"
 description: "Bitrise offers a REST API for Release Management: you can connect apps, configure presets, manage your releases, and distribute the apps via the API."
-sidebar_position: 7
-slug: /release-management/release-management-api
+sidebar_position: 1
+slug: /release-management/api/release-management-api
 sidebar_custom_props:
   icon: Code
 ---

--- a/docs/release-management/api/release-management-api.mdx
+++ b/docs/release-management/api/release-management-api.mdx
@@ -1,10 +1,8 @@
 ---
-title: "Release Management API"
+title: "Overview"
 description: "Bitrise offers a REST API for Release Management: you can connect apps, configure presets, manage your releases, and distribute the apps via the API."
 sidebar_position: 1
 slug: /release-management/api/release-management-api
-sidebar_custom_props:
-  icon: Code
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/release-management/api/releasing-an-app.mdx
+++ b/docs/release-management/api/releasing-an-app.mdx
@@ -1,0 +1,257 @@
+---
+title: "Releasing an app to the store"
+description: "Submit your app for review and release it to the App Store or Google Play via the Release Management API."
+sidebar_position: 6
+slug: /release-management/api/releasing-an-app
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Once your release has a release candidate and all approvals are completed, you can submit the app for store review and then release it to users.
+
+The Store Releases sub-API base URL: `https://api.bitrise.io/release-management/v2/store-releases/v1`
+
+## Configuring beta distribution
+
+Before submitting for full release, you can distribute the build to beta testers through TestFlight (iOS) or internal tracks (Android).
+
+<Tabs groupId="platform">
+<TabItem value="ios" label="iOS (TestFlight)">
+
+### Listing TestFlight testing groups
+
+```bash
+curl -X GET "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/beta-distribution/testing-groups" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Accept: application/json"
+```
+
+### Starting beta distribution to a TestFlight group
+
+```bash
+curl -X PATCH "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/beta-distribution/testing-groups/GROUP_ID" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+### Adding what-to-test notes for TestFlight
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/beta-distribution/what-to-test" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "locale": "en-US",
+    "whats_new": "Fixed login issue and improved onboarding flow."
+  }'
+```
+
+</TabItem>
+<TabItem value="android" label="Android (Google Play)">
+
+### Adding release notes
+
+```bash
+curl -X PUT "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/google-play-store/localized-release-notes" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "release_notes": [
+      {
+        "language": "en-US",
+        "text": "Fixed login issue and improved onboarding flow."
+      },
+      {
+        "language": "de-DE",
+        "text": "Login-Problem behoben und Onboarding-Flow verbessert."
+      }
+    ]
+  }'
+```
+
+Each release note text can be up to 500 characters.
+
+</TabItem>
+</Tabs>
+
+## Submitting for store review
+
+<Tabs groupId="platform">
+<TabItem value="ios" label="iOS">
+
+| Method | Path | Function | Required role |
+| --- | --- | --- | --- |
+| POST /app-versions/\{id\}/apple-app-store/review/submit | Submit the release for App Store review. | Release manager |
+| GET /app-versions/\{id\}/apple-app-store/review/status | Get the current App Store review status. | Any |
+| POST /app-versions/\{id\}/apple-app-store/review/cancel | Cancel a pending review submission. | Release manager |
+
+Submit the release for App Store review:
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/apple-app-store/review/submit" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "copy_primary_whats_new": true,
+    "localizations": [
+      {
+        "locale": "en-US",
+        "whats_new": "Bug fixes and performance improvements.",
+        "description": "Updated description for this version.",
+        "keywords": "productivity, task manager"
+      }
+    ]
+  }'
+```
+
+Setting `copy_primary_whats_new: true` copies the primary locale's "What's new" text to all other localizations that have no text set.
+
+To check the review status:
+
+```bash
+curl -X GET "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/apple-app-store/review/status" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Accept: application/json"
+```
+
+</TabItem>
+<TabItem value="android" label="Android">
+
+Android releases submitted via the API go directly to the configured Google Play track and do not require a separate review submission step. Proceed to the release step below.
+
+</TabItem>
+</Tabs>
+
+## Configuring release settings
+
+<Tabs groupId="platform">
+<TabItem value="ios" label="iOS">
+
+Before releasing, configure how the update rolls out to users:
+
+```bash
+curl -X PATCH "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/apple-app-store/release/settings" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "release_type": "AFTER_APPROVAL",
+    "phased_release": true
+  }'
+```
+
+`release_type` options:
+- `AFTER_APPROVAL`: Release automatically once approved by Apple.
+- `MANUAL`: Hold the release until you manually trigger it.
+- `SCHEDULED`: Release at a specific date and time (requires `earliest_release_date` in ISO 8601 format).
+
+`phased_release: true` rolls the update out to users over 7 days rather than all at once.
+
+</TabItem>
+<TabItem value="android" label="Android">
+
+For Android you can schedule the rollout to a fraction of users (staged rollout):
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/google-play-store/staged-rollout-schedule" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "location": "America/New_York",
+    "schedule": [
+      { "percentage": 10, "when": "2026-07-20T09:00:00-04:00" },
+      { "percentage": 50, "when": "2026-07-22T09:00:00-04:00" },
+      { "percentage": 100, "when": "2026-07-25T09:00:00-04:00" }
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Releasing to users
+
+<Tabs groupId="platform">
+<TabItem value="ios" label="iOS">
+
+| Method | Path | Function | Required role |
+| --- | --- | --- | --- |
+| POST /app-versions/\{id\}/apple-app-store/release | Release the app to the App Store. | Release manager |
+| GET /app-versions/\{id\}/apple-app-store/release/status | Get the release status. | Any |
+| POST /app-versions/\{id\}/apple-app-store/release/pause | Pause a phased release. | Release manager |
+| POST /app-versions/\{id\}/apple-app-store/release/continue | Continue a paused phased release. | Release manager |
+| POST /app-versions/\{id\}/apple-app-store/release/complete | Complete a phased release immediately. | Release manager |
+
+Trigger the release:
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/apple-app-store/release" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+Check the release status:
+
+```bash
+curl -X GET "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/apple-app-store/release/status" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Accept: application/json"
+```
+
+To complete a phased release immediately (rolling out to 100% of users right away):
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/apple-app-store/release/complete" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+</TabItem>
+<TabItem value="android" label="Android">
+
+| Method | Path | Function | Required role |
+| --- | --- | --- | --- |
+| POST /app-versions/\{id\}/google-play-store/release | Release to all or a fraction of users. | Release manager |
+
+Release to all users:
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/google-play-store/release" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_fraction": 1.0
+  }'
+```
+
+For a staged rollout starting at 10%:
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/google-play-store/release" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_fraction": 0.1
+  }'
+```
+
+The `user_fraction` value ranges from `0` to `1`, where `1` equals 100% of users.
+
+</TabItem>
+</Tabs>
+
+## Setting up release webhooks
+
+You can configure outgoing webhooks to receive notifications when a release reaches key stages.
+
+```bash
+curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/outgoing-webhooks" \
+  -H "Authorization: YOUR_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "events": ["release_started", "submitted_for_review"],
+    "webhook_configuration_id": "WEBHOOK_CONFIG_ID"
+  }'
+```
+
+Set `all_events: true` instead of listing individual events to receive notifications for all release lifecycle events.

--- a/docs/release-management/api/releasing-an-app.mdx
+++ b/docs/release-management/api/releasing-an-app.mdx
@@ -12,14 +12,13 @@ Once your release has a release candidate and all approvals are completed, you c
 
 The Store Releases sub-API base URL: `https://api.bitrise.io/release-management/v2/store-releases/v1`
 
-## Configuring beta distribution
+## Configuring beta distribution (iOS)
 
-Before submitting for full release, you can distribute the build to beta testers through TestFlight (iOS) or internal tracks (Android).
-
-<Tabs groupId="platform">
-<TabItem value="ios" label="iOS (TestFlight)">
+Before submitting for full release, you can distribute the build to beta testers through TestFlight (iOS only).
 
 ### Listing TestFlight testing groups
+
+Returns the TestFlight testing groups associated with the release. Use the `id` values from the response to start distribution to a specific group.
 
 ```bash
 curl -X GET "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/beta-distribution/testing-groups" \
@@ -29,6 +28,8 @@ curl -X GET "https://api.bitrise.io/release-management/v2/store-releases/v1/app-
 
 ### Starting beta distribution to a TestFlight group
 
+Makes the release build available to testers in a specific TestFlight group. Testers receive a notification and can install the build directly from the TestFlight app.
+
 ```bash
 curl -X PATCH "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/beta-distribution/testing-groups/GROUP_ID" \
   -H "Authorization: YOUR_ACCESS_TOKEN" \
@@ -36,6 +37,8 @@ curl -X PATCH "https://api.bitrise.io/release-management/v2/store-releases/v1/ap
 ```
 
 ### Adding what-to-test notes for TestFlight
+
+Attaches testing instructions to the release build. Testers see these notes in the TestFlight app when they receive the build notification.
 
 ```bash
 curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/beta-distribution/what-to-test" \
@@ -47,10 +50,11 @@ curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app
   }'
 ```
 
-</TabItem>
-<TabItem value="android" label="Android (Google Play)">
+## Adding release notes (Android)
 
-### Adding release notes
+Release notes appear on the app's Google Play Store listing under **What's new**, and are shown to users before and after they update the app. You can provide notes in multiple languages — Google Play displays the version that matches the user's device language, falling back to `en-US` if no match is found.
+
+Pass an array of language/text pairs to the `release_notes` field, using [BCP 47 language tags](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) (e.g. `en-US`, `de-DE`, `fr-FR`):
 
 ```bash
 curl -X PUT "https://api.bitrise.io/release-management/v2/store-releases/v1/app-versions/RELEASE_ID/google-play-store/localized-release-notes" \
@@ -72,16 +76,16 @@ curl -X PUT "https://api.bitrise.io/release-management/v2/store-releases/v1/app-
 
 Each release note text can be up to 500 characters.
 
-</TabItem>
-</Tabs>
+## Submitting for store review (iOS)
 
-## Submitting for store review
+:::note[Android]
 
-<Tabs groupId="platform">
-<TabItem value="ios" label="iOS">
+Android releases submitted via the API go directly to the configured Google Play track and do not require a separate review submission step. Proceed to the release step below.
 
-| Method | Path | Function | Required role |
-| --- | --- | --- | --- |
+:::
+
+| Endpoint | Function | Required role |
+| --- | --- | --- |
 | POST /app-versions/\{id\}/apple-app-store/review/submit | Submit the release for App Store review. | Release manager |
 | GET /app-versions/\{id\}/apple-app-store/review/status | Get the current App Store review status. | Any |
 | POST /app-versions/\{id\}/apple-app-store/review/cancel | Cancel a pending review submission. | Release manager |
@@ -114,14 +118,6 @@ curl -X GET "https://api.bitrise.io/release-management/v2/store-releases/v1/app-
   -H "Authorization: YOUR_ACCESS_TOKEN" \
   -H "Accept: application/json"
 ```
-
-</TabItem>
-<TabItem value="android" label="Android">
-
-Android releases submitted via the API go directly to the configured Google Play track and do not require a separate review submission step. Proceed to the release step below.
-
-</TabItem>
-</Tabs>
 
 ## Configuring release settings
 
@@ -174,8 +170,8 @@ curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app
 <Tabs groupId="platform">
 <TabItem value="ios" label="iOS">
 
-| Method | Path | Function | Required role |
-| --- | --- | --- | --- |
+| Endpoint | Function | Required role |
+| --- | --- | --- |
 | POST /app-versions/\{id\}/apple-app-store/release | Release the app to the App Store. | Release manager |
 | GET /app-versions/\{id\}/apple-app-store/release/status | Get the release status. | Any |
 | POST /app-versions/\{id\}/apple-app-store/release/pause | Pause a phased release. | Release manager |
@@ -209,8 +205,8 @@ curl -X POST "https://api.bitrise.io/release-management/v2/store-releases/v1/app
 </TabItem>
 <TabItem value="android" label="Android">
 
-| Method | Path | Function | Required role |
-| --- | --- | --- | --- |
+| Endpoint | Function | Required role |
+| --- | --- | --- |
 | POST /app-versions/\{id\}/google-play-store/release | Release to all or a fraction of users. | Release manager |
 
 Release to all users:

--- a/docs/release-management/codepush/creating-a-codepush-deployment.mdx
+++ b/docs/release-management/codepush/creating-a-codepush-deployment.mdx
@@ -12,7 +12,7 @@ import Partial_ReleaseManagementConfiguration from '@site/src/partials/release-m
 
 Create a CodePush deployment to get your deployment key. You need the deployment key to release CodePush updates to your apps.
 
-You can create a deployment either via the [API](/en/release-management/release-management-api) or on the Release Management GUI.
+You can create a deployment either via the [API](/en/release-management/api/release-management-api) or on the Release Management GUI.
 
 <Tabs>
   <TabItem value="gui" label="GUI">
@@ -33,7 +33,7 @@ You can create a deployment either via the [API](/en/release-management/release-
 
   1. Make sure you have a [personal access token](/en/bitrise-platform/accounts/personal-access-tokens#creating-a-personal-access-token) or a [workspace API token](/en/bitrise-platform/workspaces/workspace-api-token#creating-a-workspace-api-token).
 
-     A token is required for authorization with the [Release Management API](/en/release-management/release-management-api).
+     A token is required for authorization with the [Release Management API](/en/release-management/api/release-management-api).
   1. For each React Native project, make sure you have [two apps](/en/release-management/getting-started-with-release-management/adding-a-new-app-to-release-management) in Release Management: one for iOS, one for Android.
   1. Get the app ID for each app. You can see it in the URL of the app page: https://app.bitrise.io/release-management/workspaces/<worskspace-id>/connected-apps/<connected-app-id>.
 

--- a/docs/release-management/index.mdx
+++ b/docs/release-management/index.mdx
@@ -71,7 +71,7 @@ import ProductOverview from '@site/src/components/ProductOverview';
         },
         {
           label: 'Release Management API',
-          href: '/en/release-management/release-management-api',
+          href: '/en/release-management/api/release-management-api',
           description: 'Bitrise provides a REST API for Release Management, which offers the same features as the GUI.',
         },
       ],

--- a/docs/release-management/releases/managing-the-release-process/creating-tasks-for-the-approvals-stage.md
+++ b/docs/release-management/releases/managing-the-release-process/creating-tasks-for-the-approvals-stage.md
@@ -36,7 +36,7 @@ When done, you can proceed to:
 
 ## Assigning an approval task to a team member with the REST API
 
-You can assign an approval task to a team member with the help of our [Release Management API](/en/release-management/release-management-api). For more information on our API endpoint, check out our [API docs](https://api-docs.bitrise.io/).
+You can assign an approval task to a team member with the help of our [Release Management API](/en/release-management/api/release-management-api). For more information on our API endpoint, check out our [API docs](https://api-docs.bitrise.io/).
 
 :::note[Limited access]
 

--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -1,0 +1,122 @@
+<head>
+  <link rel="alternate" type="application/rss+xml" title="Bitrise Docs changelog" href="/changelog.xml" />
+</head>
+
+<a href="/changelog.xml" className="changelog-subscribe-btn" target="_blank" rel="noopener noreferrer">
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19.01 7.38 20 6.18 20 4.98 20 4 19.01 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/></svg>
+  Subscribe to RSS
+</a>
+
+<!-- changelog-entries -->
+
+## 2026 June
+
+### <time dateTime="2026-06-18">2026-06-18</time> Release Management API: new how-to guides {#2026-06-18-release-management-api-new-how-to-guides}
+
+The Release Management API section now includes step-by-step guides for the most common workflows: adding and connecting an app, creating releases and presets, releasing to the App Store or Google Play, and distributing builds to tester groups via custom access links. See [Release Management API](/en/release-management/api/release-management-api) to get started.
+
+### <time dateTime="2026-06-17">2026-06-17</time> GitHub App integration: event subscriptions clarified {#2026-06-17-github-app-integration-event-subscriptions-clarified}
+
+The [GitHub App integration](/en/bitrise-platform/repository-access/github-app-integration) page now has an Event subscriptions section explaining that the Bitrise GitHub App subscribes to `push`, `pull_request`, and `issue_comment` events via GitHub's app installation mechanism, not through repo-level webhooks. The section also warns that any existing manual webhooks pointing to `hooks.bitrise.io` must be removed after switching to the GitHub App to avoid duplicate builds.
+
+### <time dateTime="2026-06-15">2026-06-15</time> Bitrise MCP: new registration tools and API group {#2026-06-15-bitrise-mcp-new-registration-tools-and-api-group}
+
+The Bitrise MCP server now includes a `registration` API group with two unauthenticated tools — `register` and `verify_registration` — that let an AI agent onboard a brand-new Bitrise user without a token. The agent sends a one-time password to the user's email via `register`, then calls `verify_registration` with the OTP to receive a personal access token. These tools are most useful with the remote (HTTP) MCP server. See [Bitrise MCP tools](/en/bitrise-platform/ai/bitrise-mcp/tools) for the full reference.
+
+### <time dateTime="2026-06-15">2026-06-15</time> Bitrise MCP: install guides added for six tools {#2026-06-15-bitrise-mcp-install-guides-added-for-six-tools}
+
+Step-by-step install guides for the Bitrise MCP server are now available for VS Code, Cursor, Claude, Windsurf, Kiro, Gemini CLI, and other Copilot-compatible IDEs. Each guide covers how to configure the MCP server and authenticate with your Bitrise token. See [Bitrise MCP](/en/bitrise-platform/ai/bitrise-mcp) to get started.
+
+### <time dateTime="2026-06-11">2026-06-11</time> Workflow Editor can now push bitrise.yml directly to the repository {#2026-06-11-workflow-editor-can-now-push-bitrise-yml-directly-to-the-repository}
+
+The Workflow Editor now supports pushing changes to a repository-stored `bitrise.yml` directly from the editor — either to the current branch or a new branch — without manually copying and committing. See [Storing an app's configuration YAML](/en/bitrise-ci/configure-builds/configuration-yaml/storing-an-apps-configuration-yaml) for the updated flow.
+
+### <time dateTime="2026-06-10">2026-06-10</time> Build Hub: Gradle dependency mirroring explained {#2026-06-10-build-hub-gradle-dependency-mirroring-explained}
+
+The Build Hub documentation now includes an explanation of how Gradle dependency mirroring works, giving you a clearer picture of caching behaviour for Gradle projects running on Build Hub.
+
+### <time dateTime="2026-06-09">2026-06-09</time> Configuration YAML docs updated for YAML/Visual mode switcher {#2026-06-09-configuration-yaml-docs-updated-for-yaml-visual-mode-switcher}
+
+References throughout the docs have been updated to reflect the new toggle between YAML and Visual editing modes in the Workflow Editor. Where instructions previously referred to the left navigation menu, they now point to the **YAML** toggle at the top of the editor.
+
+### <time dateTime="2026-06-08">2026-06-08</time> New guide: Maven Central repository manager {#2026-06-08-new-guide-maven-central-repository-manager}
+
+A new guide covering the Maven Central repository manager is now available under [Build Cache getting started](/en/bitrise-build-cache/getting-started-with-the-build-cache/maven-central-repository-manager). It explains how Bitrise's proxy cache works for Maven dependencies, covers special cases like dependency verification and custom Docker images, and documents the opt-out process.
+
+### <time dateTime="2026-06-08">2026-06-08</time> Bitrise MCP server: OAuth is now the primary authentication method {#2026-06-08-bitrise-mcp-server-oauth-is-now-the-primary-authentication-method}
+
+The Bitrise MCP server now uses OAuth as the primary authentication method. See [Bitrise MCP](/en/bitrise-platform/ai/bitrise-mcp) for the updated setup steps.
+
+## 2026 May
+
+### <time dateTime="2026-05-29">2026-05-29</time> Build distribution: custom access links for installable artifacts {#2026-05-29-build-distribution-custom-access-links-for-installable-artifacts}
+
+In Release Management, you can now create shareable install links. See [Custom access links](/en/release-management/build-distribution/distributing-builds-to-testers#custom-access-link) for details.
+
+### <time dateTime="2026-05-28">2026-05-28</time> Modular YAML: increased file and nesting limits for GitHub users {#2026-05-28-modular-yaml-increased-file-and-nesting-limits-for-github-users}
+
+The modular YAML configuration guide has been updated to reflect the new, higher file count and nesting limits for GitHub users. See [Modular YAML configuration](/en/bitrise-ci/configure-builds/configuration-yaml/modular-yaml-configuration) for the updated limits.
+
+### <time dateTime="2026-05-20">2026-05-20</time> Python projects now supported {#2026-05-20-python-projects-now-supported}
+
+Bitrise now detects Python projects automatically and offers default workflows. The [Default workflows](/en/bitrise-ci/workflows-and-pipelines/workflows/default-workflows) and [Getting started with web CI](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci) guides have been updated to include Python.
+
+## 2026 April
+
+### <time dateTime="2026-04-20">2026-04-20</time> Next.js and Flutter Web project types documented {#2026-04-20-next-js-and-flutter-web-project-types-documented}
+
+The [Getting started with web CI](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci) guide and [Default workflows](/en/bitrise-ci/workflows-and-pipelines/workflows/default-workflows) page now cover Next.js (as an extension of Node.js) and Flutter Web project types.
+
+## 2026 March
+
+### <time dateTime="2026-03-30">2026-03-30</time> M4 machine type added to build machine docs {#2026-03-30-m4-machine-type-added-to-build-machine-docs}
+
+The [Build machine types](/en/bitrise-platform/infrastructure/build-machines/build-machine-types) page now lists the M4 machine type alongside the existing M4 Pro, M2 Pro, and M1 options, with region availability for each.
+
+### <time dateTime="2026-03-25">2026-03-25</time> Ruby projects now supported {#2026-03-25-ruby-projects-now-supported}
+
+Bitrise now detects Ruby projects automatically and offers default workflows. The [Getting started with web CI](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci) guide has been updated to include Ruby.
+
+### <time dateTime="2026-03-24">2026-03-24</time> Pro Trial: credit card required to access the full trial {#2026-03-24-pro-trial-credit-card-required-to-access-the-full-trial}
+
+New users now need to provide a valid credit card (which won't be charged) to access the full Pro Trial. The [Getting started with Bitrise CI](/en/bitrise-ci/getting-started/getting-started) guide has been updated to explain this.
+
+### <time dateTime="2026-03-20">2026-03-20</time> New page: build artifact retention policy {#2026-03-20-new-page-build-artifact-retention-policy}
+
+A dedicated [Build artifact retention policy](/en/bitrise-ci/run-and-analyze-builds/managing-build-files/artifact-retention-policy) page is now available, covering default retention periods by artifact type, extended retention options for enterprise customers, and the edge case around transferred projects.
+
+### <time dateTime="2026-03-10">2026-03-10</time> Xcode compilation cache: new flag to disable caching without disabling analytics {#2026-03-10-xcode-compilation-cache-new-flag-to-disable-caching-without-disabling-analytics}
+
+The [Xcode compilation cache FAQ](/en/bitrise-build-cache/build-cache-for-xcode/xcode-compilation-cache-faq) now documents the `--no-bitrise-build-cache` flag, which lets you disable caching temporarily while keeping analytics and build history intact.
+
+## 2026 February
+
+### <time dateTime="2026-02-20">2026-02-20</time> Build Cache: clear cache button replaces Settings dropdown {#2026-02-20-build-cache-clear-cache-button-replaces-settings-dropdown}
+
+The [Clearing the Build Cache](/en/bitrise-build-cache/getting-started-with-the-build-cache/clearing-the-build-cache) guide has been updated to reflect the current UI: the Settings dropdown was replaced by a **Clear Cache** button. The guide includes a new screenshot and a note that clearing the cache requires Workspace owner permissions.
+
+### <time dateTime="2026-02-20">2026-02-20</time> New guide: Endpoint Detection and Response (EDR) on Bitrise {#2026-02-20-new-guide-endpoint-detection-and-response-edr-on-bitrise}
+
+A new page under Integrations explains how Bitrise uses Endpoint Detection and Response (EDR) as part of its corporate security program, and clarifies that EDR agents are not deployed on Bitrise-hosted CI runners.
+
+### <time dateTime="2026-02-13">2026-02-13</time> OIDC for AWS guide updated {#2026-02-13-oidc-for-aws-guide-updated}
+
+The [OIDC for AWS](/en/bitrise-platform/integrations/oidc-authentication/oidc-for-aws) guide has been updated with additional clarifications on configuration and usage.
+
+### <time dateTime="2026-02-03">2026-02-03</time> New guide: GitHub App migration API {#2026-02-03-new-guide-github-app-migration-api}
+
+A new guide explains how to use the Bitrise API to bulk-migrate projects from OAuth-based GitHub connections to the GitHub App integration, including caveats about reverting the migration. See [Adding and managing apps](/en/bitrise-ci/api/adding-and-managing-apps) for details.
+
+## 2026 January
+
+### <time dateTime="2026-01-27">2026-01-27</time> Tool setup: new tool versions added {#2026-01-27-tool-setup-new-tool-versions-added}
+
+The [Configuring tool versions](/en/bitrise-ci/configure-builds/configuring-build-settings/configuring-tool-versions) guide has been updated with newly supported tool versions in the tool setup feature.
+
+### <time dateTime="2026-01-19">2026-01-19</time> Build artifact retention policy documented {#2026-01-19-build-artifact-retention-policy-documented}
+
+The [Build artifacts](/en/bitrise-ci/run-and-analyze-builds/managing-build-files/build-artifacts-online) page now includes a section on the artifact retention policy, covering default retention periods by artifact type and options for Enterprise customers. The policy takes effect on March 31, 2026.
+
+### <time dateTime="2026-01-12">2026-01-12</time> Pipeline rebuild: dynamic parallel workflows explained {#2026-01-12-pipeline-rebuild-dynamic-parallel-workflows-explained}
+
+The guide on rebuilding failed pipelines now includes an explanation of how dynamic parallel Workflows affect rebuild options — specifically, when you can rebuild individual Workflows versus all unsuccessful ones. See [Rebuilding a failed build](/en/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/rebuilding-a-failed-build#rebuilding-a-failed-pipeline) for details.


### PR DESCRIPTION
## Summary

- Adds five new how-to guides under the Release Management API section: adding and connecting an app, creating releases, creating presets, releasing an app, and distributing builds to testers
- Adds the `update-changelog` slash command to this branch (carried over from `main`)
- Adds a changelog entry for the new guides

## Test plan

- [ ] Check the new guides render correctly under `/en/release-management/api/`
- [ ] Verify internal links within the guides resolve
- [ ] Confirm changelog entry appears at the top of the June 2026 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)