### PR TITLE
docs(bitrise-ci/getting-started): fix verified label/text drift (screenshot retakes still needed)

### DIFF
--- a/docs/bitrise-ci/getting-started/adding-a-ci-configuration-to-a-project.md
+++ b/docs/bitrise-ci/getting-started/adding-a-ci-configuration-to-a-project.md
@@ -16,9 +16,9 @@ To add CI configuration to a project:
 
    ![extending-ci-config.png](/img/_paligo/uuid-d6541f5d-351c-81f9-7a8b-41cfa8c1a21d.png)
 
-   :::note[Start new project]
+   :::note[Start a new project]
 
-   The **Start new project** option starts a new project with a CI configuration. If you want a Release Management project without a CI configuration, select **Releases** from navigation menu on the left and [add an app](/en/release-management/getting-started-with-release-management/adding-a-new-app-to-release-management).
+   The **Start a new project** option starts a new project with a CI configuration. If you want a Release Management project without a CI configuration, select **Releases** from navigation menu on the left and [add an app](/en/release-management/getting-started-with-release-management/adding-a-new-app-to-release-management).
 
    :::
 1. Select a project from the dropdown menu, then click **Continue**.

--- a/docs/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-app-center-to-bitrise.mdx
+++ b/docs/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-app-center-to-bitrise.mdx
@@ -22,11 +22,12 @@ On App Center, your user account can own apps. Organizations are optional: App C
 
 A [Bitrise Workspace](/en/bitrise-platform/workspaces/workspaces-overview) is a little different: when you sign up for the first time, we automatically create your first Workspace, too. This is because only Workspaces can own Bitrise <GlossTerm baseform="project">projects</GlossTerm>. Projects are not tied to your account but to Workspaces. A Workspace can own several projects but a project cannot be linked to multiple Workspaces.
 
-A Bitrise Workspace has three main roles:
+A Bitrise Workspace has four main roles:
 
 - **Owner**: The owner of the Workspace. Full administrative control over the Workspace without restrictions. A Workspace can have multiple Owners. The default Owner is the account that created the Workspace.
 - **Manager**: The user can access and modify Workspace settings such as connected service accounts, can manage members but can't access billing details and can't delete the Workspace.
-- **Viewer**: The user can't access Workspace settings and can't add new members or manage existing members.
+- **Contributor**: The user can't access Workspace settings and can't add new members or manage existing members.
+- **Viewer**: The user can't add new projects or Release Management apps to the Workspace.
 
 On App Center, you can create teams within organizations. On Bitrise, Workspace members can be added to Workspace groups: this makes it easier to assign multiple people to projects at the same time.
 
@@ -48,13 +49,10 @@ Bitrise supports multiple mobile frameworks, including iOS, Android, React Nativ
 
 Bitrise supports connections to multiple code repository services:
 
-- GitHub
-- GitLab
-- Bitbucket
-- Azure DevOps
-- Deveo
-- Gogs
-- Assembla
+- GitHub (including the GitHub app and GitHub Enterprise Server)
+- GitLab (including self-hosted GitLab)
+- Bitbucket (including Bitbucket Server)
+- Any other Git repository via a generic Git connection
 
 For most cases, you can use OAuth connections and [SSH keys](/en/bitrise-platform/repository-access/configuring-ssh-keys) to set up repository access. [HTTPS authorization](/en/bitrise-platform/repository-access/configuring-https-authorization-credentials) is also supported.
 

