### PR TITLE
Add description frontmatter to product landing pages

### DIFF
--- a/docs/bitrise-api/index.mdx
+++ b/docs/bitrise-api/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Bitrise API"
+description: "The Bitrise API lets you automate and integrate every part of your mobile CI/CD pipeline: trigger builds, manage apps, configure secrets, and more — all over REST."
 sidebar_class_name: product-index-link
 hide_title: true
 pagination_next: null

--- a/docs/bitrise-build-cache/index.mdx
+++ b/docs/bitrise-build-cache/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Bitrise Build Cache"
+description: "Bitrise Build Cache helps teams speed up CI builds and tests for Gradle and Bazel projects, eliminating redundant work to reduce build times. With toolchain observability, Bitrise Build Cache gives you clear visibility into where time is spent during builds—so you can identify and resolve productivity bottlenecks fast."
 sidebar_position: 1
 sidebar_class_name: product-index-link
 hide_title: true

--- a/docs/bitrise-build-hub/index.mdx
+++ b/docs/bitrise-build-hub/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Bitrise Build Hub"
+description: "Build Hub provides mobile infrastructure and build distribution for GitHub Actions users, bringing Bitrise's mobile-optimized build machines and testing capabilities to your existing CI/CD workflows."
 sidebar_position: 1
 sidebar_class_name: product-index-link
 hide_title: true

--- a/docs/bitrise-ci/index.mdx
+++ b/docs/bitrise-ci/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Bitrise CI"
+description: "Bitrise empowers mobile teams to ship apps faster by automating repetitive mobile workflows, delivering ready-to-use integrations tailored for iOS and Android, accelerating testing cycles across real-device environments, and ensuring consistently high-quality releases."
 sidebar_position: 1
 sidebar_class_name: product-index-link
 hide_title: true

--- a/docs/bitrise-platform/index.mdx
+++ b/docs/bitrise-platform/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Bitrise Platform"
+description: "Bitrise is the CI/CD Platform built for Mobile DevOps. With scalable infrastructure, robust collaboration features, and a wide range of integrations, our platform offers the tools to fit all your Mobile DevOps needs."
 sidebar_position: 1
 sidebar_label: Bitrise as a Platform
 sidebar_class_name: product-index-link

--- a/docs/bitrise-rde/index.mdx
+++ b/docs/bitrise-rde/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Remote Dev Environments"
+description: "On-demand cloud dev machines — macOS and Linux — running on the same infrastructure, stacks, and caches as Bitrise CI. Spin one up in seconds, connect from your terminal, IDE, or AI agent, then archive it and restore it later. Remote Dev Environments is currently in beta."
 sidebar_position: 1
 sidebar_class_name: product-index-link
 hide_title: true

--- a/docs/insights/index.mdx
+++ b/docs/insights/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Insights"
+description: "Increase the speed and efficiency of your development process. With Insights' build, test, and credit data, know what to prioritize and optimize your Mobile DevOps experience."
 sidebar_position: 1
 sidebar_class_name: product-index-link
 hide_title: true

--- a/docs/release-management/index.mdx
+++ b/docs/release-management/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Release Management"
+description: "Bitrise Release Management simplifies distributing your iOS and Android apps to testers or directly to app stores—all from one platform, from the CI you choose."
 sidebar_position: 1
 sidebar_class_name: product-index-link
 hide_title: true


### PR DESCRIPTION
## Summary
- All 8 product landing pages (`docs/bitrise-api`, `bitrise-ci`, `insights`, `bitrise-rde`, `release-management`, `bitrise-platform`, `bitrise-build-cache`, `bitrise-build-hub`) were missing a `description` field in frontmatter.
- `docusaurus-plugin-llms` (generates the `.md` mirrors under docs.bitrise.io for AI-agent consumption) falls back to using the first non-heading paragraph as the description when frontmatter has none. Since each page's body is a single multi-line `<ProductOverview ... />` JSX block with no internal blank line, the plugin swallowed the *entire* component as the "description" and then duplicated it — once as a blockquote, once as the real content — in the generated `.md` mirror (e.g. `bitrise-api.md` had two copies of `<ProductOverview>`).
- Added the real `description` (reusing each page's existing `ProductOverview` `description` prop text) to frontmatter, which prevents the plugin's fallback from triggering. Verified by running the plugin's own processing functions against all 8 files before/after: `<ProductOverview>` occurrence count went from 2 → 1 for every page.

## Test plan
- [x] Ran `docusaurus-plugin-llms`'s `processMarkdownFile`/`createMarkdownContent` functions directly against all 8 files, confirmed each generated mirror now contains exactly one `<ProductOverview>` instance and no more "description contains HTML tags" / "description is very long" warnings.
- [x] Ran a full `npm run build` and inspected the actual generated `.md` mirrors in `build/`: all 8 pages contain exactly 1 `<ProductOverview>` occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)