### PR TITLE
feat: add click-to-zoom lightbox for doc images

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -422,10 +422,10 @@ const config: Config = {
       additionalLanguages: ['yaml', 'bash', 'json', 'ruby', 'swift', 'kotlin', 'groovy', 'dart'],
     },
     zoom: {
-      selector: '.markdown img',
+      selector: '.markdown img:not(a > img)',
       background: {
-        light: 'var(--sys-bg-surface)',
-        dark: '#1a1a2e',
+        light: 'var(--ifm-background-color)',
+        dark: 'var(--ifm-background-color)',
       },
       config: {
         margin: 24,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -319,6 +319,7 @@ const config: Config = {
       },
     ],
     changelogFeedPlugin,
+    'docusaurus-plugin-image-zoom',
     function webpackFallbacks() {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const webpack = require('webpack');
@@ -419,6 +420,16 @@ const config: Config = {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
       additionalLanguages: ['yaml', 'bash', 'json', 'ruby', 'swift', 'kotlin', 'groovy', 'dart'],
+    },
+    zoom: {
+      selector: '.markdown img',
+      background: {
+        light: 'var(--sys-bg-surface)',
+        dark: '#1a1a2e',
+      },
+      config: {
+        margin: 24,
+      },
     },
   } satisfies Preset.ThemeConfig,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mdx-js/react": "^3.0.0",
         "buffer": "^6.0.3",
         "clsx": "^2.0.0",
+        "docusaurus-plugin-image-zoom": "^3.0.1",
         "docusaurus-plugin-openapi-docs": "^5.0.2",
         "docusaurus-theme-openapi-docs": "^5.0.2",
         "prism-react-renderer": "^2.3.0",
@@ -4244,6 +4245,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.1.tgz",
       "integrity": "sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.10.1",
         "@docusaurus/logger": "3.10.1",
@@ -11604,6 +11606,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/docusaurus-plugin-image-zoom": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-image-zoom/-/docusaurus-plugin-image-zoom-3.0.1.tgz",
+      "integrity": "sha512-mQrqA99VpoMQJNbi02qkWAMVNC4+kwc6zLLMNzraHAJlwn+HrlUmZSEDcTwgn+H4herYNxHKxveE2WsYy73eGw==",
+      "license": "MIT",
+      "dependencies": {
+        "medium-zoom": "^1.1.0",
+        "validate-peer-dependencies": "^2.2.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/theme-classic": ">=3.0.0"
+      }
+    },
     "node_modules/docusaurus-plugin-openapi-docs": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/docusaurus-plugin-openapi-docs/-/docusaurus-plugin-openapi-docs-5.0.2.tgz",
@@ -15366,6 +15381,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/medium-zoom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.1.0.tgz",
+      "integrity": "sha512-ewyDsp7k4InCUp3jRmwHBRFGyjBimKps/AJLjRSox+2q/2H4p/PNpQf+pwONWlJiOudkBXtbdmVbFjqyybfTmQ==",
+      "license": "MIT"
+    },
     "node_modules/memfs": {
       "version": "4.57.2",
       "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.57.2.tgz",
@@ -18318,6 +18339,27 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
     },
+    "node_modules/path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
+      "license": "MIT",
+      "dependencies": {
+        "path-root-regex": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
@@ -20588,6 +20630,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -21316,6 +21359,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-package-path": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-4.0.3.tgz",
+      "integrity": "sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-root": "^0.1.1"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/resolve-pathname": {
@@ -23651,6 +23706,19 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/validate-peer-dependencies": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/validate-peer-dependencies/-/validate-peer-dependencies-2.2.0.tgz",
+      "integrity": "sha512-8X1OWlERjiUY6P6tdeU9E0EwO8RA3bahoOVG7ulOZT5MqgNDUO/BQoVjYiHPcNe+v8glsboZRIw9iToMAA2zAA==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-package-path": "^4.0.3",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/validate.io-array": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@mdx-js/react": "^3.0.0",
     "buffer": "^6.0.3",
     "clsx": "^2.0.0",
+    "docusaurus-plugin-image-zoom": "^3.0.1",
     "docusaurus-plugin-openapi-docs": "^5.0.2",
     "docusaurus-theme-openapi-docs": "^5.0.2",
     "prism-react-renderer": "^2.3.0",


### PR DESCRIPTION
## Summary
- Wire in `docusaurus-plugin-image-zoom` so readers can click any doc image to view it enlarged, instead of being stuck at inline size.
- Scope the zoom selector to skip images that are already wrapped in a link (e.g. the MCP install badge), so those keep navigating normally instead of opening the lightbox.
- Reuse the site's `--ifm-background-color` var for the zoom overlay background instead of a hardcoded color, so it can't drift from the theme.

## Test plan
- [x] Verified locally: clicking a doc image opens the zoomed overlay, background matches the site's surface color, and click-away closes it.
- [x] Confirmed linked images (e.g. the MCP install badge) still navigate on click instead of zooming.
- [x] `npm run build` completes successfully.