### PR TITLE
Update changelog

### DIFF
--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -11,6 +11,14 @@
 
 ## 2026 June
 
+### <time dateTime="2026-06-19">2026-06-19</time> CodePush CLI docs expanded with full reference {#2026-06-19-codepush-cli-docs-expanded-with-full-reference}
+
+The CodePush CLI documentation has been expanded and restructured. A new reference page covers all commands, global flags, environment variables, and exit codes. The [Using the CodePush CLI](/en/release-management/codepush/codepush-cli/using-the-codepush-cli) page now includes workflow examples, JSON output, and Bitrise CI integration details. The code signing page adds a directory naming warning and a React Native >= 0.61 Android setup note. See [CodePush CLI](/en/release-management/codepush/codepush-cli).
+
+### <time dateTime="2026-06-18">2026-06-18</time> AI agent onboarding tip added to sign-up page {#2026-06-18-ai-agent-onboarding-tip-added-to-sign-up-page}
+
+The [Signing up for Bitrise](/en/bitrise-platform/getting-started/signing-up-for-bitrise) page now includes a tip pointing AI agents and coding assistants to the [dedicated onboarding runbook](/en/bitrise-platform/ai/onboarding-for-agents), which covers how to create a Bitrise account and connect everything directly from an agent session without a website visit.
+
 ### <time dateTime="2026-06-17">2026-06-17</time> GitHub App integration: event subscriptions clarified {#2026-06-17-github-app-integration-event-subscriptions-clarified}
 
 The [GitHub App integration](/en/bitrise-platform/repository-access/github-app-integration) page now has an Event subscriptions section explaining that the Bitrise GitHub App subscribes to `push`, `pull_request`, and `issue_comment` events via GitHub's app installation mechanism, not through repo-level webhooks. The section also warns that any existing manual webhooks pointing to `hooks.bitrise.io` must be removed after switching to the GitHub App to avoid duplicate builds.


### PR DESCRIPTION
## Summary

- CodePush CLI docs expanded with full reference (PR #58, 2026-06-19)
- AI agent onboarding tip added to sign-up page (PR #51, 2026-06-18)

Skipped: PRs #55, #56, #57, #59, #60 (link fixes, formatting, tab markup, corrections — no new information for readers).