### PR TITLE
fix: resolve broken internal links across docs

### DIFF
--- a/docs/bitrise-ci/api/managing-an-apps-builds.mdx
+++ b/docs/bitrise-ci/api/managing-an-apps-builds.mdx
@@ -32,7 +32,7 @@ You can get all builds of an app with the `GET /apps/{app-slug}/builds` endpoint
 GET /apps/{app-slug}/builds?parameter_name=parameter_value&other_parameter_name=other_parameter_value
 ```
 
-The full list of parameters can be found in the [API reference](/en/bitrise-ci/api/api-reference) documentation.
+The full list of parameters can be found in the [API reference](/en/bitrise-api/api-reference/bitrise-api) documentation.
 
 :::note[Build retention for 200 days]
 
@@ -192,7 +192,7 @@ Response (in this example there were two failed builds):
 }
 ```
 
-You can try any of these endpoints in the [API reference](/en/bitrise-ci/api/api-reference) documentation.
+You can try any of these endpoints in the [API reference](/en/bitrise-api/api-reference/bitrise-api) documentation.
 
 
 ## Listing the archived builds of an app

--- a/docs/bitrise-ci/api/managing-build-artifacts.mdx
+++ b/docs/bitrise-ci/api/managing-build-artifacts.mdx
@@ -18,10 +18,10 @@ You can also manage the generated artifacts with the Bitrise API.
 
 | Endpoint | Function | Required role on the app's team |
 | --- | --- | --- |
-| [GET/apps/\{app-slug\}/builds/\{build-slug\}/artifacts](/en/bitrise-ci/api/api-reference) | Listing build artifacts | Any |
-| [GET/apps/\{app-slug\}/builds/\{build-slug\}/artifacts/\{artifact-slug\}](/en/bitrise-ci/api/api-reference) | Retrieving data of a specific build artifact | Any |
-| [PATCH/apps/\{app-slug\}/builds/\{build-slug\}/artifacts/\{artifact-slug\}](/en/bitrise-ci/api/api-reference) | Updating a build artifact | Owner, Admin, or Developer |
-| [DELETE/apps/\{app-slug\}/builds/\{build-slug\}/artifacts/\{artifact-slug\}](/en/bitrise-ci/api/api-reference) | Deleting a build artifact | Owner, Admin, or Developer |
+| [GET/apps/\{app-slug\}/builds/\{build-slug\}/artifacts](/en/bitrise-api/api-reference/bitrise-api) | Listing build artifacts | Any |
+| [GET/apps/\{app-slug\}/builds/\{build-slug\}/artifacts/\{artifact-slug\}](/en/bitrise-api/api-reference/bitrise-api) | Retrieving data of a specific build artifact | Any |
+| [PATCH/apps/\{app-slug\}/builds/\{build-slug\}/artifacts/\{artifact-slug\}](/en/bitrise-api/api-reference/bitrise-api) | Updating a build artifact | Owner, Admin, or Developer |
+| [DELETE/apps/\{app-slug\}/builds/\{build-slug\}/artifacts/\{artifact-slug\}](/en/bitrise-api/api-reference/bitrise-api) | Deleting a build artifact | Owner, Admin, or Developer |
 
 
 ## Listing build artifacts

