### PR TITLE
Add CI link check for the curated static/llms.txt

### DIFF
--- a/.github/workflows/check-llms-txt.yml
+++ b/.github/workflows/check-llms-txt.yml
@@ -1,8 +1,9 @@
 name: Check llms.txt links
 
 # The root llms.txt is hand-curated (PR #114), so its links can go stale when
-# pages move. This workflow checks every link against the live site: weekly to
-# catch drift, and on any PR that touches the file or the checker itself.
+# pages move. This workflow checks its links against the live site (see the
+# script for the skipped domains): weekly to catch drift, and on any PR that
+# touches the file or the checker.
 
 on:
   schedule:
@@ -12,6 +13,7 @@ on:
     paths:
       - 'static/llms.txt'
       - 'scripts/check_llms_txt.py'
+      - '.github/workflows/check-llms-txt.yml'
 
 jobs:
   check-links:

--- a/.github/workflows/check-llms-txt.yml
+++ b/.github/workflows/check-llms-txt.yml
@@ -1,0 +1,22 @@
+name: Check llms.txt links
+
+# The root llms.txt is hand-curated (PR #114), so its links can go stale when
+# pages move. This workflow checks every link against the live site: weekly to
+# catch drift, and on any PR that touches the file or the checker itself.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'static/llms.txt'
+      - 'scripts/check_llms_txt.py'
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check links in static/llms.txt
+        run: python3 scripts/check_llms_txt.py

--- a/scripts/check_llms_txt.py
+++ b/scripts/check_llms_txt.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Check that every link in static/llms.txt resolves.
+
+The root llms.txt is a hand-curated index (see PR #114), so its links can go
+stale when pages move — unlike the auto-generated llms-full.txt and per-page
+markdown, which are rebuilt from source on every deploy. This script extracts
+every URL from static/llms.txt and checks it against the live site.
+
+Note: links are checked against production, so a page that is added or moved
+in the same PR will be reported as broken until the change is deployed.
+
+Usage:
+  python3 scripts/check_llms_txt.py
+"""
+
+import re
+import sys
+import urllib.request
+import urllib.error
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+LLMS_TXT = Path(__file__).parent.parent / 'static' / 'llms.txt'
+LINK_RE = re.compile(r'\[[^\]]*\]\((https?://[^)\s]+)\)')
+
+
+def check_url(url: str):
+    try:
+        req = urllib.request.Request(
+            url, method='HEAD',
+            headers={'User-Agent': 'Mozilla/5.0 (check_llms_txt)'},
+        )
+        with urllib.request.urlopen(req, timeout=15) as r:
+            return url, r.status
+    except urllib.error.HTTPError as e:
+        if e.code in (403, 405):  # some CDNs reject HEAD; retry with GET
+            try:
+                req2 = urllib.request.Request(
+                    url, method='GET',
+                    headers={'User-Agent': 'Mozilla/5.0 (check_llms_txt)'},
+                )
+                with urllib.request.urlopen(req2, timeout=15) as r:
+                    return url, r.status
+            except urllib.error.HTTPError as e2:
+                return url, e2.code
+            except Exception as e2:
+                return url, str(e2)
+        return url, e.code
+    except Exception as e:
+        return url, str(e)
+
+
+def main() -> None:
+    if not LLMS_TXT.exists():
+        print(f'✗ {LLMS_TXT} not found.')
+        sys.exit(1)
+
+    url_lines: dict[str, list[int]] = {}
+    for lineno, line in enumerate(LLMS_TXT.read_text('utf-8').splitlines(), 1):
+        for m in LINK_RE.finditer(line):
+            url_lines.setdefault(m.group(1), []).append(lineno)
+
+    print(f'Checking {len(url_lines)} links from static/llms.txt …\n', flush=True)
+
+    broken = []
+    with ThreadPoolExecutor(max_workers=10) as pool:
+        futures = {pool.submit(check_url, url): url for url in url_lines}
+        done = 0
+        for future in as_completed(futures):
+            url, status = future.result()
+            done += 1
+            print(f'  [{done}/{len(url_lines)}] {status}  {url}', flush=True)
+            if isinstance(status, int) and 200 <= status < 400:
+                continue
+            for lineno in url_lines[url]:
+                broken.append((lineno, url, str(status)))
+
+    print()
+    if not broken:
+        print('✓ All llms.txt links resolve.')
+        return
+
+    print(f'✗ {len(broken)} broken link(s) in static/llms.txt:\n')
+    for lineno, url, reason in sorted(broken):
+        print(f'  static/llms.txt:{lineno}  {reason}  {url}')
+
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/check_llms_txt.py
+++ b/scripts/check_llms_txt.py
@@ -21,6 +21,11 @@ import urllib.error
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+# Domains scripts/audit_links.py also skips: the bot-protected marketing site
+# rejects automated requests and would false-alarm. docs.bitrise.io and
+# support.bitrise.io stay checked.
+SKIP_DOMAINS = {'bitrise.io', 'app.bitrise.io', 'www.bitrise.io', 'api.bitrise.io'}
+
 LLMS_TXT = Path(__file__).parent.parent / 'static' / 'llms.txt'
 LINK_RE = re.compile(r'\[[^\]]*\]\((https?://[^)\s]+)\)')
 
@@ -59,7 +64,11 @@ def main() -> None:
     url_lines: dict[str, list[int]] = {}
     for lineno, line in enumerate(LLMS_TXT.read_text('utf-8').splitlines(), 1):
         for m in LINK_RE.finditer(line):
-            url_lines.setdefault(m.group(1), []).append(lineno)
+            url = m.group(1)
+            dom = re.match(r'https?://([^/]+)', url)
+            if dom and dom.group(1) in SKIP_DOMAINS:
+                continue
+            url_lines.setdefault(url, []).append(lineno)
 
     print(f'Checking {len(url_lines)} links from static/llms.txt …\n', flush=True)
 


### PR DESCRIPTION
## What

Follow-up to #114, closing the trade-off noted there: the curated `static/llms.txt` can go stale when pages move, and today nothing checks its links — `audit_links.py` only covers doc pages and is run by hand, and the site build ignores files in `static/`.

- `scripts/check_llms_txt.py` — extracts every link from `static/llms.txt` and checks it against the live site (same stdlib-only pattern as `scripts/audit_links.py`: HEAD with GET fallback, 10 workers, exits 1 with a per-line report). Skips the same bot-protected domains audit_links.py skips (`bitrise.io`, `www`, `app`, `api`) to avoid false alarms; `docs.bitrise.io` and `support.bitrise.io` stay checked.
- `.github/workflows/check-llms-txt.yml` — runs weekly (Mondays 06:00 UTC), on any PR touching `static/llms.txt` or the checker itself, and via workflow_dispatch.

## Notes

- Links are checked against production, so a page added/moved in the same PR flags until deployed — acceptable for a rarely-changing curated file. Shout if you'd rather resolve against repo source.
- Alternative considered: extending `audit_links.py` with a `--file` mode instead of a separate script. Chose the standalone script to keep the MDX/slug auditor untangled from this and the CI job fast, at the cost of ~30 duplicated lines in the URL checker. Happy to fold it in if you prefer.
- This PR touches the workflow's own trigger paths, so the check runs on this very PR as a live test.

No changelog entry — docs infrastructure, per #99/#114 precedent.