### PR TITLE
fix: sidebar scrollbar styling and bullet point correction

### DIFF
--- a/docs/bitrise-ci/api/adding-and-managing-apps.mdx
+++ b/docs/bitrise-ci/api/adding-and-managing-apps.mdx
@@ -362,7 +362,7 @@ Both endpoints take two parameters:
 
 - from_machine: The machine type you want to switch from.
 
-  to_machine: The machine type you want to switch to.
+-  to_machine: The machine type you want to switch to.
 
 You can find the list of available machine types here: [Build machine types](/en/bitrise-build-hub/infrastructure/build-machine-types).
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -334,6 +334,18 @@
 .menu.thin-scrollbar {
   padding: 0;
   scrollbar-gutter: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--ifm-color-emphasis-300) transparent;
+}
+.menu.thin-scrollbar::-webkit-scrollbar {
+  width: 4px;
+}
+.menu.thin-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+.menu.thin-scrollbar::-webkit-scrollbar-thumb {
+  background: var(--ifm-color-emphasis-300);
+  border-radius: 4px;
 }
 
 /* ---- Breadcrumbs ---- */


### PR DESCRIPTION
## Summary

- Sidebar scrollbar is now slim (4px) and styled to match the theme, replacing the default browser scrollbar
- Fixed a bullet point indentation in the Adding and managing apps API guide

## Test plan

- [ ] Verify sidebar scrollbar appearance across pages, especially in the Bitrise API docs
- [ ] Verify the `to_machine` bullet point renders correctly in the Adding and managing apps page

🤖 Generated with [Claude Code](https://claude.com/claude-code)