--- a/docs/bitrise-ci/api/managing-files-in-generic-file-storage.mdx
+++ b/docs/bitrise-ci/api/managing-files-in-generic-file-storage.mdx
@@ -13,12 +13,12 @@ You can upload, delete, update, and list any project files in the `GENERIC FILE 
 
 | Endpoints | Function | Required role on the app's team |
 | --- | --- | --- |
-| [POST/apps/\{app-slug\}/generic-project-files](/en/bitrise-ci/api/api-reference) | Create a generic project file | Owner or Admin |
-| [POST/apps/\{app-slug\}/generic-project-files/\{generic-project-file-slug\}/uploaded](/en/bitrise-ci/api/api-reference) | Confirm the upload process | Owner or Admin |
-| [PATCH/apps/\{app-slug\}/generic-project-files/\{generic-project-file-slug\}](/en/bitrise-ci/api/api-reference) | Update an uploaded project file | Owner or Admin |
-| [GET/apps/\{app-slug\}/generic-project-files](/en/bitrise-ci/api/api-reference) | Get a list of the uploaded project files | Owner or Admin |
-| [GET/apps/\{app-slug\}/generic-project-files/\{generic-project-file-slug\}](/en/bitrise-ci/api/api-reference) | Retrieve data of a specific project file | Owner or Admin |
-| [DELETE/apps/\{app-slug\}/generic-project-files/\{generic-project-file-slug\}](/en/bitrise-ci/api/api-reference) | Delete an uploaded project file | Owner or Admin |
+| [POST/apps/\{app-slug\}/generic-project-files](/en/bitrise-api/api-reference/bitrise-api) | Create a generic project file | Owner or Admin |
+| [POST/apps/\{app-slug\}/generic-project-files/\{generic-project-file-slug\}/uploaded](/en/bitrise-api/api-reference/bitrise-api) | Confirm the upload process | Owner or Admin |
+| [PATCH/apps/\{app-slug\}/generic-project-files/\{generic-project-file-slug\}](/en/bitrise-api/api-reference/bitrise-api) | Update an uploaded project file | Owner or Admin |
+| [GET/apps/\{app-slug\}/generic-project-files](/en/bitrise-api/api-reference/bitrise-api) | Get a list of the uploaded project files | Owner or Admin |
+| [GET/apps/\{app-slug\}/generic-project-files/\{generic-project-file-slug\}](/en/bitrise-api/api-reference/bitrise-api) | Retrieve data of a specific project file | Owner or Admin |
+| [DELETE/apps/\{app-slug\}/generic-project-files/\{generic-project-file-slug\}](/en/bitrise-api/api-reference/bitrise-api) | Delete an uploaded project file | Owner or Admin |
 
 
 ## Creating and uploading files to the Generic File Storage

--- a/docs/bitrise-ci/getting-started/migrating-to-bitrise/about-migrating-to-bitrise.md
+++ b/docs/bitrise-ci/getting-started/migrating-to-bitrise/about-migrating-to-bitrise.md
@@ -23,6 +23,6 @@ If you want to migrate to Bitrise from some other CI/CD or DevOps platform, we r
 Once you're familiar with these concepts, we offer quick start guides to get you through the first steps:
 
 - [Getting started with the Bitrise platform](/en/bitrise-build-cache/getting-started-with-the-build-cache/getting-started-with-the-build-cache).
-- [Getting started with web CI](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci).
+- [Getting started with Bitrise CI](/en/bitrise-ci/getting-started/getting-started).
 - [Getting started with the Build Cache](/en/bitrise-build-cache/getting-started-with-the-build-cache/getting-started-with-the-build-cache).
 - [Getting started with Release Management](/en/release-management/getting-started-with-release-management/adding-a-new-app-to-release-management).

--- a/docs/bitrise-ci/workflows-and-pipelines/workflows/default-workflows.mdx
+++ b/docs/bitrise-ci/workflows-and-pipelines/workflows/default-workflows.mdx
@@ -95,7 +95,7 @@ For Python, a single `run_tests` Workflow is generated. The included Steps depen
 
 | Workflow ID | Workflow summary | Workflow description |
 | --- | --- | --- |
-| `run_tests` | Run your project’s tests. | The Workflow clones your Git repository and installs Python based on the detected version. If no version is detected, the <GlossTerm baseform="stack">stack's</GlossTerm> default Python version is used. Installs dependencies: the exact command used depends on the [detected package manager](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci#package-manager-detection-for-python).  If `pytest` is detected, the Workflow runs your tests. |
+| `run_tests` | Run your project’s tests. | The Workflow clones your Git repository and installs Python based on the detected version. If no version is detected, the <GlossTerm baseform="stack">stack's</GlossTerm> default Python version is used. Installs dependencies: the exact command used depends on the detected package manager.  If `pytest` is detected, the Workflow runs your tests. |
 
 
 ## Default Workflows for a Flutter project

--- a/docs/release-management/getting-started-with-release-management/connecting-an-app.mdx
+++ b/docs/release-management/getting-started-with-release-management/connecting-an-app.mdx
@@ -21,7 +21,7 @@ After successfully adding a new app to Release Management, connect it to an app 
    Later in the connecting process, you will have to enter the bundle ID of the app.
 1. Make sure you have a Bitrise CI project.
 
-   If you created your project when adding the app to Release Management, you can extend it with a CI configuration: [Adding a CI configuration to a project](/en/bitrise-ci/getting-started/adding-a-ci-configuration-to-a-project).
+   If you created your project when adding the app to Release Management, you can extend it with a CI configuration: [Adding a new project](/en/bitrise-ci/getting-started/adding-a-new-project).
 1. Make sure you have at least one App Store Connect API key added to your workspace: [Connecting to an Apple service with API key](/en/bitrise-platform/integrations/apple-services-connection/connecting-to-an-apple-service-with-api-key).
 1. Open your app in Release Management and select **Releases** in the left navigation.
 1. Click **Connect app**.

--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -21,7 +21,7 @@ The Bitrise CI API reference is now available as a full interactive explorer at 
 
 ### <time dateTime="2026-06-19">2026-06-19</time> CodePush CLI docs expanded with full reference {#2026-06-19-codepush-cli-docs-expanded-with-full-reference}
 
-The CodePush CLI documentation has been expanded and restructured. A new reference page covers all commands, global flags, environment variables, and exit codes. The [Using the CodePush CLI](/en/release-management/codepush/codepush-cli/using-the-codepush-cli) page now includes workflow examples, JSON output, and Bitrise CI integration details. The code signing page adds a directory naming warning and a React Native >= 0.61 Android setup note. See [CodePush CLI](/en/release-management/codepush/codepush-cli).
+The CodePush CLI documentation has been expanded and restructured. A new reference page covers all commands, global flags, environment variables, and exit codes. The [Using the CodePush CLI](/en/release-management/codepush/codepush-cli/using-the-codepush-cli) page now includes workflow examples, JSON output, and Bitrise CI integration details. The code signing page adds a directory naming warning and a React Native >= 0.61 Android setup note. See [CodePush CLI](/en/release-management/codepush/codepush-cli/about-the-codepush-cli).
 
 ### <time dateTime="2026-06-18">2026-06-18</time> AI agent onboarding tip added to sign-up page {#2026-06-18-ai-agent-onboarding-tip-added-to-sign-up-page}
 
@@ -71,13 +71,13 @@ The modular YAML configuration guide has been updated to reflect the new, higher
 
 ### <time dateTime="2026-05-20">2026-05-20</time> Python projects now supported {#2026-05-20-python-projects-now-supported}
 
-Bitrise now detects Python projects automatically and offers default workflows. The [Default workflows](/en/bitrise-ci/workflows-and-pipelines/workflows/default-workflows) and [Getting started with web CI](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci) guides have been updated to include Python.
+Bitrise now detects Python projects automatically and offers default workflows. The [Default workflows](/en/bitrise-ci/workflows-and-pipelines/workflows/default-workflows) and [Getting started with Bitrise CI](/en/bitrise-ci/getting-started/getting-started) guides have been updated to include Python.
 
 ## 2026 April
 
 ### <time dateTime="2026-04-20">2026-04-20</time> Next.js and Flutter Web project types documented {#2026-04-20-next-js-and-flutter-web-project-types-documented}
 
-The [Getting started with web CI](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci) guide and [Default workflows](/en/bitrise-ci/workflows-and-pipelines/workflows/default-workflows) page now cover Next.js (as an extension of Node.js) and Flutter Web project types.
+The [Getting started with Bitrise CI](/en/bitrise-ci/getting-started/getting-started) guide and [Default workflows](/en/bitrise-ci/workflows-and-pipelines/workflows/default-workflows) page now cover Next.js (as an extension of Node.js) and Flutter Web project types.
 
 ## 2026 March
 
@@ -87,7 +87,7 @@ The [Build machine types](/en/bitrise-platform/infrastructure/build-machines/bui
 
 ### <time dateTime="2026-03-25">2026-03-25</time> Ruby projects now supported {#2026-03-25-ruby-projects-now-supported}
 
-Bitrise now detects Ruby projects automatically and offers default workflows. The [Getting started with web CI](/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci) guide has been updated to include Ruby.
+Bitrise now detects Ruby projects automatically and offers default workflows. The [Getting started with Bitrise CI](/en/bitrise-ci/getting-started/getting-started) guide has been updated to include Ruby.
 
 ### <time dateTime="2026-03-24">2026-03-24</time> Pro Trial: credit card required to access the full trial {#2026-03-24-pro-trial-credit-card-required-to-access-the-full-trial}
 


### PR DESCRIPTION
## Summary

- `/en/release-management/codepush/codepush-cli` — pointed to a non-clickable sidebar category; updated to `/en/release-management/codepush/codepush-cli/about-the-codepush-cli`.
- `/en/bitrise-ci/getting-started/quick-start-guides/getting-started-with-web-ci` — page is set to `draft: true`; updated to `/en/bitrise-ci/getting-started/getting-started` (matches the existing redirect).
- `/en/bitrise-ci/api/api-reference` — no page exists at this path; updated to `/en/bitrise-api/api-reference/bitrise-api` (the generated API reference intro).
- `/en/bitrise-ci/getting-started/adding-a-ci-configuration-to-a-project` — page was removed; updated to `/en/bitrise-ci/getting-started/adding-a-new-project`.

Affected files: changelog partial (used by 7 changelogs), about-migrating-to-bitrise, default-workflows, 3 API guide pages, connecting-an-app.

## Test plan

- [x] `npm run build` passes with no broken link errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)