### PR TITLE
Fix broken "Configure your builds" link on Bitrise CI landing page

### DIFF
--- a/docs/bitrise-ci/index.mdx
+++ b/docs/bitrise-ci/index.mdx
@@ -31,7 +31,7 @@ import ProductOverview from '@site/src/components/ProductOverview';
         },
         {
           label: 'Configure your builds',
-          href: '/en/bitrise-ci/configure-builds/configuring-build-settings',
+          href: '/en/bitrise-ci/configure-builds/configuration-yaml/configuration-yaml-overview',
           description: 'Create complex configurations in a convenient way. Edit your configuration in a GUI or in a YAML file.',
         },
       ],


### PR DESCRIPTION
## Problem

On the [Bitrise CI overview page](https://docs.bitrise.io/en/bitrise-ci), the **Configure your builds** card (under *Get started*) links to:

`/en/bitrise-ci/configure-builds/configuring-build-settings`

That path is a **category folder with no index page**, so it returns an **HTTP 404**.

## Fix

Repoint the card to the **Configuration YAML overview** page, which exists and returns HTTP 200:

`/en/bitrise-ci/configure-builds/configuration-yaml/configuration-yaml-overview`

This destination matches the card's existing description — *"Create complex configurations in a convenient way. Edit your configuration in a GUI or in a YAML file."*

## Verification

| URL | Before | After |
|-----|--------|-------|
| `/en/bitrise-ci/configure-builds/configuring-build-settings` | 404 | — |
| `/en/bitrise-ci/configure-builds/configuration-yaml/configuration-yaml-overview` | — | 200 |

I also checked the other 9 links on the Bitrise CI landing page — all return 200. This was the only broken one.

No redirect entry is needed in `redirects.json`: this changes a link's target, not a page slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)