### PR TITLE
Update changelog

### DIFF
--- a/src/partials/changelog-content.mdx
+++ b/src/partials/changelog-content.mdx
@@ -11,6 +11,10 @@
 
 ## 2026 July
 
+### <time dateTime="2026-07-14">2026-07-14</time> RDE CLI docs refreshed to match current commands {#2026-07-14-rde-cli-docs-refreshed-to-match-current-commands}
+
+The RDE CLI reference now covers stack-based session creation, running commands in a session with `session exec`, VNC tunneling, workspace selection, and the reconnect behavior of `rde claude`. See [Bitrise RDE CLI](/en/bitrise-rde/rde-options/bitrise-rde-cli).
+
 ### <time dateTime="2026-07-10">2026-07-10</time> Building a Slack-native coding agent {#2026-07-10-building-a-slack-native-coding-agent}
 
 A new recipe walks through a reference architecture for a Slack-native coding agent: a locked-down orchestrator that delegates coding work to disposable Remote Dev Environments, plus an open source reference implementation you can try. See [Building a Slack-native coding agent](/en/bitrise-rde/recipes/building-a-slack-native-coding-agent-recipe).


### PR DESCRIPTION
## Summary
- Add a changelog entry for the RDE CLI docs refresh (#110), covering stack-based session creation, `session exec`, VNC tunneling, workspace selection, and `rde claude` reconnect behavior.