### PR TITLE
feat: add nightly sync workflow for bitrise-mcp docs

### DIFF
--- a/.github/workflows/sync-mcp-docs.yml
+++ b/.github/workflows/sync-mcp-docs.yml
@@ -1,0 +1,71 @@
+name: Sync MCP docs
+
+# Keeps the Bitrise MCP server docs (docs/bitrise-platform/ai/bitrise-mcp/) in
+# sync with the docs/ folder of bitrise-io/bitrise-mcp. Runs nightly and on
+# demand ("Run workflow"). When new commits on bitrise-mcp's main branch touch
+# docs/, it re-syncs the affected content and opens a PR for review — it
+# never commits to main directly.
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # 06:00 UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: sync-mcp-docs
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Refreshes the tracked HEAD SHA only when new commits on bitrise-mcp's
+      # main branch touched docs/ since the last sync; see
+      # scripts/check_bitrise_mcp_commits.py.
+      - name: Check bitrise-mcp for new docs commits
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN || github.token }}
+        run: |
+          python3 scripts/check_bitrise_mcp_commits.py | tee check-result.json
+          status=$(python3 -c "import json; print(json.load(open('check-result.json'))['status'])")
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          rm -f check-result.json
+
+      - name: Sync the changed docs
+        if: steps.check.outputs.status != 'unchanged'
+        env:
+          GITHUB_TOKEN: ${{ secrets.DOCS_SYNC_TOKEN || github.token }}
+        run: python3 scripts/sync_mcp_docs.py
+
+      # Opens (or updates) a PR with the synced content. Uses a PAT/App token
+      # when available so the PR triggers the deploy preview + checks; falls
+      # back to GITHUB_TOKEN (PR opens, but no downstream checks run).
+      - name: Open PR
+        if: steps.check.outputs.status != 'unchanged'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.DOCS_SYNC_TOKEN || github.token }}
+          base: main
+          branch: auto/mcp-docs-sync
+          delete-branch: true
+          add-paths: |
+            docs/bitrise-platform/ai/bitrise-mcp
+            scripts/mcp_docs_sync_state.json
+          commit-message: 'chore: sync bitrise-mcp docs'
+          title: 'chore: sync bitrise-mcp docs'
+          labels: |
+            automated
+            documentation
+          body: |
+            Automated sync of the Bitrise MCP server docs — new commits on
+            `bitrise-io/bitrise-mcp`'s `main` branch touched its `docs/`
+            folder since the last sync. Review the diff before merging.
+
+            Triggered by `.github/workflows/sync-mcp-docs.yml`.

--- a/scripts/check_bitrise_mcp_commits.py
+++ b/scripts/check_bitrise_mcp_commits.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Detect new commits touching docs/ in bitrise-io/bitrise-mcp since the last sync.
+
+Usage:
+  python3 scripts/check_bitrise_mcp_commits.py           # check for changes
+  python3 scripts/check_bitrise_mcp_commits.py --update  # force-refresh the stored SHA
+
+Output (JSON to stdout): { "status": "unchanged" | "changed" | "initialized", "head_sha": "..." }
+
+On "changed"/"initialized", scripts/mcp_docs_sync_state.json is overwritten with
+the new HEAD SHA. Run scripts/sync_mcp_docs.py afterwards to pull the content.
+
+Authentication:
+  Set GITHUB_TOKEN in the environment to use authenticated requests and to
+  read bitrise-io/bitrise-mcp if it isn't public.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO = "bitrise-io/bitrise-mcp"
+STATE_FILE = Path(__file__).parent / "mcp_docs_sync_state.json"
+
+
+def gh_request(url: str):
+    token = os.environ.get("GITHUB_TOKEN")
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "mcp-docs-sync/1.0"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def main():
+    force_update = "--update" in sys.argv
+    state = json.loads(STATE_FILE.read_text(encoding="utf-8")) if STATE_FILE.exists() else {}
+    last_sha = None if force_update else state.get("last_sha")
+
+    head_sha = gh_request(f"https://api.github.com/repos/{REPO}/commits/main")["sha"]
+
+    if last_sha is None:
+        status = "initialized"
+    elif last_sha == head_sha:
+        status = "unchanged"
+    else:
+        compare = gh_request(f"https://api.github.com/repos/{REPO}/compare/{last_sha}...{head_sha}")
+        touched = [f["filename"] for f in compare.get("files", []) if f["filename"].startswith("docs/")]
+        status = "changed" if touched else "unchanged"
+
+    if status != "unchanged":
+        STATE_FILE.write_text(json.dumps({"last_sha": head_sha}, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps({"status": status, "head_sha": head_sha}))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mcp_docs_sync_state.json
+++ b/scripts/mcp_docs_sync_state.json
@@ -1,0 +1,3 @@
+{
+  "last_sha": "763ee5c7c97129f33f689e5dccec31bdf183a349"
+}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sync-mcp-docs.yml`: a nightly (06:00 UTC) + on-demand workflow that checks `bitrise-io/bitrise-mcp` for new commits touching its `docs/` folder, syncs the changed content via the existing `scripts/sync_mcp_docs.py`, and opens a PR here for review — never commits to `main` directly.
- Adds `scripts/check_bitrise_mcp_commits.py`: a small companion script (mirrors the ETag/SHA-gate shape of `scripts/spec_sync.py`) that tracks the last-seen `bitrise-mcp` commit SHA and detects whether any new commits touched `docs/` since then.
- Adds `scripts/mcp_docs_sync_state.json`, seeded with the SHA already recorded by the equivalent local scheduled routine, so the first CI run doesn't treat this as a cold start and open a redundant full-resync PR.

## Test plan
- [ ] Confirm the workflow runs successfully on its first nightly trigger (or via manual `workflow_dispatch` once merged to `main`, since `workflow_dispatch` requires the workflow file to already exist on the default branch)
- [ ] Confirm it correctly reports `unchanged` if no new `bitrise-mcp` commits have touched `docs/` since the seeded SHA
- [ ] Once a real `bitrise-mcp` docs change lands, confirm the opened PR contains the expected diff under `docs/bitrise-platform/ai/bitrise-mcp/`