### PR TITLE
docs: refresh RDE CLI docs to match current bitrise-cli behavior

### DIFF
--- a/docs/bitrise-rde/getting-started/quickstart.mdx
+++ b/docs/bitrise-rde/getting-started/quickstart.mdx
@@ -43,15 +43,15 @@ Run these commands in your terminal.
    ```
    :::note
 
-   If you belong to more than one workspace, set the one to use with the `--workspace` flag or the `BITRISE_WORKSPACE_ID` environment variable. You can also set a default workspace with `bitrise-cli config set default_workspace_id <id>`.
+   If you belong to more than one workspace, the CLI asks you to pick one. To skip the prompt, set a default with `bitrise-cli config set default_workspace_id <id>`, or use the `--workspace` flag.
 
    :::
 1. Pick a stack and a machine type. 
-1. Claude Code will open the browser for authorization. Sign in with your subscription or API key.
+1. Authenticate Claude Code if prompted. If no credential is saved for you yet, the CLI picks up your local Claude Code credential, or opens the browser so you can sign in with your subscription or API key. The credential is saved, so future sessions start with Claude Code already authenticated.
 
    :::tip
 
-   To skip this step on future sessions, save your Claude Code credential once in the [Bitrise RDE UI](/en/bitrise-rde/rde-options/bitrise-rde-ui#authentication). Sessions that include the credential in their template will start with Claude Code already authenticated.
+   You can also save or update the credential in the [Bitrise RDE UI](/en/bitrise-rde/rde-options/bitrise-rde-ui#authentication).
 
    :::
 
@@ -80,6 +80,8 @@ Opening a VNC viewer works for macOS sessions, which have a graphical desktop. L
 :::
 
 ## Resume your session later
+
+If your connection drops, the CLI reconnects automatically while Claude Code keeps running in the session. Press Ctrl-C during a reconnect to detach and leave the machine running.
 
 When you exit Claude Code, the session is automatically terminated to free the machine, but it's preserved so you can come back to it. From the same repository folder, resume your most recent session and conversation:
 

--- a/docs/bitrise-rde/rde-options/bitrise-rde-cli.mdx
+++ b/docs/bitrise-rde/rde-options/bitrise-rde-cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Bitrise RDE CLI"
-description: "Install and use the Bitrise RDE CLI to create and connect to Remote Dev Environment sessions, transfer files, and run AI coding agents from your terminal."
+description: "Install and use the Bitrise RDE CLI to create and connect to Remote Dev Environment sessions, run commands, transfer files, and run AI coding agents from your terminal."
 sidebar_position: 1
 slug: /bitrise-rde/rde-options/bitrise-rde-cli
 ---
@@ -9,7 +9,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GlossTerm from '@site/src/components/GlossTerm';
 
-The Bitrise RDE CLI lets you manage Remote Dev Environments from your terminal: create and connect to <GlossTerm baseform="rde session">sessions</GlossTerm>, transfer files, and start AI coding agents. The CLI is open source, and all RDE commands live under `bitrise-cli rde`.
+The Bitrise RDE CLI lets you manage Remote Dev Environments from your terminal: create and connect to <GlossTerm baseform="rde session">sessions</GlossTerm>, run commands in them, transfer files, and start AI coding agents. The CLI is open source, and all RDE commands live under `bitrise-cli rde`.
 
 If you just want to get started fast, follow the [Quickstart](/en/bitrise-rde/getting-started/quickstart). This page is the broader reference for what the CLI can do.
 
@@ -33,42 +33,84 @@ bitrise-cli auth login
 
 Check your status with `bitrise-cli auth status`, and sign out with `bitrise-cli auth logout`. For non-interactive use, such as CI, set the `BITRISE_TOKEN` environment variable to a personal access token, or pipe a token into `bitrise-cli auth login --with-token`.
 
-If you belong to more than one <GlossTerm baseform="workspace">workspace</GlossTerm>, set the one to use with the `--workspace` flag or the `BITRISE_WORKSPACE_ID` environment variable.
+### Choosing a workspace
+
+RDE commands run against a <GlossTerm baseform="workspace">workspace</GlossTerm>. If you belong to exactly one, the CLI selects it automatically. If you belong to more than one, the CLI asks you to pick one. To skip the prompt, save a default:
+
+```bash
+bitrise-cli config set default_workspace_id WORKSPACE_ID
+```
+
+For a single command, the `--workspace` flag takes precedence, followed by the `BITRISE_WORKSPACE_ID` environment variable, then the saved default.
 
 ## Managing sessions
 
-The `bitrise-cli rde session` commands cover the full session lifecycle:
+The `bitrise-cli rde session` commands cover the full session lifecycle. Commands that take a `SESSION_ID` also accept the session's name, as long as the name is unique.
 
 | Command | What it does |
 | --- | --- |
-| `bitrise-cli rde session create NAME` | Create a session from a `--template`, or directly with `--image` and `--machine-type`. |
+| `bitrise-cli rde session create NAME` | Create a session from a `--template`, or without one by passing `--stack` and `--machine-type`. Add `--wait` to block until the session is running. |
 | `bitrise-cli rde session list` | List your sessions and their status. |
 | `bitrise-cli rde session view SESSION_ID` | Show a session's details, including connection credentials. |
-| `bitrise-cli rde session exec SESSION_ID -- COMMAND` | Run a command in the session over SSH. |
-| `bitrise-cli rde session open-vnc SESSION_ID` | Open a VNC viewer to the session's desktop (macOS only). |
+| `bitrise-cli rde session update SESSION_ID` | Rename a session, change its description, or adjust its auto-terminate timer. |
+| `bitrise-cli rde session exec SESSION_ID -- COMMAND` | Run a command in the session over SSH. See [Running commands in a session](#running-commands-in-a-session). |
 | `bitrise-cli rde session upload SESSION_ID LOCAL_PATH REMOTE_FOLDER` | Upload a file or folder into the session. |
 | `bitrise-cli rde session download SESSION_ID REMOTE_PATH LOCAL_PATH` | Download a file or folder from the session. |
+| `bitrise-cli rde session vnc SESSION_ID` | Print the session's VNC connection details, or tunnel them to a local port with `--forward` (macOS only). |
+| `bitrise-cli rde session open-vnc SESSION_ID` | Open the session's desktop in your default VNC viewer (macOS only). |
+| `bitrise-cli rde session logs SESSION_ID --stage startup` | Print the session's warmup or startup script logs. Add `--follow` to stream them live. |
+| `bitrise-cli rde session notifications SESSION_ID` | List events the session emitted, such as agent stops and permission prompts. |
+| `bitrise-cli rde session diff SESSION_ID` | Show how the session's template changed since the session was created. |
 | `bitrise-cli rde session terminate SESSION_ID` | Stop the machine but keep the session for later. |
-| `bitrise-cli rde session restore SESSION_ID` | Restart a terminated session from its persistent disk. |
+| `bitrise-cli rde session restore SESSION_ID` | Restart a terminated session from its persistent disk. Add `--wait` to block until it's running. |
 | `bitrise-cli rde session delete SESSION_ID` | Permanently delete a terminated session. |
+| `bitrise-cli rde session delete-terminated` | Permanently delete all terminated sessions in the workspace. |
+
+## Running commands in a session
+
+`bitrise-cli rde session exec` runs a single command in a session and streams its output back, without opening an interactive shell. It's the main building block for scripting sessions and for letting AI agents drive them:
+
+```bash
+bitrise-cli rde session exec SESSION_ID -- npm test
+```
+
+The command runs in a login shell, so the session's `PATH`, Homebrew packages, and language version managers are all available. If a local SSH agent is running, the CLI forwards it into the session, so Git over SSH inside the session uses your local keys.
+
+Everything after `--` is passed as a program with literal arguments. To use pipes, `&&`, or redirection, add `--shell` and quote the command:
+
+```bash
+bitrise-cli rde session exec SESSION_ID --shell -- 'cd my-app && xcodebuild | xcpretty'
+```
+
+The most useful flags:
+
+- `--timeout`: the remote command is stopped after 10 minutes by default. Raise the cap for long builds (`--timeout 30m`) or disable it with `--timeout 0`.
+- `--env`: forward a local environment variable to the remote command (`--env NPM_TOKEN`), or set a literal value (`--env CI=1`). Forwarded values are never printed locally, but they are visible in the session's process list while the command runs.
+- `--output json`: emit a single JSON object with the exit code, stdout, and stderr — easy to parse from a script or an agent.
+
+To share a list of forwarded environment variables with your team, add them to `.bitrise/rde.yml` in your repository:
+
+```yaml
+exec:
+  env:
+    - API_BASE_URL
+    - NPM_TOKEN=abc123
+```
+
+The `exec` command reads the file from the working directory or any parent folder and forwards the listed variables on every run. `--env` overrides a same-named entry, and `--no-env-file` skips the file entirely.
 
 ## Running AI coding agents
 
 The `bitrise-cli rde claude` command creates a session, clones your current repository branch into it, and drops you into Claude Code running on the cloud machine. While the agent works, the CLI keeps a secure connection open so it can open a VNC viewer or transfer files to and from your local machine.
 
-:::note
+This is the recommended way to start. For the full walkthrough, see the [Quickstart](/en/bitrise-rde/getting-started/quickstart). Some behaviors worth knowing:
 
-If you belong to more than one workspace, set the one to use with the `--workspace` flag or the `BITRISE_WORKSPACE_ID` environment variable.
+- The CLI asks you to pick a stack and a machine type, and remembers your choice for the repository. Pass `--stack` and `--machine-type` to skip the prompts, for example in scripts.
+- If no Claude Code credential is saved for your workspace yet, the CLI picks up your local one, or opens the browser so you can create one, and saves it for future sessions. You can also manage the credential in the [Bitrise RDE UI](/en/bitrise-rde/rde-options/bitrise-rde-ui#authentication).
+- If the connection drops, the CLI reconnects automatically while Claude Code keeps running in the session. Press Ctrl-C during a reconnect to detach and leave the machine running.
+- When you exit Claude Code, the session is terminated automatically, but preserved so you can restore it later.
 
-:::
-
-This is the recommended way to start. For the full walkthrough, see the [Quickstart](/en/bitrise-rde/getting-started/quickstart). To return to a session later, use `bitrise-cli rde claude --continue` or `bitrise-cli rde claude --resume`.
-
-:::tip
-
-To avoid authenticating Claude Code every time, save your credential once in the [Bitrise RDE UI](/en/bitrise-rde/rde-options/bitrise-rde-ui#authentication). Sessions that include it will start with Claude Code already authenticated.
-
-:::
+To return to a session, use `bitrise-cli rde claude --continue` for the most recent one, or `bitrise-cli rde claude --resume` to pick from a list. Resuming reconnects to a running session, or restores a terminated one and continues the same Claude Code conversation.
 
 ## Templates, saved inputs, and machine options
 
@@ -76,9 +118,16 @@ The CLI also manages the configuration objects behind your sessions:
 
 - `bitrise-cli rde template`: list, create, view, update, and delete [templates](/en/bitrise-rde/configuration/templates).
 - `bitrise-cli rde saved-input`: list, create, view, update, and delete [saved inputs](/en/bitrise-rde/configuration/saved-inputs).
-- `bitrise-cli rde image list`: list the stacks available to you.
-- `bitrise-cli rde machine-type list --image NAME`: list the machine types that work with a given stack.
+- `bitrise-cli rde stack list`: list the stacks available in your workspace.
+- `bitrise-cli rde machine-type list --stack STACK_ID`: list the machine types compatible with a given stack.
 
 ## Full command reference
 
-For every command, flag, and argument, see the open-source repository and its generated reference: [bitrise-io/bitrise-cli](https://github.com/bitrise-io/bitrise-cli).
+Every command has detailed built-in help, written so that both people and AI agents can discover features from it. The help is updated together with the features themselves, so it's the most current reference:
+
+```bash
+bitrise-cli rde --help
+bitrise-cli rde session exec --help
+```
+
+The generated reference for every command, flag, and argument lives in the open-source repository: [bitrise-io/bitrise-cli](https://github.com/bitrise-io/bitrise-cli/tree/main/docs/cli).

--- a/docs/bitrise-rde/rde-options/connecting-to-a-session.mdx
+++ b/docs/bitrise-rde/rde-options/connecting-to-a-session.mdx
@@ -21,9 +21,11 @@ Each session has an SSH address and a one-time password, shown on the session de
 
 For passwordless access, register your SSH public key as a [saved input](/en/bitrise-rde/configuration/saved-inputs). Bitrise adds it to the session's authorized keys, so you can connect without copying a password each time. macOS sessions sign in as the `vagrant` user and Linux sessions as the `ubuntu` user.
 
+To run a single command without opening an interactive shell, use [`bitrise-cli rde session exec`](/en/bitrise-rde/rde-options/bitrise-rde-cli#running-commands-in-a-session).
+
 ## VNC
 
-macOS sessions expose a graphical desktop over VNC, which is useful for watching a simulator or a GUI app. The session detail page shows the VNC address and credentials, and builds a `vnc://` link that opens your VNC viewer. From the CLI, run `bitrise-cli rde session open-vnc SESSION_ID` to open the viewer directly.
+macOS sessions expose a graphical desktop over VNC, which is useful for watching a simulator or a GUI app. The session detail page shows the VNC address and credentials, and builds a `vnc://` link that opens your VNC viewer. From the CLI, run `bitrise-cli rde session open-vnc SESSION_ID` to open the viewer directly, or `bitrise-cli rde session vnc SESSION_ID` to print the connection details. If there's no direct network route to the session, `bitrise-cli rde session vnc SESSION_ID --forward 5901` tunnels the VNC endpoint to a local port over SSH.
 
 Linux sessions don't have a desktop, so VNC isn't available for them.
 


