### PR TITLE
Document Builds pane settings and fix inaccuracies for Bitrise Desktop App

### DIFF
--- a/docs/bitrise-ci/run-and-analyze-builds/bitrise-desktop-app-for-macos.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/bitrise-desktop-app-for-macos.mdx
@@ -25,6 +25,10 @@ The Bitrise Desktop App requires macOS 14.6 or later and a Bitrise account with 
 
 The app appears as an icon in the menu bar on the top of your screen. On first launch, it shows an unconfigured state until you sign in.
 
+## Launching at login
+
+In **Settings**, in the **General** pane, turn on **Launch at login** to have the app start automatically each time you log in to your Mac, so build status is in the menu bar without opening the app manually.
+
 ## Signing in
 
 1. Click the Bitrise icon in the menu bar.
@@ -74,9 +78,20 @@ A branch with no builds in Bitrise shows an empty list. If you switch to a new b
 
 Each project you watch has its own settings, edited in its detail view in the **Projects** pane.
 
-- **Branch filter**: Choose which branches a project tracks. For local folders, this stays in sync with your checkout automatically.
-- **Show only builds since the last push**: for local folders, hide builds that started before your most recent push, so old runs on the same branch don't clutter the list.
-- **Notification mode**: set each project to off, failures only, or every completion. A global **Allow notifications** switch in the Notifications pane turns all banners on or off.
+- **Branches**: Choose which branches a project tracks. For local folders, this stays in sync with your checkout automatically.
+- **Notifications**: set each project to off, failures only, or every completion. A global **Allow notifications** switch in the Notifications pane turns all banners on or off.
+
+## Grouping the build list
+
+In **Settings**, in the **Builds** pane, choose how the build list is organized:
+
+- **By project**: group builds under their project, one section per project.
+- **By date**: list every build newest-first across all projects, each one labeled with its project.
+
+A project can be **dual-tracked**: watched both because you subscribed to it directly and because you're tracking a local folder that matches the same repository. For dual-tracked projects, choose how to display them:
+
+- **Separate lists per source**: show two sections for the project, one per source, each labeled with an icon showing where it came from.
+- **Merged into one list**: combine builds from both sources into a single list for that project.
 
 ## Reading build status
 


### PR DESCRIPTION
## Summary
- Add a "Launching at login" section documenting the General pane's Launch at login toggle
- Add a "Grouping the build list" section documenting the Builds pane (group by project/date, dual-tracked project display)
- Remove a fabricated "Show only builds since the last push" setting that doesn't exist in the app
- Correct UI labels: "Branch filter" → "Branches", "Notification mode" → "Notifications"

## Test plan
- [ ] Verify rendered page against the actual app Settings panes (General, Builds, Projects, Notifications)