### PR TITLE
fix: wrap bare env var names in backticks in CodePush docs

### DIFF
--- a/docs/release-management/codepush/codepush-cli/setting-up-the-codepush-cli.mdx
+++ b/docs/release-management/codepush/codepush-cli/setting-up-the-codepush-cli.mdx
@@ -80,7 +80,7 @@ There are three ways to do so:
   ```bash
   bitrise :codepush push --server-url https://api.staging.bitrise.io
   ```
-- Export the $CODEPUSH_SERVER_URL Environment Variable:
+- Export the `CODEPUSH_SERVER_URL` Environment Variable:
 
   ```bash
   export CODEPUSH_SERVER_URL=https://api.staging.bitrise.io
@@ -94,6 +94,6 @@ There are three ways to do so:
 The server URL is resolved in the following order:
 
 1. The `--server-url` flag (highest priority)
-1. The CODEPUSH_SERVER_URL environment variable
+1. The `CODEPUSH_SERVER_URL` environment variable
 1. The `server_url` field in the `.codepush.json` file.
 1. Default: https://api.bitrise.io

--- a/docs/release-management/codepush/codepush-updates-with-bitrise-ci.mdx
+++ b/docs/release-management/codepush/codepush-updates-with-bitrise-ci.mdx
@@ -20,15 +20,15 @@ You can release your CodePush updates via a [Bitrise CI](/en/bitrise-ci) <GlossT
 1. [Get your credentials](/en/release-management/codepush/creating-and-releasing-codepush-updates#getting-your-codepush-credentials): you need the Release Management app IDs and the CodePush deployment IDs and deployment keys.
 1. [Create Environment Variables](/en/bitrise-ci/configure-builds/environment-variables#setting-an-env-var-in-the-workflow-editor) for the deployment IDs and the connected app IDs:
 
-   - IOS_PROD_DEPLOYMENT_ID: The deployment ID for the iOS app.
-   - ANDROID_PROD_DEPLOYMENT_ID: The deployment ID for the Android app.
-   - IOS_CONNECTED_APP_ID: The app ID for the iOS app.
-   - ANDROID_CONNECTED_APP_ID: The app ID for the Android app.
+   - `IOS_PROD_DEPLOYMENT_ID`: The deployment ID for the iOS app.
+   - `ANDROID_PROD_DEPLOYMENT_ID`: The deployment ID for the Android app.
+   - `IOS_CONNECTED_APP_ID`: The app ID for the iOS app.
+   - `ANDROID_CONNECTED_APP_ID`: The app ID for the Android app.
 1. [Create Secrets](/en/bitrise-ci/configure-builds/secrets#setting-a-secret) for the deployment key and the API token:
 
-   - IOS_PROD_DEPLOYMENT_KEY: The deployment key of the iOS deployment from Bitrise CodePush.
-   - ANDROID_PROD_DEPLOYMENT_KEY: The deployment key of the Android deployment from Bitrise CodePush.
-   - BITRISE_API_TOKEN: Your personal access token or <GlossTerm baseform="workspace">workspace</GlossTerm> API token.
+   - `IOS_PROD_DEPLOYMENT_KEY`: The deployment key of the iOS deployment from Bitrise CodePush.
+   - `ANDROID_PROD_DEPLOYMENT_KEY`: The deployment key of the Android deployment from Bitrise CodePush.
+   - `BITRISE_API_TOKEN`: Your personal access token or <GlossTerm baseform="workspace">workspace</GlossTerm> API token.
 
 
 ## Creating a Workflow for CodePush updates


### PR DESCRIPTION
## Summary

- Nine env var names used in prose were plain text; wrapped in backticks for monospace rendering
- Files affected: `codepush-updates-with-bitrise-ci.mdx` (7 names) and `setting-up-the-codepush-cli.mdx` (2 occurrences of `CODEPUSH_SERVER_URL`)

## Test plan

- [ ] Verify env var names render in monospace in the affected list items and numbered steps