### PR TITLE
Update changelog for July 2026 doc changes

### DIFF
--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -9,6 +9,24 @@
 
 <!-- changelog-entries -->
 
+## 2026 July
+
+### <time dateTime="2026-07-10">2026-07-10</time> Building a Slack-native coding agent {#2026-07-10-building-a-slack-native-coding-agent}
+
+A new recipe walks through a reference architecture for a Slack-native coding agent: a locked-down orchestrator that delegates coding work to disposable Remote Dev Environments, plus an open source reference implementation you can try. See [Building a Slack-native coding agent](/en/bitrise-rde/recipes/building-a-slack-native-coding-agent-recipe).
+
+### <time dateTime="2026-07-09">2026-07-09</time> Bitrise for Mac menu bar app guide {#2026-07-09-bitrise-for-mac-menu-bar-app-guide}
+
+A new guide covers the Bitrise for Mac menu bar app: installing it, signing in, selecting a workspace and project, configuring filters and notifications, and troubleshooting. See [Bitrise for Mac](/en/bitrise-ci/run-and-analyze-builds/bitrise-for-mac).
+
+### <time dateTime="2026-07-07">2026-07-07</time> Product subscriptions can now be canceled independently {#2026-07-07-product-subscriptions-can-now-be-canceled-independently}
+
+Each product (Bitrise CI, Build Cache, Release Management, and so on) has its own independently cancellable subscription, and add-ons can be canceled on their own too. The docs now walk through the updated **Plan & Billing** cancellation flow. See [Workspace billing and invoicing](/en/bitrise-platform/workspaces/workspace-billing-and-invoicing).
+
+### <time dateTime="2026-07-02">2026-07-02</time> Bitrise MCP server drops self-registration tools {#2026-07-02-bitrise-mcp-server-drops-self-registration-tools}
+
+The `register` and `verify_registration` tools, along with the `registration` API group, are no longer part of the Bitrise MCP server. See [Bitrise MCP tools](/en/bitrise-platform/ai/bitrise-mcp/tools).
+
 ## 2026 June
 
 ### <time dateTime="2026-06-29">2026-06-29</time> RDE API reference now available in-site {#2026-06-29-rde-api-reference-now-available-in-site}


### PR DESCRIPTION
## Summary
- Adds 4 changelog entries covering merged doc PRs not yet reflected in the changelog: the Slack-native coding agent recipe, the Bitrise for Mac guide, the updated subscription cancellation flow, and the MCP server's dropped self-registration tools.
- Retroactive pass — skips PRs that were pure UI-label/table/broken-link corrections with no new reader-facing information.

🤖 Generated with [Claude Code](https://claude.com/claude-code)