### PR TITLE
fix: restore broken table in AI FAQ customer data section

### DIFF
--- a/docs/bitrise-platform/ai/ai-faq-how-bitrise-leverages-ai-technologies-in-its-features-and-services.mdx
+++ b/docs/bitrise-platform/ai/ai-faq-how-bitrise-leverages-ai-technologies-in-its-features-and-services.mdx
@@ -26,9 +26,10 @@ Below we collected the most frequent questions we have received on how Bitrise i
 
 Bitrise classifies Customer data into the following Customer Content categories:
 
-| **Customer content categories** | **Customer Sensitive Content**  Content that must be handled with strict access controls and cannot be used for training, fine-tuning, or other secondary purposes, without explicit customer consent and appropriate privacy protections. |
+| **Customer content category** | **Description** |
 | --- | --- |
-| **Customer Non-sensitive data**  Data that can be handled with standard operational controls and which may be used for service improvement, analytics, and operational purposes without requiring explicit customer consent. Includes Customer Non-Sensitive Content. |  |
+| **Customer Sensitive Content** | Content that must be handled with strict access controls and cannot be used for training, fine-tuning, or other secondary purposes, without explicit customer consent and appropriate privacy protections. |
+| **Customer Non-Sensitive Data** | Data that can be handled with standard operational controls and which may be used for service improvement, analytics, and operational purposes without requiring explicit customer consent. Includes Customer Non-Sensitive Content. |
 
 Customer Sensitive Content and Non-sensitive Data shall be further classified as non-anonymizable, anonymizable, and directly useable, and may be processed as described below based on such classification:
 


### PR DESCRIPTION
## Summary

- The first table in the "How is Customer data used with AI on Bitrise?" section had a malformed structure: both category names and their descriptions were crammed into the header row, leaving an empty second column and no proper data rows.
- Restructured the table with a clear two-column header (`Customer content category` / `Description`) and two proper data rows.

## Test plan

- [ ] Confirm the table renders correctly at the affected section of the AI FAQ page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)