### PR TITLE
docs: add changelog entries for RDE docs, RDE API reference, and agent onboarding update

### DIFF
--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -11,6 +11,18 @@
 
 ## 2026 June
 
+### <time dateTime="2026-06-29">2026-06-29</time> RDE API reference now available in-site {#2026-06-29-rde-api-reference-now-available-in-site}
+
+The Remote Dev Environments REST API reference is now part of docs.bitrise.io as a native interactive explorer, covering 42 endpoints across user, workspace, sessions, templates, and saved inputs. See [RDE API reference](/en/bitrise-rde-api/api-reference/bitrise-remote-dev-environments-api).
+
+### <time dateTime="2026-06-29">2026-06-29</time> Remote Dev Environments docs now available {#2026-06-29-remote-dev-environments-docs-now-available}
+
+Documentation for Bitrise Remote Dev Environments (RDE) is now available, covering key concepts, a quickstart, configuration options (templates, saved inputs), and the available interfaces: CLI, MCP server, UI, and VS Code plugin. See [Remote Dev Environments](/en/bitrise-rde).
+
+### <time dateTime="2026-06-26">2026-06-26</time> Agent onboarding guide updated with OAuth flow {#2026-06-26-agent-onboarding-guide-updated-with-oauth-flow}
+
+The [onboarding guide for AI agents](/en/bitrise-platform/ai/onboarding-for-agents) now covers the full OAuth sign-in flow in detail: how your agent triggers browser authorization, creating an account during sign-in, email confirmation for password-based accounts, and troubleshooting steps for common issues.
+
 ### <time dateTime="2026-06-23">2026-06-23</time> Entra ID SCIM provisioning guide {#2026-06-23-entra-id-scim-provisioning-guide}
 
 You can now set up automatic user and group provisioning for your Bitrise workspace using Microsoft Entra ID SCIM. The guide covers generating SCIM credentials, configuring Entra ID, attribute mapping, group and deprovisioning behavior, and migrating existing workspace members. See [Entra ID SCIM](/en/bitrise-platform/accounts/saml-sso-in-bitrise/setting-up-entra-id-scim-for-bitrise).


### PR DESCRIPTION
## Summary

Changelog entries for three merged PRs not yet covered:

- #71 — Remote Dev Environments docs now available
- #77 — RDE API reference now available in-site
- #74 — Agent onboarding guide updated with OAuth flow

## Test plan

- [ ] Changelog entries render correctly on the changelog pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)