### PR TITLE
Replace generated llms.txt with a curated index (keep llms-full.txt and per-page markdown)

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -326,7 +326,7 @@ const config: Config = {
         // Auto-generate llms.txt, llms-full.txt and per-page markdown mirrors
         // of the docs so AI coding agents can consume the documentation
         // directly. Title and description fall back to the site config.
-        generateLLMsTxt: true,
+        generateLLMsTxt: false,
         generateLLMsFullTxt: true,
         generateMarkdownFiles: true,
         // The docs live under docs/ but are served under the `en/` route base.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -14,7 +14,6 @@ Every documentation page is also available as plain markdown: take the page path
 - [Adding a new project from a CLI](https://docs.bitrise.io/bitrise-ci/bitrise-cli/adding-a-new-project-from-a-cli.md): Register a Bitrise project from the command line and start building.
 - [Steplib (Steps catalog)](https://www.bitrise.io/integrations/steps): Browse all available Steps to compose into Workflows.
 - [Migrating from Jenkins](https://docs.bitrise.io/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-jenkins-to-bitrise.md): Moving CI from Jenkins.
-- [Migrating from App Center](https://docs.bitrise.io/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-app-center-to-bitrise.md): Moving from Microsoft App Center.
 
 ## Configuring builds
 
@@ -28,13 +27,15 @@ Every documentation page is also available as plain markdown: take the page path
 - [Quick start: Android projects](https://docs.bitrise.io/bitrise-ci/getting-started/quick-start-guides/getting-started-with-android-projects.md): End-to-end CI setup for Android.
 - [Quick start: Flutter projects](https://docs.bitrise.io/bitrise-ci/getting-started/quick-start-guides/getting-started-with-flutter-projects.md): End-to-end CI setup for Flutter.
 - [iOS code signing](https://docs.bitrise.io/bitrise-ci/code-signing/ios-code-signing/ios-code-signing.md): Configuring code signing for iOS — provisioning profiles, certificates, App Store Connect.
-- [Running instrumented tests for Android apps](https://docs.bitrise.io/bitrise-ci/testing/testing-android-apps/running-instrumented-tests-for-android-apps.md): Android instrumented test setup.
+- [Deploying and viewing test results](https://docs.bitrise.io/bitrise-ci/testing/deploying-and-viewing-test-results.md): Deploying and viewing test results for any platform.
 
 ## Build performance
 
 - [Build Cache for Xcode](https://docs.bitrise.io/bitrise-build-cache/build-cache-for-xcode/configuring-the-build-cache-for-xcode-in-the-bitrise-ci-environment.md): Cache iOS builds.
 - [Build Cache for Gradle](https://docs.bitrise.io/bitrise-build-cache/build-cache-for-gradle/configuring-the-build-cache-for-gradle-in-the-bitrise-ci-environment.md): Cache Gradle (Android) builds.
 - [Build Cache for Bazel](https://docs.bitrise.io/bitrise-build-cache/build-cache-for-bazel/configuring-the-build-cache-for-bazel-in-the-bitrise-ci-environment.md): Cache Bazel builds.
+- [Dependencies and caching overview](https://docs.bitrise.io/bitrise-ci/dependencies-and-caching/dependencies-and-caching-overview.md): How dependency management and caching work in Bitrise CI.
+- [Using key-based caching](https://docs.bitrise.io/bitrise-ci/dependencies-and-caching/key-based-caching/using-key-based-caching.md): Key-based caching with the Save/Restore cache Steps, independent of the Build Cache product.
 
 ## Build Hub (mobile GitHub Actions runners)
 
@@ -53,6 +54,8 @@ Every documentation page is also available as plain markdown: take the page path
 ## Release Management
 
 - [Distributing builds to testers](https://docs.bitrise.io/release-management/build-distribution/distributing-builds-to-testers.md): Distribute builds for internal testing.
+- [Releasing your app on the App Store](https://docs.bitrise.io/release-management/releases/managing-the-release-process/releasing-your-app-on-the-app-store.md): Publishing your app to the Apple App Store.
+- [Releasing your app on Google Play](https://docs.bitrise.io/release-management/releases/managing-the-release-process/releasing-your-app-on-google-play.md): Publishing your app to Google Play.
 - [Bitrise CodePush](https://docs.bitrise.io/release-management/codepush/about-codepush.md): Over-the-air updates for React Native and Capacitor apps.
 - [Distribution API](https://docs.bitrise.io/release-management/release-management-api.md): Programmatic release operations.
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,80 @@
+# Bitrise
+
+> Bitrise is a Mobile DevOps platform for CI/CD, build caching, build infrastructure, remote development environments, release management, and analytics, tailored for mobile engineering teams (iOS, Android, React Native, Flutter, KMP, Capacitor).
+
+The central configuration artifact is `bitrise.yml`, a YAML file at the project root. It defines **Workflows** (ordered sequences of **Steps**, the reusable build actions from the [Steplib](https://www.bitrise.io/integrations/steps)), **Triggers** (when Workflows run), and **Pipelines** (parallel or sequential groups of Workflows). The **Bitrise CLI** runs and debugs `bitrise.yml` locally before pushing. The platform separates concerns into products: **Bitrise CI** (build & test), **Build Cache** (faster builds via Xcode/Gradle/Bazel caches), **Build Hub** (mobile-optimized GitHub Actions runners), **Remote Dev Environments** (cloud dev machines for humans and AI agents), **Release Management** (build distribution + CodePush over-the-air updates), and **Insights** (CI metrics + alerts).
+
+Every documentation page is also available as plain markdown: take the page path without the `/en/` locale prefix and append `.md` (for example `https://docs.bitrise.io/bitrise-ci/getting-started/getting-started.md`). The complete documentation corpus in a single file is at [llms-full.txt](https://docs.bitrise.io/llms-full.txt).
+
+## Getting started
+
+- [Getting started with the Bitrise platform](https://docs.bitrise.io/bitrise-platform/getting-started/getting-started-with-the-bitrise-platform.md): First-time setup for new accounts and projects.
+- [Getting started with CI](https://docs.bitrise.io/bitrise-ci/getting-started/getting-started.md): Walkthrough for setting up your first Workflow.
+- [Installing and updating the Bitrise CLI](https://docs.bitrise.io/bitrise-ci/bitrise-cli/installing-and-updating-the-bitrise-cli.md): Run, configure, and debug Bitrise builds locally before pushing.
+- [Adding a new project from a CLI](https://docs.bitrise.io/bitrise-ci/bitrise-cli/adding-a-new-project-from-a-cli.md): Register a Bitrise project from the command line and start building.
+- [Steplib (Steps catalog)](https://www.bitrise.io/integrations/steps): Browse all available Steps to compose into Workflows.
+- [Migrating from Jenkins](https://docs.bitrise.io/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-jenkins-to-bitrise.md): Moving CI from Jenkins.
+- [Migrating from App Center](https://docs.bitrise.io/bitrise-ci/getting-started/migrating-to-bitrise/migrating-from-app-center-to-bitrise.md): Moving from Microsoft App Center.
+
+## Configuring builds
+
+- [Editing the bitrise.yml file](https://docs.bitrise.io/bitrise-ci/configure-builds/configuration-yaml/editing-an-app-s-bitrise-yml-file.md): The central CI config — what to put in it and how.
+- [Workflows and Pipelines overview](https://docs.bitrise.io/bitrise-ci/workflows-and-pipelines/workflows/workflows-overview.md): Core concepts for composing builds.
+- [YAML syntax for build triggers](https://docs.bitrise.io/bitrise-ci/run-and-analyze-builds/build-triggers/yaml-syntax-for-build-triggers.md): How to express when a Workflow should run.
+
+## Platform-specific setup
+
+- [Quick start: iOS projects](https://docs.bitrise.io/bitrise-ci/getting-started/quick-start-guides/getting-started-with-ios-projects.md): End-to-end CI setup for iOS.
+- [Quick start: Android projects](https://docs.bitrise.io/bitrise-ci/getting-started/quick-start-guides/getting-started-with-android-projects.md): End-to-end CI setup for Android.
+- [Quick start: Flutter projects](https://docs.bitrise.io/bitrise-ci/getting-started/quick-start-guides/getting-started-with-flutter-projects.md): End-to-end CI setup for Flutter.
+- [iOS code signing](https://docs.bitrise.io/bitrise-ci/code-signing/ios-code-signing/ios-code-signing.md): Configuring code signing for iOS — provisioning profiles, certificates, App Store Connect.
+- [Running instrumented tests for Android apps](https://docs.bitrise.io/bitrise-ci/testing/testing-android-apps/running-instrumented-tests-for-android-apps.md): Android instrumented test setup.
+
+## Build performance
+
+- [Build Cache for Xcode](https://docs.bitrise.io/bitrise-build-cache/build-cache-for-xcode/configuring-the-build-cache-for-xcode-in-the-bitrise-ci-environment.md): Cache iOS builds.
+- [Build Cache for Gradle](https://docs.bitrise.io/bitrise-build-cache/build-cache-for-gradle/configuring-the-build-cache-for-gradle-in-the-bitrise-ci-environment.md): Cache Gradle (Android) builds.
+- [Build Cache for Bazel](https://docs.bitrise.io/bitrise-build-cache/build-cache-for-bazel/configuring-the-build-cache-for-bazel-in-the-bitrise-ci-environment.md): Cache Bazel builds.
+
+## Build Hub (mobile GitHub Actions runners)
+
+- [Build Hub overview](https://docs.bitrise.io/bitrise-build-hub/build-hub-for-github-actions/build-hub-for-github-actions-overview.md): What Build Hub is and when to use it.
+- [Configuring Build Hub for GitHub Actions](https://docs.bitrise.io/bitrise-build-hub/build-hub-for-github-actions/configuring-build-hub-for-github-actions.md): Setup guide.
+- [Machine types](https://docs.bitrise.io/bitrise-build-hub/infrastructure/build-machine-types.md): Available build machines and their capabilities.
+
+## Remote Dev Environments (RDE)
+
+- [RDE overview](https://docs.bitrise.io/bitrise-rde/getting-started/remote-dev-environments-overview.md): What Remote Dev Environments are and when to use them.
+- [RDE quickstart](https://docs.bitrise.io/bitrise-rde/getting-started/quickstart.md): Spin up your first remote dev environment.
+- [RDE CLI](https://docs.bitrise.io/bitrise-rde/rde-options/bitrise-rde-cli.md): Managing environments and sessions from the command line.
+- [RDE MCP server](https://docs.bitrise.io/bitrise-rde/rde-options/bitrise-rde-mcp-server.md): Controlling RDEs from AI agents via MCP.
+- [RDE API](https://docs.bitrise.io/bitrise-rde/configuration/rde-api.md): Programmatic RDE operations.
+
+## Release Management
+
+- [Distributing builds to testers](https://docs.bitrise.io/release-management/build-distribution/distributing-builds-to-testers.md): Distribute builds for internal testing.
+- [Bitrise CodePush](https://docs.bitrise.io/release-management/codepush/about-codepush.md): Over-the-air updates for React Native and Capacitor apps.
+- [Distribution API](https://docs.bitrise.io/release-management/release-management-api.md): Programmatic release operations.
+
+## AI and agents
+
+- [Bitrise MCP](https://docs.bitrise.io/bitrise-platform/ai/bitrise-mcp.md): The Bitrise MCP server — let AI agents manage builds, apps, and artifacts.
+- [Onboarding for agents](https://docs.bitrise.io/bitrise-platform/ai/onboarding-for-agents.md): How AI agents should set up and interact with Bitrise.
+- [AI FAQ](https://docs.bitrise.io/bitrise-platform/ai/ai-faq---how-bitrise-leverages-ai-technologies-in-its-features-and-services.md): How Bitrise uses AI in its features and services, including data handling.
+
+## Programmatic access
+
+- [Bitrise API authentication](https://docs.bitrise.io/bitrise-ci/api/authenticating-with-the-bitrise-api.md): How to authenticate API requests.
+- [Identifying Workspaces and apps by slug](https://docs.bitrise.io/bitrise-ci/api/identifying-workspaces-and-apps-with-their-slugs.md): Slugs are the canonical identifiers for API operations.
+
+## Insights (build analytics)
+
+- [CI metrics](https://docs.bitrise.io/insights/available-metrics-in-insights/bitrise-ci-metrics.md): Available CI metrics and how to interpret them.
+- [Alerts](https://docs.bitrise.io/insights/configuring-alerts-in-insights.md): Configuring alerting on metric thresholds.
+
+## Optional
+
+- [Workspaces overview](https://docs.bitrise.io/bitrise-platform/workspaces/workspaces-overview.md): How teams, billing, and projects are organized.
+- [Integrations](https://docs.bitrise.io/bitrise-platform/integrations/about-integrations.md): The full list of supported integrations across the platform.
+- [llms-full.txt](https://docs.bitrise.io/llms-full.txt): The entire documentation set as a single markdown file.
+- [Support knowledge base](https://support.bitrise.io/en/): Customer support articles and troubleshooting (separate surface from product docs).


### PR DESCRIPTION
## What

- Adds a hand-curated `static/llms.txt` as the root llms.txt
- Sets `generateLLMsTxt: false` in `docusaurus.config.ts` — `llms-full.txt` and per-page `.md` generation stay untouched

## Why

The [llmstxt.org](https://llmstxt.org) spec intends the root `llms.txt` to be a small, curated index that helps agents find the right entry points; the full-corpus dump is what `llms-full.txt` is for (~2.2 MB, unchanged). The auto-generated `llms.txt` was a flat ~112 KB list of all 416 pages with truncated descriptions, which buries the pages agents actually need (Bitrise MCP, agent onboarding, quickstarts).

The curated file links to the per-page `.md` versions, so agents get clean markdown instead of HTML.

## Verification

All 37 doc links in the curated file were checked against the live generated index — zero misses. Sections cover all six products, including RDE and a dedicated "AI and agents" section.

## Trade-off

A curated file can go stale when pages move (the generated one couldn't). If our link checking can be extended to cover `static/llms.txt`, happy to wire that in — suggestions welcome.

## Out of scope, but noticed while testing

Two separate things in the generated output:

1. **Likely a real bug:** the generated `/bitrise-api/bitrise-api.md` contains **two** copies of the `<ProductOverview .../>` component, while the source (`docs/bitrise-api/index.mdx`) has only **one** — something in the plugin duplicates it.
2. **Known limitation, worth a thought:** raw JSX appears in the generated files at all (`excludeImports: true` strips import lines but not component usage in page bodies), so component-only landing pages produce noisy output and their old llms.txt descriptions were raw component text. Maybe worth excluding them via `ignoreFiles`, like the API reference already is.

Leaving both to you, @zoltan-baba.

No changelog entry — following #99 precedent (docs infrastructure, not reader-facing content).