### PR TITLE
fix: fully regenerate API reference docs on spec change

### DIFF
--- a/.github/workflows/sync-api-references.yml
+++ b/.github/workflows/sync-api-references.yml
@@ -75,10 +75,15 @@ jobs:
             !node_modules/.cache
           key: node-modules-${{ runner.os }}-node20-${{ hashFiles('package-lock.json', 'patches/**') }}
 
+      # gen-api-docs only writes files that don't already exist (see the
+      # plugin's CLI source) — it never overwrites content for operations
+      # that were already generated in a prior run. clean-api-docs must run
+      # first so a changed spec is actually reflected, not just skipped.
       - name: Regenerate the ${{ matrix.name }} reference
         if: steps.sync.outputs.status != 'unchanged'
         run: |
           npm install
+          npm run docusaurus -- clean-api-docs ${{ matrix.spec }}
           npm run docusaurus -- gen-api-docs ${{ matrix.spec }}
           node scripts/patch-api-info.js
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "gen-api-docs": "docusaurus gen-api-docs all && node scripts/patch-api-info.js",
+    "gen-api-docs": "docusaurus clean-api-docs all && docusaurus gen-api-docs all && node scripts/patch-api-info.js",
     "start": "docusaurus start",
     "build": "docusaurus build",
     "cloudflare:upload_redirects": "node cloudflare.js",


### PR DESCRIPTION
## Summary
- `docusaurus-plugin-openapi-docs`'s `gen-api-docs` command only creates
  files that don't already exist (see its CLI source / README) — it never
  overwrites previously generated output.
- PR #131 merged an RDE spec update (`labels` / `labelSelectors` added to
  existing session endpoints) but the generated `.mdx`/JSON docs under
  `docs/bitrise-rde-api/api-reference/` were never updated, because those
  files already existed from a prior run.
- Fix: run `clean-api-docs` before `gen-api-docs`, in both `npm run
  gen-api-docs` and the `sync-api-references.yml` workflow (applies to
  both the Bitrise CI and RDE matrix jobs since it's a shared step
  template).

## Test plan
- [x] Verified locally: without the fix, regenerating against a spec with
      new fields produced zero file changes; with `clean-api-docs` first,
      the new fields correctly appeared in the regenerated output.
- [x] Confirmed against the plugin's own README/CLI source that there's no
      overwrite/force flag — clean-then-generate is the documented,
      intended workflow.

Note: this PR only fixes the tooling. The RDE docs on `main` are
currently stale relative to the spec (from #131) — a follow-up PR will
regenerate and commit the corrected docs separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)