### PR TITLE
Reword "triggers a native build" to "runs a build" in RN Build Cache docs

### DIFF
--- a/docs/bitrise-build-cache/build-cache-for-react-native/configuring-the-build-cache-for-react-native-in-non-bitrise-ci-environments.md
+++ b/docs/bitrise-build-cache/build-cache-for-react-native/configuring-the-build-cache-for-react-native-in-non-bitrise-ci-environments.md
@@ -11,7 +11,7 @@ The Bitrise Build Cache CLI can be downloaded and run on any third-party CI prov
 
    - BITRISE_BUILD_CACHE_AUTH_TOKEN: your Personal Access Token.
    - BITRISE_BUILD_CACHE_WORKSPACE_ID: your Workspace slug.
-1. Add the following script to your CI pipeline before any Step that triggers a native build.
+1. Add the following script to your CI pipeline before any Step that runs a build.
 
    It must run in the same environment (same shell, same container) as the build commands it's meant to accelerate.
 
@@ -39,7 +39,7 @@ The Bitrise Build Cache CLI can be downloaded and run on any third-party CI prov
    If you have previously used the Bitrise Build Cache CLI for Gradle or Xcode only, make sure you are on **CLI v1.0.0 or later** to get React Native support.
 
    :::
-1. After activation, the `bitrise-build-cache` binary is on PATH. Prefix any command that triggers a native build with `bitrise-build-cache react-native run`.
+1. After activation, the `bitrise-build-cache` binary is on PATH. Prefix any command that runs a build with `bitrise-build-cache react-native run`.
 
    :::note
 

--- a/docs/bitrise-build-cache/build-cache-for-react-native/configuring-the-build-cache-for-react-native-in-the-bitrise-ci-environment.mdx
+++ b/docs/bitrise-build-cache/build-cache-for-react-native/configuring-the-build-cache-for-react-native-in-the-bitrise-ci-environment.mdx
@@ -46,7 +46,7 @@ You can add the activation either through the <GlossTerm baseform="workflow edit
      - An active Bitrise Build Cache trial or subscription. You can check your subscription status on the [Bitrise Build Cache page](https://app.bitrise.io/build-cache/).
      - A React Native project that already builds successfully without Build Cache (so you have a clear baseline).
      - For iOS projects: **Xcode 26 or later**.
-  1. Add the `activate-build-cache-for-react-native` Step before any step that triggers a native build:
+  1. Add the `activate-build-cache-for-react-native` Step before any step that runs a build:
 
      ```yaml
      workflows:

--- a/docs/bitrise-build-cache/build-cache-for-react-native/react-native-cache-faq.md
+++ b/docs/bitrise-build-cache/build-cache-for-react-native/react-native-cache-faq.md
@@ -59,4 +59,4 @@ Anything else — including your `ccache.conf` — is yours to customize. Note t
 
 ## I'm using an official Bitrise step to build my app. Do I still need the wrapper?
 
-No. If you are using the latest versions of **Gradle Runner**, **Android Build**, or **Xcode Archive**, the wrapping is handled by the step itself — just make sure those steps are up to date. If you use a different official Bitrise step that triggers a native build, [let us know](https://github.com/bitrise-io/bitrise-build-cache-cli/issues) so we can add support.
+No. If you are using the latest versions of **Gradle Runner**, **Android Build**, or **Xcode Archive**, the wrapping is handled by the step itself — just make sure those steps are up to date. If you use a different official Bitrise step that runs a build, [let us know](https://github.com/bitrise-io/bitrise-build-cache-cli/issues) so we can add support.


### PR DESCRIPTION
## What

Reword "triggers a native build" → "runs a build" in the React Native Build Cache docs.

A build Step doesn't *trigger* a native build — it *runs* the build. This also drops the redundant "native" qualifier.

## Changes

Updated all 4 occurrences across 3 pages for consistency:

- `configuring-the-build-cache-for-react-native-in-the-bitrise-ci-environment.mdx` (line 49)
- `configuring-the-build-cache-for-react-native-in-non-bitrise-ci-environments.md` (lines 14, 42)
- `react-native-cache-faq.md` (line 62)

Docs-only / wording change. No functional impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)