### PR TITLE
ci: sync redirects to Cloudflare on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,17 @@ jobs:
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: pages deploy ./build --project-name=bitrise-docs --branch=${{ github.head_ref || github.ref_name }}
 
+      # Redirects are served by a Cloudflare Bulk Redirects list, not by the
+      # Pages deploy above. Editing redirects.json has no effect until this
+      # syncs it, so run it on every push to main. Gated off PRs so preview
+      # builds never mutate the production redirect list.
+      - name: Upload redirects to Cloudflare
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: npm run cloudflare:upload_redirects
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+
       - name: Comment preview URL
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7


### PR DESCRIPTION
## Problem

Production redirects are served by a **Cloudflare Bulk Redirects list** (`bitrise_docs`), which is updated *only* by `npm run cloudflare:upload_redirects` (`cloudflare.js`). That script is defined in `package.json` but **called by no workflow** — so editing `redirects.json` and merging to `main` has never actually deployed a redirect.

The deployed list is a stale snapshot from a past manual run. This is why e.g. `https://docs.bitrise.io/en/bitrise-ci/deploying.html` still 404s even though its mapping has been on `main` for a while, and why the redirect fixes in #101 / #103 don't take effect on merge.

## Change

Add a step to `deploy.yml` that runs the redirect upload on every push to `main`, right after the Pages deploy:

```yaml
- name: Upload redirects to Cloudflare
  if: github.event_name == 'push' && github.ref == 'refs/heads/main'
  run: npm run cloudflare:upload_redirects
  env:
    CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
    CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
```

- **Gated to `push` on `main`** so pull-request preview builds never mutate the production redirect list.
- Runs after the Pages deploy; independent of it.

## Required secret (action needed before/at merge)

- `CF_ACCOUNT_ID` — already configured (used by the Pages deploy).
- `CF_API_TOKEN` — **needs a token with account-level _Rules → Lists_ edit permission.** The existing `CF_API_TOKEN_PAGES` is scoped for Pages and may not carry Lists permission. Either add a dedicated `CF_API_TOKEN` secret, or, if `CF_API_TOKEN_PAGES` already has Lists scope, switch the `env` to reuse it.

## After merge

The first push to `main` runs the sync and makes the already-merged fixes (#101, #103) live. Note `cloudflare.js` uses a strict `JSON.parse`; #101 fixed the trailing comma that would otherwise have made this step fail, so #101 must be on `main` first (it is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
