### PR TITLE
fix: add missing icon for Build Cache for React Native sidebar category

### DIFF
--- a/docs/bitrise-build-cache/build-cache-for-react-native/_category_.json
+++ b/docs/bitrise-build-cache/build-cache-for-react-native/_category_.json
@@ -1,5 +1,8 @@
 {
   "label": "Build Cache for React Native",
   "position": 5,
-  "link": null
+  "link": null,
+  "customProps": {
+    "icon": "React"
+  }
 }

--- a/src/theme/DocSidebarItem/SidebarIcon.tsx
+++ b/src/theme/DocSidebarItem/SidebarIcon.tsx
@@ -32,6 +32,7 @@ import IconSiren from '@site/src/images/icon-siren-16px.svg';
 import IconInsights from '@site/src/images/icon-insights-16px.svg';
 import IconInstall from '@site/src/images/icon-install-16px.svg';
 import IconGit from '@site/src/images/icon-git-16px.svg';
+import IconReact from '@site/src/images/icon-react-16px.svg';
 
 const iconMap: Record<string, React.ComponentType<React.SVGProps<SVGSVGElement>>> = {
   Power: IconPower,
@@ -66,6 +67,7 @@ const iconMap: Record<string, React.ComponentType<React.SVGProps<SVGSVGElement>>
   Insights: IconInsights,
   Install: IconInstall,
   Git: IconGit,
+  React: IconReact,
 };
 
 export default function SidebarIcon({name}: {name?: string}): ReactNode {


### PR DESCRIPTION
## Summary
- Wire up the existing React logo (`icon-react-16px.svg`) into `SidebarIcon.tsx`'s icon map
- Add `customProps.icon: "React"` to the React Native build cache category, matching the pattern used by Xcode/Bazel

## Test plan
- [x] Verified locally that the sidebar now shows the React icon next to "Build Cache for React Native"

🤖 Generated with [Claude Code](https://claude.com/claude-code)