### PR TITLE
chore: mark generated API reference docs as linguist-generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Generated API reference docs (docusaurus-plugin-openapi-docs output).
+# Never hand-edited — regenerated wholesale on every spec sync. Collapsed by
+# default in GitHub PR diffs so the reviewable content (the spec JSON under
+# api/) isn't buried under noisy regenerated MDX/JSON.
+docs/bitrise-api/api-reference/** linguist-generated=true
+docs/bitrise-rde-api/api-reference/** linguist-generated=true


### PR DESCRIPTION
## Summary
- `docs/bitrise-api/api-reference/` and `docs/bitrise-rde-api/api-reference/`
  are fully regenerated from their OpenAPI specs on every sync (see #132)
  and are never hand-edited.
- Marking them `linguist-generated=true` collapses them by default in
  GitHub's PR diff view, so reviewers see the actual spec diff
  (`api/bitrise-ci.json` / `api/bitrise-rde.json`) without having to scroll
  past regenerated content — one click still expands them if needed.
- No effect on git behavior, CI, or local tooling — this is a GitHub
  web-UI-only convention. Trade-off: these paths are also excluded from
  GitHub's code search by default going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)