### PR TITLE
Fix broken Paligo component references in CodePush auth doc

### DIFF
--- a/docs/release-management/codepush/codepush-cli-plugin/codepush-cli-plugin-authentication.md
+++ b/docs/release-management/codepush/codepush-cli-plugin/codepush-cli-plugin-authentication.md
@@ -12,13 +12,13 @@ If you have both, the Env Var is resolved first and takes priority.
 
 ## Authenticating with an Env Var
 
-1. [Generate a personal access token](urn:resource:component:54560) and copy it.
+1. [Generate a personal access token](/en/bitrise-platform/accounts/personal-access-tokens) and copy it.
 1. Add the value of the token to the BITRISE_API_TOKEN Environment Variable.
 1. When running a command with the plugin, the CLI resolves the Env Var automatically.
 
 ## Storing the token locally
 
-1. [Generate a personal access token](urn:resource:component:54560) and copy it.
+1. [Generate a personal access token](/en/bitrise-platform/accounts/personal-access-tokens) and copy it.
 1. Run the following command:
 
    ```bash


### PR DESCRIPTION
## Summary

- Replaces two `urn:resource:component:54560` Paligo migration artifacts with the correct internal link to `/en/bitrise-platform/accounts/personal-access-tokens`

## Test plan

- [ ] Both "Generate a personal access token" links in the CodePush CLI plugin authentication page resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)