### PR DESCRIPTION
## Why

The [RDE CLI page](https://docs.bitrise.io/en/bitrise-rde/rde-options/bitrise-rde-cli) had drifted behind the CLI itself — flagged in [this Slack thread](https://bitfall.slack.com/archives/C068XS4M3RN/p1783953402811489), which specifically asked about `rde session exec` for driving sessions with local agents.

## What changed

Synced against `bitrise-io/bitrise-cli` HEAD (`2b78338`), using the generated command reference in `docs/cli/` as the source of truth.

**`bitrise-rde-cli.mdx`** (main refresh):
- Image → stack migration: `rde stack list`, `--stack` on `session create` / `claude`, `machine-type list --stack` (was `rde image list` / `--image`).
- New "Running commands in a session" section for `session exec`: `--shell`, `--timeout`, `--env` + `.bitrise/rde.yml` env forwarding, `--output json`, SSH agent forwarding.
- Session table now covers the new commands: `vnc` (incl. `--forward` tunneling), `logs`, `update`, `diff`, `notifications`, `delete-terminated`, plus `--wait` on `create`/`restore`, and name-as-ID resolution.
- New "Choosing a workspace" section: auto-detect, interactive picker, `config set default_workspace_id`, precedence order.
- `rde claude`: `--stack`/`--machine-type` to skip prompts, automatic Claude credential save, reconnect-forever + Ctrl-C detach semantics.
- "Full command reference" now points readers (and their agents) at `--help` as the always-current reference, per the Slack thread suggestion.

**`quickstart.mdx`**: workspace picker note, updated Claude Code auth step (browser only when no local credential), connection-drop/Ctrl-C note.

**`connecting-to-a-session.mdx`**: added `session vnc` / `--forward`, cross-link to the `exec` section.

No slugs changed, so no redirect updates needed. `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)