### PR TITLE
Enable docusaurus-plugin-llms to generate llms.txt, llms-full.txt and per-page markdown

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -320,6 +320,29 @@ const config: Config = {
     ],
     changelogFeedPlugin,
     'docusaurus-plugin-image-zoom',
+    [
+      'docusaurus-plugin-llms',
+      {
+        // Auto-generate llms.txt, llms-full.txt and per-page markdown mirrors
+        // of the docs so AI coding agents can consume the documentation
+        // directly. Title and description fall back to the site config.
+        generateLLMsTxt: true,
+        generateLLMsFullTxt: true,
+        generateMarkdownFiles: true,
+        // The docs live under docs/ but are served under the `en/` route base.
+        // Dropping the source directory prefix keeps every generated markdown
+        // URL uniform (e.g. /bitrise-ci/… .md) instead of leaking a `docs/`
+        // segment for the pages that lack an explicit slug.
+        preserveDirectoryStructure: false,
+        // Pages are MDX-heavy; drop the component import lines from the output.
+        excludeImports: true,
+        // Skip the OpenAPI-generated API reference: those pages are almost
+        // entirely theme components fed by the embedded specs, so text
+        // extraction yields near-empty pages. The specs under api/ stay the
+        // machine-readable source for those endpoints.
+        ignoreFiles: ['**/api-reference/**'],
+      },
+    ],
     function webpackFallbacks() {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const webpack = require('webpack');

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "buffer": "^6.0.3",
         "clsx": "^2.0.0",
         "docusaurus-plugin-image-zoom": "^3.0.1",
+        "docusaurus-plugin-llms": "^0.4.0",
         "docusaurus-plugin-openapi-docs": "^5.0.2",
         "docusaurus-theme-openapi-docs": "^5.0.2",
         "prism-react-renderer": "^2.3.0",
@@ -11617,6 +11618,66 @@
       },
       "peerDependencies": {
         "@docusaurus/theme-classic": ">=3.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.4.0.tgz",
+      "integrity": "sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==",
+      "license": "MIT",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "minimatch": "^9.0.3",
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rachfop"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/docusaurus-plugin-openapi-docs": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "buffer": "^6.0.3",
     "clsx": "^2.0.0",
     "docusaurus-plugin-image-zoom": "^3.0.1",
+    "docusaurus-plugin-llms": "^0.4.0",
     "docusaurus-plugin-openapi-docs": "^5.0.2",
     "docusaurus-theme-openapi-docs": "^5.0.2",
     "prism-react-renderer": "^2.3.0",


### PR DESCRIPTION
## What
Enables the [`docusaurus-plugin-llms`](https://www.npmjs.com/package/docusaurus-plugin-llms) community plugin so the site build auto-generates:
- `llms.txt` — a concise index of docs with links
- `llms-full.txt` — the full docs content concatenated into one file
- Per-page markdown mirrors of every doc page

These are the files AI coding agents (Cursor, Windsurf, Copilot, Claude Code, etc.) look for when working against a docs site.

## Config choices
- `generateLLMsTxt` / `generateLLMsFullTxt` / `generateMarkdownFiles`: all enabled.
- `excludeImports: true` — strips MDX import statements from generated output (this site's docs are import-heavy).
- `ignoreFiles: ['**/api-reference/**']` — excludes the ~164 auto-generated OpenAPI reference pages. Those pages are almost entirely theme components (`<MethodEndpoint>`, `<StatusCodes>`) driven by an embedded spec, not prose — text extraction on them yields near-empty, low-value pages. The specs remain the machine-readable source for those endpoints.
- `preserveDirectoryStructure: false` — this site's `docsDir` (`docs`) differs from its `routeBasePath` (`en`). The plugin's default leaks a `docs/` path segment into generated URLs for any page lacking an explicit frontmatter `slug` (~31 pages here). Setting this to `false` keeps every generated markdown URL uniform.

## Verification
Ran a full production build locally and confirmed:
- Build succeeds, all existing plugins/pages unaffected (579 HTML pages under `/en/`, all 164 OpenAPI reference pages still rendered).
- `llms.txt` (112K) and `llms-full.txt` (2.1M) generated at build root; 416 per-page `.md` files generated.
- 0 broken/inconsistent links — every link in `llms.txt`/`llms-full.txt` resolves to an actual generated `.md` file.
- 0 API-reference leakage into `llms.txt`.

## Known limitation
This repo shares content across pages via `@site/src/partials/` component imports. The plugin only inlines relative `./_*.mdx`-style imports, not this convention, so a handful of pages will be missing shared partial content in the generated markdown/llms output (HTML pages are unaffected). This is a plugin limitation, not something addressable via its documented options — flagging here for visibility rather than blocking on it.

## package-lock.json
Kept the diff minimal/surgical — only the plugin's own dependency tree entries, verified byte-identical to what `npm` itself computes for this install. Excluded unrelated lockfile drift (optional native deps, peer-metadata churn) that a full `npm install` reconcile would otherwise have pulled in on this platform.