### PR TITLE
docs: add Entra ID SCIM provisioning guide

### DIFF
--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-ad-fs-sso-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-ad-fs-sso-for-bitrise.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Setting up AD FS SSO for Bitrise"
+title: "AD FS SSO"
 description: "Add SAML SSO to your Bitrise Workspace using Microsoft Active Directory Federation Services."
 sidebar_position: 4
 slug: /bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-ad-fs-sso-for-bitrise

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-auth0-sso-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-auth0-sso-for-bitrise.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Setting up Auth0 SSO for Bitrise"
+title: "Auth0 SSO"
 description: "Add SAML SSO to your Bitrise Workspace using Auth0."
 sidebar_position: 5
 slug: /bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-auth0-sso-for-bitrise

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-azure-ad-sso-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-azure-ad-sso-for-bitrise.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Setting up Azure AD SSO for Bitrise"
+title: "Azure AD SSO"
 description: "Add SAML SSO to your Bitrise Workspace using Microsoft Entra ID."
 sidebar_position: 6
 slug: /bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-azure-ad-sso-for-bitrise
-sidebar_label: Setting up Entra ID (former Azure AD) SSO for Bitrise
+sidebar_label: Entra ID (former Azure AD) SSO
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-entra-id-scim-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-entra-id-scim-for-bitrise.mdx
@@ -1,0 +1,103 @@
+---
+title: "Setting up Entra ID SCIM for Bitrise"
+description: "Provision and deprovision Bitrise workspace members automatically using Microsoft Entra ID SCIM."
+sidebar_position: 7
+slug: /bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-entra-id-scim-for-bitrise
+sidebar_label: Setting up Entra ID SCIM for Bitrise
+---
+
+import GlossTerm from '@site/src/components/GlossTerm';
+
+Bitrise supports automatic user and group provisioning via [SCIM 2.0](https://scim.cloud/) with Microsoft Entra ID. Once configured, Entra ID becomes the authoritative source for workspace membership: users and group assignments are pushed to Bitrise automatically, and removing a user in Entra deactivates their access on Bitrise.
+
+## Before you start
+
+- SCIM provisioning requires an **Enterprise plan**.
+- You must have [SAML SSO configured](/en/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-azure-ad-sso-for-bitrise) between Bitrise and Entra ID before enabling SCIM.
+- You must have a [verified domain](/en/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-saml-sso-on-bitrise#verifying-your-domain). Domain verification can take up to 72 hours. SCIM credentials cannot be generated until at least one domain is verified.
+- You will need both the Bitrise Workspace owner and an Entra ID administrator available during setup.
+
+## Step 1: Generate SCIM credentials on Bitrise
+
+1. Open your <GlossTerm baseform="workspace">Workspace</GlossTerm> settings and select **Single sign-on** from the left menu.
+1. Select the **SCIM** tab.
+1. Click **Generate SCIM credentials**.
+1. Copy and save both values shown in the dialog:
+   - **SCIM base URL**
+   - **SCIM authentication token**
+
+   The token is not displayed again after you close the dialog. If you lose it, you can regenerate it, but doing so immediately invalidates the previous token.
+
+## Step 2: Configure SCIM provisioning in Entra ID
+
+Bitrise is not a gallery app in Entra ID. Use Microsoft's [tutorial for configuring SCIM with non-gallery applications](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups) and apply the following Bitrise-specific values:
+
+- **Tenant URL:** your SCIM base URL from Step 1
+- **Secret token:** your SCIM authentication token from Step 1
+- **Unique identifier field:** `userName` (mapped to the user's email address)
+
+When configuring **Provisioning Mode**, select **Automatic**. Use **Sync only assigned users and groups** to control which users and groups are pushed to Bitrise.
+
+:::important[Enable Push Groups]
+
+Workspace membership on Bitrise is managed through groups. You must enable group provisioning (Push Groups) so that Entra ID can manage group membership in Bitrise. Without it, users will be provisioned but not added to any group.
+
+:::
+
+## Step 3: Verify the connection
+
+Click **Test Connection** in the Entra ID provisioning configuration. This queries the Bitrise `/ServiceProviderConfig` endpoint and confirms that the credentials are valid. A successful test means Entra ID can reach Bitrise and authenticate correctly.
+
+## Attribute mapping
+
+Bitrise implements the SCIM 2.0 Core User Schema and Core Group Schema (RFC 7643/7644). Entra ID's default attribute mapping works without custom transforms.
+
+Supported user attributes: `userName`, `emails`, `name.givenName`, `name.familyName`, `active`, `externalId`.
+
+Supported group attributes: `displayName`, `members`.
+
+For workspace role assignment via the `roles` attribute, see [Managing workspace roles via SCIM](/en/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-scim#managing-workspace-roles-via-scim).
+
+## Group behavior
+
+**Name matching:** When Entra ID pushes a group, Bitrise links it to an existing group with the same name, or creates a new one. Matching is case-sensitive and exact. `ios_dev` and `iOS Dev` are treated as different groups. Make sure group names in Entra ID match your existing Bitrise group names exactly before enabling sync.
+
+**Entra ID becomes authoritative for membership:** Once Entra ID is syncing a group, it controls that group's membership. Any members added manually in Bitrise who are not in the corresponding Entra ID group will be removed on the next sync.
+
+**Protected groups:** Global Access groups and SAML default groups cannot be deleted via SCIM. Keep these groups out of Entra ID's sync scope to avoid unintended membership changes.
+
+## User provisioning behavior
+
+**No email activation step:** Users provisioned via SCIM on a verified domain are created in a confirmed, active state immediately. They do not receive an email activation link from Bitrise. On first login they are redirected directly to the Entra ID SSO flow.
+
+**Default workspace role:** All SCIM-provisioned users receive the Workspace Viewer role by default, which does not include Bitrise CI product access. To assign a different role at provisioning time, configure the `roles` attribute in Entra ID. See [Managing workspace roles via SCIM](/en/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-scim#managing-workspace-roles-via-scim).
+
+## Deprovisioning behavior
+
+When you remove a user's assignment in Entra ID, or Entra ID sends a `PATCH active:false` or `DELETE` request:
+
+- The user is removed from the workspace and from all their groups within it simultaneously.
+- Their personal access tokens remain active but lose access to all resources in the workspace.
+- Their workflows and secrets are preserved and not reassigned automatically.
+- The seat is freed immediately.
+
+**Re-provisioning a deprovisioned user:** A deprovisioned user's account is not deleted; they are removed from the workspace. Re-provisioning them via SCIM with the same email is not supported and returns a conflict error. To re-onboard a previously deprovisioned user, a workspace admin must re-invite them manually. Once they accept, Entra ID can manage their group membership via SCIM as normal.
+
+## Migrating existing workspace members
+
+SCIM is push-based. Bitrise only acts on requests Entra ID sends. Existing workspace members who are not assigned in Entra ID are not touched and remain in the workspace.
+
+To migrate an existing workspace with members and groups:
+
+1. Verify all relevant email domains before enabling SCIM.
+1. Align Entra ID group names to match your existing Bitrise group names exactly.
+1. Enable SCIM with **Sync only assigned users and groups** in Entra ID.
+1. Assign a small pilot group first to validate end-to-end, then expand incrementally.
+
+There is no dry-run or preview mode. The incremental pilot approach is the practical equivalent.
+
+## Users on unverified domains
+
+Users whose email is on a domain that has not been verified in Bitrise cannot be managed via SCIM. Any attempt to provision or modify them will be rejected. Exclude those users from Entra ID's assignment scope until their domain is verified.
+
+To verify additional domains, go to Workspace Settings and add each domain under **Domain verification**. Each domain must be verified separately.

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-entra-id-scim-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-entra-id-scim-for-bitrise.mdx
@@ -1,25 +1,35 @@
 ---
-title: "Setting up Entra ID SCIM for Bitrise"
+title: "Entra ID SCIM"
 description: "Provision and deprovision Bitrise workspace members automatically using Microsoft Entra ID SCIM."
 sidebar_position: 7
 slug: /bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-entra-id-scim-for-bitrise
-sidebar_label: Setting up Entra ID SCIM for Bitrise
+sidebar_label: Entra ID SCIM
 ---
 
 import GlossTerm from '@site/src/components/GlossTerm';
+import Partial_OpeningTheWorkspaceSettingsPage from '@site/src/partials/opening-the-workspace-settings-page.mdx';
 
-Bitrise supports automatic user and group provisioning via [SCIM 2.0](https://scim.cloud/) with Microsoft Entra ID. Once configured, Entra ID becomes the authoritative source for workspace membership: users and group assignments are pushed to Bitrise automatically, and removing a user in Entra deactivates their access on Bitrise.
+Bitrise supports automatic user and group provisioning via [SCIM 2.0](https://scim.cloud/) with Microsoft Entra ID. Once configured, Entra ID becomes the authoritative source for <GlossTerm baseform="workspace">workspace</GlossTerm> membership: users and group assignments are pushed to Bitrise automatically, and removing a user in Entra deactivates their access on Bitrise.
 
-## Before you start
+## SCIM requirements
 
 - SCIM provisioning requires an **Enterprise plan**.
 - You must have [SAML SSO configured](/en/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-azure-ad-sso-for-bitrise) between Bitrise and Entra ID before enabling SCIM.
 - You must have a [verified domain](/en/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-saml-sso-on-bitrise#verifying-your-domain). Domain verification can take up to 72 hours. SCIM credentials cannot be generated until at least one domain is verified.
-- You will need both the Bitrise Workspace owner and an Entra ID administrator available during setup.
+- You will need both the [Bitrise workspace owner](/en/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/roles-and-permissions-in-workspaces) and an Entra ID administrator available during setup.
 
-## Step 1: Generate SCIM credentials on Bitrise
+## Setting up SCIM 
 
-1. Open your <GlossTerm baseform="workspace">Workspace</GlossTerm> settings and select **Single sign-on** from the left menu.
+The setup consists of three steps:
+
+1. [Generating SCIM credentials on Bitrise.](#generating-scim-credentials-on-bitrise)
+1. [Configuring SCIM provisioning in Entra ID.](#configuring-scim-provisioning-in-entra-id)
+1. [Verifying the connection.](#verifying-the-connection)
+
+### Generating SCIM credentials on Bitrise
+
+1. <Partial_OpeningTheWorkspaceSettingsPage />
+1. Select **Single sign-on** from the left menu.
 1. Select the **SCIM** tab.
 1. Click **Generate SCIM credentials**.
 1. Copy and save both values shown in the dialog:
@@ -28,13 +38,13 @@ Bitrise supports automatic user and group provisioning via [SCIM 2.0](https://sc
 
    The token is not displayed again after you close the dialog. If you lose it, you can regenerate it, but doing so immediately invalidates the previous token.
 
-## Step 2: Configure SCIM provisioning in Entra ID
+### Configuring SCIM provisioning in Entra ID
 
 Bitrise is not a gallery app in Entra ID. Use Microsoft's [tutorial for configuring SCIM with non-gallery applications](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups) and apply the following Bitrise-specific values:
 
-- **Tenant URL:** your SCIM base URL from Step 1
-- **Secret token:** your SCIM authentication token from Step 1
-- **Unique identifier field:** `userName` (mapped to the user's email address)
+- **Tenant URL:** [your SCIM base URL](#generating-scim-credentials-on-bitrise).
+- **Secret token:** [your SCIM authentication token](#generating-scim-credentials-on-bitrise).
+- **Unique identifier field:** `userName` (mapped to the user's email address).
 
 When configuring **Provisioning Mode**, select **Automatic**. Use **Sync only assigned users and groups** to control which users and groups are pushed to Bitrise.
 
@@ -44,7 +54,7 @@ Workspace membership on Bitrise is managed through groups. You must enable group
 
 :::
 
-## Step 3: Verify the connection
+### Verifying the connection
 
 Click **Test Connection** in the Entra ID provisioning configuration. This queries the Bitrise `/ServiceProviderConfig` endpoint and confirms that the credentials are valid. A successful test means Entra ID can reach Bitrise and authenticate correctly.
 
@@ -52,9 +62,19 @@ Click **Test Connection** in the Entra ID provisioning configuration. This queri
 
 Bitrise implements the SCIM 2.0 Core User Schema and Core Group Schema (RFC 7643/7644). Entra ID's default attribute mapping works without custom transforms.
 
-Supported user attributes: `userName`, `emails`, `name.givenName`, `name.familyName`, `active`, `externalId`.
+Supported user attributes:
 
-Supported group attributes: `displayName`, `members`.
+- `userName`: unique identifier for the user; Entra ID maps this to the user's User Principal Name (UPN), which typically matches their email address
+- `emails`: the user's email address(es)
+- `name.givenName`: first name
+- `name.familyName`: last name
+- `active`: whether the user is active; set to `false` to deprovision
+- `externalId`: the user's stable, opaque ID assigned by Entra ID; remains constant even if the user's UPN changes
+
+Supported group attributes:
+
+- `displayName`: the group's name in Entra ID
+- `members`: the list of users in the group
 
 For workspace role assignment via the `roles` attribute, see [Managing workspace roles via SCIM](/en/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-scim#managing-workspace-roles-via-scim).
 

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-entra-id-scim-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-entra-id-scim-for-bitrise.mdx
@@ -81,7 +81,7 @@ When you remove a user's assignment in Entra ID, or Entra ID sends a `PATCH acti
 - Their workflows and secrets are preserved and not reassigned automatically.
 - The seat is freed immediately.
 
-**Re-provisioning a deprovisioned user:** A deprovisioned user's account is not deleted; they are removed from the workspace. Re-provisioning them via SCIM with the same email is not supported and returns a conflict error. To re-onboard a previously deprovisioned user, a workspace admin must re-invite them manually. Once they accept, Entra ID can manage their group membership via SCIM as normal.
+**Re-provisioning a deprovisioned user:** A deprovisioned user's account is not deleted; they are removed from the workspace. Re-provisioning them via SCIM with the same email is supported, once they are assigned again in Entra ID, it can manage their group membership via SCIM as normal.
 
 ## Migrating existing workspace members
 

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-google-sso-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-google-sso-for-bitrise.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Setting up Google SSO for Bitrise"
+title: "Google SSO"
 description: "Add SAML SSO to your Bitrise Workspace using Google Workspace."
 sidebar_position: 7
 slug: /bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-google-sso-for-bitrise

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-idaptive-saml-sso-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-idaptive-saml-sso-for-bitrise.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Setting up Idaptive SAML SSO for Bitrise"
+title: "Idaptive SAML SSO"
 description: "Add SAML SSO to your Bitrise Workspace using Idaptive."
 sidebar_position: 8
 slug: /bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-idaptive-saml-sso-for-bitrise

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-okta-sso-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-okta-sso-for-bitrise.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Setting up Okta SSO for Bitrise"
+title: "Okta SSO"
 description: "Add SAML SSO to your Bitrise Workspace using Okta."
 sidebar_position: 9
 slug: /bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-okta-sso-for-bitrise

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-onelogin-sso-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-onelogin-sso-for-bitrise.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Setting up OneLogin SSO for Bitrise"
+title: "OneLogin SSO"
 description: "Add SAML SSO to your Bitrise Workspace using OneLogin."
 sidebar_position: 10
 slug: /bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-onelogin-sso-for-bitrise

--- a/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-ping-identity-sso-for-bitrise.mdx
+++ b/docs/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-ping-identity-sso-for-bitrise.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Setting up Ping Identity SSO for Bitrise"
+title: "Ping Identity SSO"
 description: "Add SAML SSO to your Bitrise Workspace using Ping Identity."
 sidebar_position: 11
 slug: /bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-ping-identity-sso-for-bitrise

--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -11,6 +11,14 @@
 
 ## 2026 June
 
+### <time dateTime="2026-06-23">2026-06-23</time> Entra ID SCIM provisioning guide {#2026-06-23-entra-id-scim-provisioning-guide}
+
+You can now set up automatic user and group provisioning for your Bitrise workspace using Microsoft Entra ID SCIM. The guide covers generating SCIM credentials, configuring Entra ID, attribute mapping, group and deprovisioning behavior, and migrating existing workspace members. See [Entra ID SCIM](/en/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-entra-id-scim-for-bitrise).
+
+### <time dateTime="2026-06-22">2026-06-22</time> Bitrise CI API reference is now interactive {#2026-06-22-bitrise-ci-api-reference-is-now-interactive}
+
+The Bitrise CI API reference is now available as a full interactive explorer at `/en/bitrise-api`, replacing the previous SwaggerUI embed. Endpoints are grouped by tag with a sidebar, and you can try requests directly from the docs. See [Bitrise CI API reference](/en/bitrise-api).
+
 ### <time dateTime="2026-06-19">2026-06-19</time> CodePush CLI docs expanded with full reference {#2026-06-19-codepush-cli-docs-expanded-with-full-reference}
 
 The CodePush CLI documentation has been expanded and restructured. A new reference page covers all commands, global flags, environment variables, and exit codes. The [Using the CodePush CLI](/en/release-management/codepush/codepush-cli/using-the-codepush-cli) page now includes workflow examples, JSON output, and Bitrise CI integration details. The code signing page adds a directory naming warning and a React Native >= 0.61 Android setup note. See [CodePush CLI](/en/release-management/codepush/codepush-cli).


### PR DESCRIPTION
## Summary

Adds a new page covering SCIM provisioning for Microsoft Entra ID. Fills the gap flagged in our current docs where SAML SSO and generic SCIM setup are documented but there is no Entra-specific SCIM reference.

- Setup steps (generate credentials on Bitrise, configure non-gallery SCIM app in Entra ID, test connection)
- Attribute mapping (confirm default Entra mapping works without custom transforms)
- Group behavior: case-sensitive exact name matching, Entra becomes authoritative source for membership, protected groups (Global Access, SAML default) excluded from SCIM deletion
- User provisioning: immediate confirmation with no email activation step on verified domains, default Workspace Viewer role
- Deprovisioning: removes user from workspace and all groups simultaneously, PATs lose workspace access, re-provisioning limitation (requires manual re-invite)
- Migration guidance for existing workspaces

## Notes

- No Entra-specific screenshots yet — the Entra-side steps link out to Microsoft's non-gallery SCIM tutorial. Screenshots can be added in a follow-up.
- Links to existing `/configuring-scim` and `/setting-up-azure-ad-sso-for-bitrise` pages for prerequisites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)