### PR TITLE
ci: cache node_modules and the Docusaurus build to speed up CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,24 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            !node_modules/.cache
+          key: node-modules-${{ runner.os }}-node20-${{ hashFiles('package-lock.json') }}
+
+      - name: Cache Docusaurus build
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules/.cache
+            .docusaurus
+          key: docusaurus-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            docusaurus-${{ runner.os }}-
+
       - run: npm install
 
       - run: npm run build

--- a/.github/workflows/sync-api-references.yml
+++ b/.github/workflows/sync-api-references.yml
@@ -66,6 +66,15 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Cache node_modules
+        if: steps.sync.outputs.status != 'unchanged'
+        uses: actions/cache@v4
+        with:
+          path: |
+            node_modules
+            !node_modules/.cache
+          key: node-modules-${{ runner.os }}-node20-${{ hashFiles('package-lock.json') }}
+
       - name: Regenerate the ${{ matrix.name }} reference
         if: steps.sync.outputs.status != 'unchanged'
         run: |


### PR DESCRIPTION
## What

Adds dependency and build caching to the GitHub Actions workflows so CI stops re-doing work it can reuse.

- **`deploy.yml`**
  - Cache `node_modules` (keyed on `package-lock.json`), excluding `node_modules/.cache`.
  - Cache the Docusaurus build (`node_modules/.cache` + `.docusaurus`) under a rolling per-commit key with a prefix `restore-keys` fallback.
- **`sync-api-references.yml`**
  - Cache `node_modules` (same key, same `.cache` exclusion). No build cache — this job only runs `gen-api-docs`.

## Why

The workflows only used `actions/setup-node`'s `cache: 'npm'`, which caches npm's **download** cache (`~/.npm`), not the installed tree. On a cache hit `npm install` still re-extracted and linked ~1700 packages into `node_modules`, so it took **over a minute** every run (see [this run](https://github.com/bitrise-io/docs/actions/runs/28391748653/job/84120313234)).

Caching `node_modules` directly lets `npm install` finish in seconds when dependencies haven't changed. The Docusaurus build cache lets warm builds reuse compiled output instead of recompiling the whole site.

## Reviewer notes

- **`npm install` kept on purpose** (not switched to `npm ci`): `npm ci` wipes `node_modules` first, which would defeat a restored cache. `npm install` reconciles an already-satisfied tree instead, so no `if: cache-hit` guard is needed.
- **Two separate caches, two key strategies.** Deps cache is lockfile-keyed (stable). The build cache is per-commit-keyed with `restore-keys` so it stays fresh rather than frozen to the lockfile — and `.cache` is excluded from the deps cache so it isn't stored twice. Webpack validates cache entries by content hash, so changed pages still recompile correctly.
- **Build cache is deploy-only** by design: the sync job runs `gen-api-docs` (codegen, no webpack build), so it neither produces nor consumes a build cache.
- **No experimental flags.** This deliberately does *not* enable Docusaurus's `future.faster` toolchain — caching only.
- Speedup only shows on **warm** runs; the first run after merge is still cold. New PR branches warm up from `main`'s build cache via the prefix restore-key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Cold cache:
<img width="1350" height="838" alt="image" src="https://github.com/user-attachments/assets/33d71da8-5c09-402f-9354-282a218b18d8" />

Warm cache:
<img width="1367" height="835" alt="image" src="https://github.com/user-attachments/assets/1a57bfb2-f775-409b-af75-7f03c0a6419f" />
