### PR TITLE
fix: style GlossTerm links blue to distinguish from regular links

### DIFF
--- a/src/components/GlossTerm/styles.module.css
+++ b/src/components/GlossTerm/styles.module.css
@@ -6,8 +6,16 @@
 }
 
 .label {
-  border-bottom: 1px dotted var(--ifm-color-primary, #7b3ba5);
-  color: var(--ifm-color-primary, #7b3ba5);
+  border-bottom: 1px dotted var(--sys-info-strong, #1f6bb8);
+  color: var(--sys-info-strong, #1f6bb8);
+  text-decoration: none;
+}
+
+.label:hover {
+  border-bottom-style: solid;
+  border-bottom-color: var(--sys-info-base, #2582d0);
+  color: var(--sys-info-base, #2582d0);
+  text-decoration: none;
 }
 
 .popover {


### PR DESCRIPTION
## Summary
- Glossary term links (`<GlossTerm>`) previously shared the same purple color as regular links, making them hard to distinguish
- Restyled to blue using the existing `--sys-info-strong` / `--sys-info-base` design tokens, with a dotted underline at rest that turns solid on hover

## Test plan
- [x] Verified in browser preview that glossary terms (e.g. "Workspaces", "Workflows") render blue and distinct from purple regular links
- [x] Verified dotted underline at rest, solid underline on hover, no double-underline artifact from Infima's default hover decoration