### PR TITLE
fix: homepage RDE CLI link 404 + redirects for old ways-to-use-rde URLs

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -1276,5 +1276,10 @@
   "/en/bitrise-ci/getting-started/migrating-to-bitrise/integrating-fastlane-to-bitrise": "/en/bitrise-ci/getting-started/migrating-to-bitrise/about-migrating-to-bitrise.html",
   "/en/bitrise-ci/run-and-analyze-builds/build-triggers/approving-pull-request-builds": "/en/bitrise-ci/run-and-analyze-builds/starting-builds/approving-pull-request-builds.html",
   "/en/bitrise-platform/getting-started/migrating-to-bitrise/migrating-from-app-center-to-bitrise": "/en/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-app-center-to-bitrise.html",
-  "/en/bitrise-platform/getting-started/migrating-to-bitrise/migrating-from-jenkins-to-bitrise": "/en/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-jenkins-to-bitrise.html"
+  "/en/bitrise-platform/getting-started/migrating-to-bitrise/migrating-from-jenkins-to-bitrise": "/en/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-jenkins-to-bitrise.html",
+  "/en/bitrise-rde/ways-to-use-rde/bitrise-rde-cli": "/en/bitrise-rde/rde-options/bitrise-rde-cli.html",
+  "/en/bitrise-rde/ways-to-use-rde/bitrise-rde-ui": "/en/bitrise-rde/rde-options/bitrise-rde-ui.html",
+  "/en/bitrise-rde/ways-to-use-rde/connecting-to-a-session": "/en/bitrise-rde/rde-options/connecting-to-a-session.html",
+  "/en/bitrise-rde/ways-to-use-rde/bitrise-vscode-plugin": "/en/bitrise-rde/rde-options/bitrise-vscode-plugin.html",
+  "/en/bitrise-rde/ways-to-use-rde/bitrise-rde-mcp-server": "/en/bitrise-rde/rde-options/bitrise-rde-mcp-server.html"
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -147,7 +147,7 @@ const sections: Section[] = [
       [
         {label: 'Remote Dev Environments overview', href: '/en/bitrise-rde/getting-started/remote-dev-environments-overview'},
         {label: 'Quickstart', href: '/en/bitrise-rde/getting-started/quickstart'},
-        {label: 'Bitrise RDE CLI', href: '/en/bitrise-rde/ways-to-use-rde/bitrise-rde-cli'},
+        {label: 'Bitrise RDE CLI', href: '/en/bitrise-rde/rde-options/bitrise-rde-cli'},
         {label: 'RDE API', href: '/en/bitrise-rde/configuration/rde-api'},
       ],
     ],


### PR DESCRIPTION
## Why

Clicking **Bitrise RDE CLI** on the docs homepage goes to a 404: the card still links to `/en/bitrise-rde/ways-to-use-rde/bitrise-rde-cli`, but the section was renamed to `rde-options` in 1d2e282 and that commit missed `src/pages/index.tsx`.

## What changed

- `src/pages/index.tsx`: homepage RDE card now links to `/en/bitrise-rde/rde-options/bitrise-rde-cli`.
- `redirects.json`: added redirects for all five renamed `ways-to-use-rde/*` URLs to their `rde-options/*` equivalents. The old URLs were live briefly, and the CLI one has been linked from the homepage since the rename, so crawlers and users have seen them.

`npm run build` passes and `redirects.json` parses as valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)