### PR TITLE
Update CodePush module links from CodePushNext to bitrise-io org

### DIFF
--- a/docs/release-management/codepush/about-codepush.mdx
+++ b/docs/release-management/codepush/about-codepush.mdx
@@ -14,7 +14,7 @@ Bitrise offers a hosted CodePush Server, integrated with Bitrise authentication.
 CodePush enables React Native developers to deploy mobile app updates directly to their users' devices. The service consists of two parts:
 
 - CodePush Server, where developers can publish app updates. Accessing the Bitrise CodePush Server requires setting up a CodePush deployment: [Creating a CodePush deployment](/en/release-management/codepush/creating-a-codepush-deployment).
-- The open source [React Native Module for CodePush](https://github.com/CodePushNext/react-native-code-push) that enables querying for updates from within an app. The SDK supports React Native New Architecture and Expo: [Configuring your app for CodePush](/en/release-management/codepush/configuring-your-app-for-codepush).
+- The open source [React Native Module for CodePush](https://github.com/bitrise-io/react-native-code-push) that enables querying for updates from within an app. The SDK supports React Native New Architecture and Expo: [Configuring your app for CodePush](/en/release-management/codepush/configuring-your-app-for-codepush).
 
 Bitrise CodePush Server is based on the Microsoft CodePush Server and it is part of Release Management. You need a Release Management [app](/en/release-management/getting-started-with-release-management/adding-a-new-app-to-release-management) to be able to push update packages to the Bitrise CodePush Server via your CodePush deployment.
 

--- a/docs/release-management/codepush/code-signing-with-codepush.mdx
+++ b/docs/release-management/codepush/code-signing-with-codepush.mdx
@@ -27,7 +27,7 @@ CodePush code signing is done in three stages:
 
 1. Use version 5.1.0 or higher of the CodePushNext React Native SDK. Earlier versions don't support code signing.
 
-   You can find the SDK here: [CodePushNext repository](https://github.com/CodePushNext/react-native-code-push).
+   You can find the SDK here: [react-native-code-push repository](https://github.com/bitrise-io/react-native-code-push).
 1. Make sure the Bitrise CodePush CLI version is 1.0.0 or higher to take advantage of code signing features.
 1. Generate an RSA keypair in PEM format with Open SSL:
 
@@ -80,7 +80,7 @@ CodePush code signing is done in three stages:
 
 1. Use version 5.1.0 or higher of the CodePushNext React Native SDK. Earlier versions don't support code signing.
 
-   You can find the SDK here: [CodePushNext repository](https://github.com/CodePushNext/react-native-code-push).
+   You can find the SDK here: [react-native-code-push repository](https://github.com/bitrise-io/react-native-code-push).
 1. Make sure the Bitrise CodePush CLI version is 1.0.0 or higher to take advantage of code signing features.
 1. Generate an RSA keypair in PEM format with Open SSL:
 

--- a/docs/release-management/codepush/configuring-your-app-for-codepush.mdx
+++ b/docs/release-management/codepush/configuring-your-app-for-codepush.mdx
@@ -25,10 +25,10 @@ CodePush for React Native requires installing the SDK and then setting up CodePu
    ```
 1. Set up CodePush for iOS. You can find the most important instructions here: [iOS setup](#ios-setup).
 
-   Read more in the GitHub repository of the SDK: [iOS](https://github.com/CodePushNext/react-native-code-push/blob/master/docs/setup-ios.md).
+   Read more in the GitHub repository of the SDK: [iOS](https://github.com/bitrise-io/react-native-code-push/blob/master/docs/setup-ios.md).
 1. Set up CodePush for Android. You can find the most important instructions here: [Android setup](#android-setup).
 
-   Read more in the GitHub repository of the SDK: [Android](https://github.com/CodePushNext/react-native-code-push/blob/master/docs/setup-android.md).
+   Read more in the GitHub repository of the SDK: [Android](https://github.com/bitrise-io/react-native-code-push/blob/master/docs/setup-android.md).
 
 ### iOS setup
 


### PR DESCRIPTION
## Summary

- Updates all references to `github.com/CodePushNext/react-native-code-push` to `github.com/bitrise-io/react-native-code-push` across three files (`about-codepush.mdx`, `configuring-your-app-for-codepush.mdx`, `code-signing-with-codepush.mdx`)
- Updates stale "CodePushNext repository" link text to "react-native-code-push repository"

Closes #54

## Test plan

- [ ] All CodePush SDK links resolve to the correct `bitrise-io` repository

🤖 Generated with [Claude Code](https://claude.ai/claude-code)