### PR TITLE
fix: drop dead anchor on ai-code-reviewer build-number link

### DIFF
--- a/docs/bitrise-platform/integrations/ai-code-reviewer.mdx
+++ b/docs/bitrise-platform/integrations/ai-code-reviewer.mdx
@@ -46,7 +46,7 @@ The AI code reviewer runs a Bitrise build that shows up in your list of Bitrise 
 
 - Doesn't count towards any of your resource limits (credits, build count, build minutes).
 - Doesn't count towards concurrency limits.
-- Increases the actual [build number](/en/bitrise-ci/run-and-analyze-builds/build-numbering-and-app-versioning#adding-the-ssh-key-to-the-machine-user).
+- Increases the actual [build number](/en/bitrise-ci/run-and-analyze-builds/build-numbering-and-app-versioning).
 - Is included in [Insights](/en/insights) data.
 
 For each new commit on a pull request, the code reviewer starts a new review and a new build.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -154,9 +154,8 @@ const config: Config = {
   organizationName: 'bitrise-io',
   projectName: 'docs',
 
-  onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'throw',
-  onBrokenAnchors: 'throw',
+  onBrokenLinks: 'warn',
+  onBrokenMarkdownLinks: 'warn',
 
   markdown: {
     format: 'detect',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -154,8 +154,9 @@ const config: Config = {
   organizationName: 'bitrise-io',
   projectName: 'docs',
 
-  onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'throw',
+  onBrokenAnchors: 'throw',
 
   markdown: {
     format: 'detect',


### PR DESCRIPTION
## What

Drops the dead `#adding-the-ssh-key-to-the-machine-user` anchor from the "build number" link in `ai-code-reviewer.mdx`. The target heading on `build-numbering-and-app-versioning` was renamed to "Changing the build number on the web UI", so the old anchor no longer resolves; the link now points to the page.

One-line change, no behavior change.

## Note

The broader "flip `onBrokenLinks`/`onBrokenAnchors` to `throw`" guardrail is parked for now, pending Zoltan's call — it's out of scope here. This same anchor fix also exists on the `add-source-link-checker` branch; whichever merges first, the other's diff for this line collapses. Only one needs to land.