### PR TITLE
docs: add Bitrise for Mac menu bar app guide

### DIFF
--- a/docs/bitrise-ci/run-and-analyze-builds/bitrise-for-mac.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/bitrise-for-mac.mdx
@@ -19,7 +19,7 @@ Bitrise for Mac is macOS only.
 
 Bitrise for Mac requires macOS 14.6 or later and a Bitrise account with access to at least one <GlossTerm baseform="workspace">workspace</GlossTerm> and project. If you want to track a local folder, you also need a local checkout of the repository.
 
-1. Download `Bitrise.dmg`.
+1. Download the `Bitrise.dmg` [file from GitHub](https://github.com/bitrise-io/bitrise-desktop-app/releases/latest/download/Bitrise.dmg).
 1. Open the `.dmg` and drag Bitrise onto the **Applications** folder.
 1. Launch Bitrise from **Applications**.
 

--- a/docs/bitrise-ci/run-and-analyze-builds/bitrise-for-mac.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/bitrise-for-mac.mdx
@@ -1,0 +1,108 @@
+---
+title: "Bitrise for Mac"
+description: "Install Bitrise for Mac, sign in, and track the status of your builds for the branch you're working on, right from the macOS menu bar."
+sidebar_position: 9
+slug: /bitrise-ci/run-and-analyze-builds/bitrise-for-mac
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GlossTerm from '@site/src/components/GlossTerm';
+
+Bitrise for Mac is a native macOS menu bar app that shows the live status of your builds for the branch you're working on, so you don't need to open a browser tab to check build status.
+
+:::note
+Bitrise for Mac is macOS only.
+:::
+
+## Installing the app
+
+Bitrise for Mac requires macOS 14.6 or later and a Bitrise account with access to at least one <GlossTerm baseform="workspace">workspace</GlossTerm> and project. If you want to track a local folder, you also need a local checkout of the repository.
+
+1. Download `Bitrise.dmg`.
+1. Open the `.dmg` and drag Bitrise onto the **Applications** folder.
+1. Launch Bitrise from **Applications**.
+
+The app appears as an icon in the menu bar on the top of your screen. On first launch, it shows an unconfigured state until you sign in.
+
+## Signing in
+
+1. Click the Bitrise icon in the menu bar.
+1. Click **Connect to Bitrise**. The app opens your browser to sign in.
+1. Complete sign-in in the browser, then return to the app.
+
+After sign-in, the app stores your access token in the macOS Keychain and refreshes it automatically. Your signed-in handle appears in the build list header and in **Settings**.
+
+## Choosing a workspace
+
+The selected workspace scopes everything the app shows, including builds, filters, and local-folder matching.
+
+- If you belong to one workspace, it's selected automatically.
+- If you belong to several, pick one from the workspace picker.
+- If you belong to none, the app points you to the Bitrise web UI to get access.
+
+You can switch workspace later from **Settings**, in the **Account** pane.
+
+## Adding projects to watch
+
+The build list starts empty. You populate it by subscribing to one or more projects in Settings, in the Projects pane. There are two ways to add a project:
+
+- **Subscribing to a project directly**: This is a project-health watch. Use it to keep an eye on a project regardless of what you have checked out locally, for example, to confirm `main` stays green.
+- **Tracking a local folder**: The app matches each repository to its Bitrise project by the git remote URL, so you don't need to pick the project manually. It then tracks builds for the branch you currently have checked out, and stays in sync as you switch branches locally.
+
+<Tabs>
+<TabItem value="subscribing-to-a-project-directly" label="Subscribing directly" default>
+
+1. Open **Settings** and go to the **Projects** pane.
+1. Choose a project from your workspace to watch.
+
+</TabItem>
+<TabItem value="tracking-a-local-folder" label="Tracking a local folder">
+
+1. In the **Projects** pane, choose to add a local folder and browse to it.
+1. The app scans the folder and its subfolders for git repositories and lists what it finds.
+1. Select the repositories you want to track.
+
+</TabItem>
+</Tabs>
+
+:::note
+A branch with no builds in Bitrise shows an empty list. If you switch to a new branch that hasn't run any builds yet, that's expected.
+:::
+
+## Setting filters and notifications
+
+Each project you watch has its own settings, edited in its detail view in the **Projects** pane.
+
+- **Branch filter**: Choose which branches a project tracks. For local folders, this stays in sync with your checkout automatically.
+- **Show only builds since the last push**: for local folders, hide builds that started before your most recent push, so old runs on the same branch don't clutter the list.
+- **Notification mode**: set each project to off, failures only, or every completion. A global **Allow notifications** switch in the Notifications pane turns all banners on or off.
+
+## Reading build status
+
+The menu bar icon mirrors the most recently started build across the projects you watch:
+
+- **Passed**: the most recent build passed.
+- **Failed**: the most recent build failed.
+- **Running**: a build is in progress.
+- **Aborted**: the most recent build was aborted.
+
+Click the icon to open the build list. Each build appears as a card showing its status and commit message, the branch or tag, the <GlossTerm baseform="workflow">Workflow</GlossTerm> or <GlossTerm baseform="pipeline">Pipeline</GlossTerm> name, and the start time, duration, and build number. From a card, you can open the build, the pull request, or the commit on Bitrise in one click.
+
+For the full list of build statuses Bitrise tracks, see [Build statuses](/en/bitrise-ci/run-and-analyze-builds/build-statuses).
+
+## Keeping the app updated
+
+The app checks for newer releases periodically, and on demand from **Settings**, in the **About** pane, using **Check Now**. 
+
+When an update is available, you can download the new `.dmg`. Install it by dragging the app into **Applications**, the same way as the first install.
+
+## Troubleshooting
+
+| What you see | What it means and what to do |
+| --- | --- |
+| Empty build list on a branch | That branch has no builds in Bitrise. Switch to a branch with build history, or trigger a build. |
+| Project not found for a folder | The folder's git remote doesn't match a project in the selected workspace. Confirm the remote and the workspace. |
+| Remote is outside this workspace | The repository belongs to a different workspace. Switch workspace in the Account pane. |
+| Detached HEAD or no remote | The app can't determine a branch to track. Check out a branch with an upstream remote. |
+| Sign-in error | Authentication failed or expired. Sign in again from the menu bar. |


### PR DESCRIPTION
## Summary
- Adds a new documentation page for the Bitrise for Mac menu bar app, covering installation, signing in, workspace/project selection, filters and notifications, build status, and troubleshooting.
- Links the `Bitrise.dmg` download to its GitHub release asset.

## Test plan
- [x] `npm run build` passes
- [x] Verified in local preview at `/en/bitrise-ci/run-and-analyze-builds/bitrise-for-mac`