--- a/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-flutter-projects.mdx
+++ b/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-flutter-projects.mdx
@@ -177,7 +177,7 @@ You can share the generated binary file (APK for Android or an IPA file for iOS)
 
 The **Deploy to Bitrise.io** Step does not use Expo commands and doesn’t publish to [expo.io](https://docs.expo.dev/workflow/publishing/). This Step publishes artifacts to Bitrise and is not specific to a particular platform.
 
-If you need to publish to [expo.io](https://docs.expo.dev/workflow/publishing/), set the **Run expo publish after eject?** input of the **Eject Expo** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
+If you need to publish to [expo.io](https://docs.expo.dev/workflow/publishing/), set the **Run expo publish after eject?** input of the **Expo Eject** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
 
 :::
 

--- a/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-ioniccordova-projects.mdx
+++ b/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-ioniccordova-projects.mdx
@@ -289,7 +289,7 @@ You can share the generated binary file (APK for Android or an IPA file for iOS)
 
 The **Deploy to Bitrise.io** Step does not use Expo commands and doesn’t publish to [expo.io](https://docs.expo.dev/workflow/publishing/). This Step publishes artifacts to Bitrise and is not specific to a particular platform.
 
-If you need to publish to [expo.io](https://docs.expo.dev/workflow/publishing/), set the **Run expo publish after eject?** input of the **Eject Expo** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
+If you need to publish to [expo.io](https://docs.expo.dev/workflow/publishing/), set the **Run expo publish after eject?** input of the **Expo Eject** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
 
 :::
 
@@ -323,7 +323,7 @@ You can use the **Deploy to Google Play** Step in your Workflow to upload your d
 1. In the **Output (.apk, .aab) pattern** input, set the path where the **Deploy to Google Play** Step will be able to access the generated binary.
 
    The path should be relative to the project source directory, stored in the BITRISE_SOURCE_DIR Environment Variable.
-1. Make sure you have the **Deploy to Google Play** Step after the **Android Sign****Cordova Archive** or **Ionic Archive** Step in your Workflow.
+1. Make sure you have the **Deploy to Google Play** Step after the **Android Sign** and **Cordova Archive** or **Ionic Archive** Step in your Workflow.
 1. Fill out the required input fields as follows:
 
    - **Service Account JSON key file path**: This field can accept a remote URL so you have to provide the Env Var which contains your uploaded service account JSON key. For example: `$BITRISEIO_SERVICE_ACCOUNT_JSON_KEY_URL`.

--- a/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-react-native-projects.mdx
+++ b/docs/bitrise-ci/getting-started/quick-start-guides/getting-started-with-react-native-projects.mdx
@@ -121,7 +121,7 @@ A React Native project can consist of an Android and an iOS project. Both have d
 
 All Android apps must be digitally signed with a certificate before they can be installed on Android devices. On Bitrise, you can use our dedicated <GlossTerm baseform="step">Step</GlossTerm> for this purpose but first you'll need a keystore file.
 
-1. [Generate a keystore file](https://developer.android.com/studio/publish/app-signing#generate-key)[Generate a keystore file](https://reactnative.dev/docs/signed-apk-android#generating-an-upload-key).
+1. [Generate a keystore file](https://reactnative.dev/docs/signed-apk-android#generating-an-upload-key).
 1. Open your project on Bitrise with a user that has the **Admin** [role on the project](/en/bitrise-platform/projects/roles-and-permissions-for-bitrise-ci).
 1. On the main page of the project, click on the **Project settings** button.
 
@@ -274,7 +274,7 @@ You can share the generated binary file (APK for Android or an IPA file for iOS)
 
 The **Deploy to Bitrise.io** Step does not use Expo commands and doesn’t publish to [expo.io](https://docs.expo.dev/workflow/publishing/). This Step publishes artifacts to Bitrise and is not specific to a particular platform.
 
-If you need to publish to [expo.io](https://docs.expo.dev/workflow/publishing/), set the **Run expo publish after eject?** input of the **Eject Expo** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
+If you need to publish to [expo.io](https://docs.expo.dev/workflow/publishing/), set the **Run expo publish after eject?** input of the **Expo Eject** Step to `yes`. Be aware that in that case you have to provide your username and password for your Expo account to publish to [expo.io.](http://expo.io/)
 
 :::
 

--- a/docs/bitrise-ci/getting-started/the-bitrise-dashboard.mdx
+++ b/docs/bitrise-ci/getting-started/the-bitrise-dashboard.mdx
@@ -52,7 +52,7 @@ In the **Insights for workspace** section, you can see some basic aggregated dat
 
 - **Successful build time**: The average Bitrise CI build time for successful builds across the workspace's projects.
 - **Build failure rate**: The percentage of failed Bitrise CI builds across the workspace's projects.
-- **Cache hit rate**: The percentage of data requests that were successfully served by the Bitrise Build Cache.
+- **Cache hit rate (P50)**: The percentage of data requests that were successfully served by the Bitrise Build Cache.
 - **Command error rate**: The percentage of failed commands.
 
 ![workspace-insights.png](/img/_paligo/uuid-b15d9482-748d-bb6a-1aaa-c1153ed8392b.png)


### PR DESCRIPTION
## What this PR does

Fixes a batch of **verified text/label drift** in the **Bitrise CI → Getting started** docs, found by validating the docs against the current implementation (`bitrise-website`, `bitrise-steplib`). Every change below is backed by a source-of-truth `file:line` or a Step Library `step.yml`.

### Changes

| File | Fix | Evidence |
|------|-----|----------|
| `migrating-from-app-center-to-bitrise.mdx` | Repository-providers list corrected — removed **Azure DevOps / Deveo / Gogs / Assembla** (never repository providers; they only ever existed as *webhook* service IDs), added the GitHub App + self-hosted/server variants | `bitrise-website` `app/javascript/models/GitProvider.ts` |
| `migrating-from-app-center-to-bitrise.mdx` | Workspace roles: "three main roles" → **four**, added **Contributor**, corrected the Viewer description | `roleToDisplayName.ts`; canonical `roles-and-permissions-in-workspaces.mdx` |
| `the-bitrise-dashboard.mdx` | Metric label "Cache hit rate" → **"Cache hit rate (P50)"** | `WorkspaceDashboardPage/InsightsInfo.tsx:49` |
| `adding-a-ci-configuration-to-a-project.md` | "Start new project" → **"Start a new project"** (note title + body) | `dashboard/NewCiConfigurationDialog.tsx:78,81` |
| `getting-started-with-{react-native,flutter,ioniccordova}-projects.mdx` | Step name "Eject Expo" → **"Expo Eject"** | `bitrise-steplib` `steps/expo-detach/1.1.0/step.yml` (`title: Expo Eject`) |
| `getting-started-with-react-native-projects.mdx` | Fixed a doubled/concatenated "Generate a keystore file" link | Markdown authoring defect |
| `getting-started-with-ioniccordova-projects.mdx` | Fixed garbled `**Android Sign****Cordova Archive**` (fused bold) → "**Android Sign** and **Cordova Archive**" | Markdown authoring defect (platform-correct content) |

## ⚠️ Still needed — NOT covered by this PR

This PR is intentionally limited to safe, mechanical text fixes. The **larger Getting Started drift requires follow-up work that a text-only PR cannot deliver**:

1. **Screenshot retakes (required).** The add-project wizard screenshots (the `20251219` set) plus `start-build-basic.png` and `project-settings-main-page.png` show a **UI that no longer exists** — the add-project flow was rebuilt into the 3-stage `AddNewCIProjectPage` (legacy AngularJS flow retired, `bitrise-website` #19641). These images must be **re-captured against the live UI**. They are untouched here.
2. **Add-project wizard prose rewrite (required).** The "Adding a project" / first-project sequence in `adding-a-new-project.mdx`, `getting-started.mdx`, and all quick-start guides still describes the **retired legacy wizard** (e.g. "Yes, auto-detect configuration", "View Project Page"). It needs rewriting against the live 3-stage flow (*Add CI config* → *Connection method* → *Select default branch* → *Access to builds* Private/Public → *Finish*). Deferred because it depends on the new screenshots and warrants author review.
3. **React Native / Flutter deploy sections (author review).** These contain **wrong-platform copy-paste** (Cordova/Ionic Archive steps in the RN/Flutter guides, incl. the remaining garbled `****` step names at RN ~135/~340 and Flutter ~273). Correct per-platform deploy steps need an SME, so they're left for a dedicated change rather than half-fixed here.

---
Findings produced by the `docs-validation` workflow (bitrise-ci / getting-started). Direction triage: **all DOC-STALE / DOC-ERROR — 0 implementation regressions.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
