### PR TITLE
fix: noindex duplicate changelog pages, keep one indexed

### DIFF
--- a/docs/changelogs/bitrise-api.mdx
+++ b/docs/changelogs/bitrise-api.mdx
@@ -12,3 +12,8 @@ import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
 This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
 
 <Partial_ChangelogContent />
+
+
+<head>
+  <meta name="robots" content="noindex, follow" />
+</head>

--- a/docs/changelogs/bitrise-build-cache.mdx
+++ b/docs/changelogs/bitrise-build-cache.mdx
@@ -12,3 +12,7 @@ import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
 This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
 
 <Partial_ChangelogContent />
+
+<head>
+  <meta name="robots" content="noindex, follow" />
+</head>

--- a/docs/changelogs/bitrise-build-hub.mdx
+++ b/docs/changelogs/bitrise-build-hub.mdx
@@ -12,3 +12,7 @@ import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
 This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
 
 <Partial_ChangelogContent />
+
+<head>
+  <meta name="robots" content="noindex, follow" />
+</head>

--- a/docs/changelogs/bitrise-platform.mdx
+++ b/docs/changelogs/bitrise-platform.mdx
@@ -12,3 +12,7 @@ import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
 This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
 
 <Partial_ChangelogContent />
+
+<head>
+  <meta name="robots" content="noindex, follow" />
+</head>

--- a/docs/changelogs/bitrise-rde.mdx
+++ b/docs/changelogs/bitrise-rde.mdx
@@ -12,3 +12,7 @@ import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
 This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
 
 <Partial_ChangelogContent />
+
+<head>
+  <meta name="robots" content="noindex, follow" />
+</head>

--- a/docs/changelogs/insights.mdx
+++ b/docs/changelogs/insights.mdx
@@ -12,3 +12,7 @@ import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
 This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
 
 <Partial_ChangelogContent />
+
+<head>
+  <meta name="robots" content="noindex, follow" />
+</head>

--- a/docs/changelogs/release-management.mdx
+++ b/docs/changelogs/release-management.mdx
@@ -12,3 +12,7 @@ import Partial_ChangelogContent from '@site/src/partials/changelog-content.mdx';
 This page tracks documentation updates: new guides, updated procedures, and changes reflecting new or updated Bitrise features.
 
 <Partial_ChangelogContent />
+
+<head>
+  <meta name="robots" content="noindex, follow" />
+</head>


### PR DESCRIPTION
Fixes the duplicate-changelog issue flagged in Search Console.

We have 8 changelog pages (one per product sidebar) that all render identical content from the shared changelog-content partial - only the URL and sidebar differ. Google treats them as duplicates ("Duplicate, Google chose different canonical than user"): it indexes one at random and drops the rest.

We can't fix this with a canonical tag, because Docusaurus already auto-adds a self-canonical to every page (verified live) - a second canonical would just conflict. So this marks the 7 non-primary changelog pages noindex, follow, leaving /en/bitrise-ci/changelog as the single indexed changelog. All 8 pages still work in-site (each keeps its product sidebar); only one shows in search. "follow" preserves link flow.

Verified live: MDX <head> tags render on these pages and there is no existing robots meta to conflict with. Please confirm on the preview deploy that each of the 7 pages emits the noindex meta (and bitrise-ci does not) before merging.

Primary indexed page = bitrise-ci; easy to switch if you'd prefer another.

Follow-ups (not in this PR):
1) llms-full.txt currently contains the changelog 8x too - add the 7 secondary changelog paths to the docusaurus-plugin-llms ignoreFiles to dedupe there.
2) The local docusaurus-plugin-llms patch is the same fix as upstream #55 (now merged) - can be dropped once the plugin is bumped to a release that includes it.