### PR TITLE
Update product subscription cancellation flow in workspace billing docs

### DIFF
--- a/docs/bitrise-platform/workspaces/workspace-billing-and-invoicing.mdx
+++ b/docs/bitrise-platform/workspaces/workspace-billing-and-invoicing.mdx
@@ -65,15 +65,24 @@ You can change your workspace's subscription plan at any time from the **Workspa
    ![checkout.png](/img/_paligo/uuid-85ec7e12-6811-a14d-5388-d5502f87fc22.png)
 
 
-## Canceling your subscription
+## Canceling a product subscription
 
-You can cancel a workspace's Bitrise subscription at any time on the **Workspace settings** page.
+In Bitrise, each product has its own independent subscription that you can cancel separately. You can cancel Bitrise CI, Build Cache, Release Management, or any other product without affecting your other subscriptions.
+
+You can also cancel an add-on subscription on its own. Canceling an add-on doesn't affect the product's subscription — it stays active.
+
+When you cancel a product subscription, you keep access until the end of your current billing period. After that, the product reverts to its free plan where available.
 
 1. <Partial_OpeningTheWorkspaceSettingsPage />
 1. On the left navigation menu, select **Plan & Billing**.
-1. Click **Manage subscription**.
-1. In the dialog, click the card with your subscription information on it.
+1. Find the product you want to cancel and click **Manage** on its card.
+1. In the product drawer, click **Cancel subscription**.
+1. Select a cancellation reason and click **Confirm cancellation**.
 
-   ![teams-sub.png](/img/_paligo/uuid-dbe3dd32-b361-1fe0-2883-cf93cd64102d.png)
-1. Select **Cancel Subscription**.
-1. Select a cancellation reason and then click **Confirm Cancellation**.
+Your subscription remains active until the end of the current billing period. A banner on the **Plan & Billing** page confirms the scheduled cancellation date.
+
+:::note
+
+To cancel all product subscriptions, repeat these steps for each product individually.
+
+:::


### PR DESCRIPTION
## Summary
- Updates the **Canceling a product subscription** section (formerly "Canceling your subscription") to reflect that each product (Bitrise CI, Build Cache, Release Management, etc.) now has its own independently cancellable subscription, rather than one workspace-wide subscription.
- Documents that add-on subscriptions can also be canceled on their own without affecting the parent product's subscription.
- Replaces the old dialog-based cancellation steps with the new **Plan & Billing** → product card → **Manage** → drawer → **Cancel subscription** flow.
- Removes the now-outdated `teams-sub.png` screenshot reference (the dialog it depicted no longer exists).

## Test plan
- [ ] Tech writer review of wording/style against the Bitrise Style Guide
- [ ] Confirm the new flow description matches the current product UI
- [ ] Add/replace screenshot for the product drawer's **Cancel subscription** step, if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)