### PR TITLE
fix: correct three content bugs in CodePush docs

### DIFF
--- a/docs/release-management/codepush/codepush-updates-with-bitrise-ci.mdx
+++ b/docs/release-management/codepush/codepush-updates-with-bitrise-ci.mdx
@@ -23,7 +23,7 @@ You can release your CodePush updates via a [Bitrise CI](/en/bitrise-ci) <GlossT
    - IOS_PROD_DEPLOYMENT_ID: The deployment ID for the iOS app.
    - ANDROID_PROD_DEPLOYMENT_ID: The deployment ID for the Android app.
    - IOS_CONNECTED_APP_ID: The app ID for the iOS app.
-   - ANDROID_CONNECTED_APP_ID: The app ID for the iOS app.
+   - ANDROID_CONNECTED_APP_ID: The app ID for the Android app.
 1. [Create Secrets](/en/bitrise-ci/configure-builds/secrets#setting-a-secret) for the deployment key and the API token:
 
    - IOS_PROD_DEPLOYMENT_KEY: The deployment key of the iOS deployment from Bitrise CodePush.

--- a/docs/release-management/codepush/configuring-your-app-for-codepush.mdx
+++ b/docs/release-management/codepush/configuring-your-app-for-codepush.mdx
@@ -38,7 +38,7 @@ CodePush for React Native requires installing the SDK and then setting up CodePu
 
    1. Add an import statement for CodePush headers:
 
-      ```python
+      ```swift
       import CodePush
       ```
    1. Find the following line of code:

--- a/docs/release-management/codepush/creating-a-codepush-deployment.mdx
+++ b/docs/release-management/codepush/creating-a-codepush-deployment.mdx
@@ -35,7 +35,7 @@ You can create a deployment either via the [API](/en/release-management/release-
 
      A token is required for authorization with the [Release Management API](/en/release-management/release-management-api).
   1. For each React Native project, make sure you have [two apps](/en/release-management/getting-started-with-release-management/adding-a-new-app-to-release-management) in Release Management: one for iOS, one for Android.
-  1. Get the app ID for each app. You can see it in the URL of the app page: https://app.bitrise.io/release-management/workspaces/<worskspace-id>/connected-apps/<connected-app-id>.
+  1. Get the app ID for each app. You can see it in the URL of the app page: https://app.bitrise.io/release-management/workspaces/<workspace-id>/connected-apps/<connected-app-id>.
 
      :::tip[ID from the API]
 


### PR DESCRIPTION
## Summary

- `ANDROID_CONNECTED_APP_ID` description incorrectly said "iOS app" instead of "Android app"
- Typo in example URL: `<worskspace-id>` → `<workspace-id>`
- Swift `import CodePush` code block had wrong language tag (`python` → `swift`)

## Test plan

- [ ] Verify the three changed lines look correct in the rendered docs