### PR TITLE
docs: point Bitrise CI links at /ci (entry-point rename)

### DIFF
--- a/docs/bitrise-ci/api/identifying-workspaces-and-apps-with-their-slugs.mdx
+++ b/docs/bitrise-ci/api/identifying-workspaces-and-apps-with-their-slugs.mdx
@@ -29,7 +29,7 @@ You can find both Workspace slugs and project slugs on the Bitrise website.
 </TabItem>
 <TabItem value="project-slugs" label="Project slugs">
 
-1. Open [Bitrise CI](https://app.bitrise.io/dashboard) and select your project.
+1. Open [Bitrise CI](https://app.bitrise.io/ci) and select your project.
 1. Once on the project's page, go to your browser's address bar.
 
    The URL will look like this: `https://app.bitrise.io/app/5c89d92-8be6-4892-b11d-efbc1fdd607`.

--- a/docs/bitrise-ci/bitrise-cli/adding-a-new-project-from-a-cli.mdx
+++ b/docs/bitrise-ci/bitrise-cli/adding-a-new-project-from-a-cli.mdx
@@ -31,14 +31,14 @@ This procedure guides you through adding a project which Bitrise will access wit
 
 You can, of course, use an HTTPS URL to access your remote repository, too: in that case, you will not set an SSH key for your project. We only recommend using HTTPS URLs for public projects (open source projects).
 
-And that’s it! You are done: the URL to your new project will be printed out, and you can also view the project on your [Dashboard](https://app.bitrise.io/dashboard/).
+And that’s it! You are done: the URL to your new project will be printed out, and you can also view the project on your [Dashboard](https://app.bitrise.io/ci).
 
 
 ## Adding the project
 
-1. Go to the [Create New project from CLI](https://app.bitrise.io/dashboard/add-project-from-cli) page.
+1. Go to the [Create New project from CLI](https://app.bitrise.io/apps/add/cli) page.
 
-   You can reach this page from your [Dashboard](https://app.bitrise.io/dashboard/builds): click the **Add new project** button on the right, and then select **Add New project from CLI**.
+   You can reach this page from your [Dashboard](https://app.bitrise.io/ci): click the **Add new project** button on the right, and then select **Add New project from CLI**.
 
    ![2025-12-10-adding-project-with-cli.png](/img/_paligo/uuid-a6c8e931-615c-8697-8cf6-ab8d5269420b.png)
 1. Set the account that will own the project, and the privacy of the project.

--- a/docs/bitrise-ci/bitrise-cli/adding-a-new-project-from-a-cli.mdx
+++ b/docs/bitrise-ci/bitrise-cli/adding-a-new-project-from-a-cli.mdx
@@ -31,14 +31,14 @@ This procedure guides you through adding a project which Bitrise will access wit
 
 You can, of course, use an HTTPS URL to access your remote repository, too: in that case, you will not set an SSH key for your project. We only recommend using HTTPS URLs for public projects (open source projects).
 
-And that’s it! You are done: the URL to your new project will be printed out, and you can also view the project on your [Dashboard](https://app.bitrise.io/ci).
+And that’s it! You are done: the URL to your new project will be printed out, and you can also view the project on your [Bitrise CI page](https://app.bitrise.io/ci).
 
 
 ## Adding the project
 
 1. Go to the [New CI project from CLI](https://app.bitrise.io/apps/add/cli) page.
 
-   You can reach this page from your [Dashboard](https://app.bitrise.io/ci): click the **New CI project** button on the right, and then select **New CI project from CLI**.
+   You can reach this page from your [Bitrise CI page](https://app.bitrise.io/ci): click the **New CI project** button on the right, and then select **New CI project from CLI**.
 
    ![2025-12-10-adding-project-with-cli.png](/img/_paligo/uuid-a6c8e931-615c-8697-8cf6-ab8d5269420b.png)
 1. Set the account that will own the project, and the privacy of the project.

--- a/docs/bitrise-ci/configure-builds/configuring-build-settings/configuring-email-notifications.mdx
+++ b/docs/bitrise-ci/configure-builds/configuring-build-settings/configuring-email-notifications.mdx
@@ -31,7 +31,7 @@ Watching a Bitrise <GlossTerm baseform="project">project</GlossTerm> means getti
 
 To enable watching:
 
-1. Open [Bitrise CI](https://app.bitrise.io/dashboard).
+1. Open [Bitrise CI](https://app.bitrise.io/ci).
 1. From the project list on the right, select your project.
 1. On the left, toggle **Watching**.
 

--- a/docs/bitrise-ci/getting-started/getting-started.mdx
+++ b/docs/bitrise-ci/getting-started/getting-started.mdx
@@ -53,7 +53,7 @@ For the full step-by-step guide, see [Adding a new project](/en/bitrise-ci/getti
 
 ## Changing your project settings
 
-You can change your project settings at any time. To do so, open your project on the [Bitrise CI page](https://app.bitrise.io/dashboard) and click **Project settings**.
+You can change your project settings at any time. To do so, open your project on the [Bitrise CI page](https://app.bitrise.io/ci) and click **Project settings**.
 
 ![project-settings-button.png](/img/_paligo/uuid-56c193b1-5aaf-9bc1-63f3-61739dfcd68d.png)
 
@@ -78,7 +78,7 @@ Your CI build configuration is defined in YAML format. The root configuration fi
 
 To edit the configuration on Bitrise:
 
-1. Open the [Bitrise CI page](https://app.bitrise.io/dashboard).
+1. Open the [Bitrise CI page](https://app.bitrise.io/ci).
 1. Select your project from the list of projects on the right. You can use the Search field to search for a specific one.
 
    ![project-list.png](/img/_paligo/uuid-624fc88e-8389-faf0-8638-465d3a7978ee.png)

--- a/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-checks-on-github.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-checks-on-github.mdx
@@ -74,7 +74,7 @@ If all goes well, you land on the **Bitrise** page of GitHub. You should see a b
 
 ## Enabling GitHub Checks on Bitrise
 
-Once [the Bitrise app is installed](/en/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-checks-on-github#installing-the-bitrise-github-app-for-github-checks) on GitHub, you need to enable GitHub Checks on the project settings page on [Bitrise](https://app.bitrise.io/dashboard/builds).
+Once [the Bitrise app is installed](/en/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-checks-on-github#installing-the-bitrise-github-app-for-github-checks) on GitHub, you need to enable GitHub Checks on the project settings page on [Bitrise](https://app.bitrise.io/ci).
 
 :::important[Enabling GitHub Checks is limited]
 

--- a/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/build-logs.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/build-logs.mdx
@@ -25,7 +25,7 @@ When Bitrise Support asks for your build logs, the best thing to do is send the 
 
 :::
 
-1. Open the [Bitrise CI](http://app.bitrise.io/dashboard) page and select your project from the project list.
+1. Open the [Bitrise CI](https://app.bitrise.io/ci) page and select your project from the project list.
 1. Select the build you want to check out.
 1. Make sure you have the **Log** tab selected.
 1. On the **Log** tab, you can see the <GlossTerm baseform="step">Steps</GlossTerm> of the <GlossTerm baseform="workflow">Workflow</GlossTerm> and their status. By default, all failed Steps are expanded.
@@ -81,7 +81,7 @@ Please note that your build log can contain sensitive information! Make sure to 
 
 :::
 
-1. Open the [Bitrise CI](http://app.bitrise.io/dashboard) page and select your project from the project list.
+1. Open the [Bitrise CI](https://app.bitrise.io/ci) page and select your project from the project list.
 1. Select the build you want to check out.
 1. Open the **Logs** dropdown menu and click the **Download logs** button.
 
@@ -98,7 +98,7 @@ Be aware that you cannot undo deleting a log. Once you delete it, there is no wa
 
 :::
 
-1. Open the [Bitrise CI](http://app.bitrise.io/dashboard) page and select your project from the project list.
+1. Open the [Bitrise CI](https://app.bitrise.io/ci) page and select your project from the project list.
 1. Select the build you want to check out.
 1. Open the **Logs** dropdown menu and click the **Delete Logs** button.
 

--- a/docs/bitrise-platform/projects/creating-white-label-app-versions.mdx
+++ b/docs/bitrise-platform/projects/creating-white-label-app-versions.mdx
@@ -23,7 +23,7 @@ What you’ll need for this setup:
 ## Prepping Workflows of a white label app
 
 1. [Add your project](/en/bitrise-ci/getting-started/adding-a-new-project) to Bitrise in the usual way.
-1. Select your project on the [Bitrise CI](https://app.bitrise.io/dashboard/) page and click **Workflows**.
+1. Select your project on the [Bitrise CI](https://app.bitrise.io/ci) page and click **Workflows**.
 
    ![getting-to-workflows.png](/img/_paligo/uuid-32b5ff3d-8431-8fe3-9971-89d8aca076f4.png)
 1. Open the dropdown menu of available Workflows and click **Create Workflow** to create your main Workflow.

--- a/src/partials/accessing-builds-tab-and-selecting-a-build.mdx
+++ b/src/partials/accessing-builds-tab-and-selecting-a-build.mdx
@@ -2,5 +2,5 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GlossTerm from '@site/src/components/GlossTerm';
 
-1. Open the [Bitrise CI](http://app.bitrise.io/dashboard) page and select your project from the project list.
+1. Open the [Bitrise CI](https://app.bitrise.io/ci) page and select your project from the project list.
 1. Select the build you want to check out.


### PR DESCRIPTION
> 🤖 **Agent-authored docs-impact review.** Generated from a code change in
> `bitrise-io/bitrise-website` by the `docs-impact-review` skill. **Needs human
> verification before merge** — this is the publish gate. Do not merge until the
> source change ships.

**Source change:** https://github.com/bitrise-io/bitrise-website/pull/20428 (fix(ci): re-land slugged `/ci` entry point without the redirect loop)

Bitrise CI's entry point is moving from the slugless `/dashboard` to `/ci` (bare `/ci` 302-redirects to the current workspace's `/ci/:workspace_slug`; the old `/dashboard` 301-redirects to `/ci`). The docs linked to `app.bitrise.io/dashboard` in 13 places; those still resolve via the redirect, but should point at the canonical `/ci`.

### Changes for this code change
Repointed every `https://app.bitrise.io/dashboard*` link to the canonical `/ci` (also normalized `http://` → `https://` on the links that were touched):
- `docs/bitrise-ci/getting-started/getting-started.mdx` — 2 links
- `docs/bitrise-ci/configure-builds/configuring-build-settings/configuring-email-notifications.mdx`
- `docs/bitrise-ci/api/identifying-workspaces-and-apps-with-their-slugs.mdx`
- `docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/build-logs.mdx` — 3 links
- `docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-checks-on-github.mdx`
- `docs/bitrise-platform/projects/creating-white-label-app-versions.mdx`
- `docs/bitrise-ci/bitrise-cli/adding-a-new-project-from-a-cli.mdx`
- `src/partials/accessing-builds-tab-and-selecting-a-build.mdx` — shared partial (propagates to all consumers)

### Pre-existing drift fixed
Two links pointed at paths that never resolved to a distinct page (they hit the `/dashboard/*` catch-all), independent of this change:
- `adding-a-new-project-from-a-cli.mdx` — the "Create New project from CLI" link was `/dashboard/add-project-from-cli`; the real page is `/apps/add/cli`.
- `adding-a-new-project-from-a-cli.mdx` + `bitrise-checks-on-github.mdx` — `/dashboard/builds` had no distinct page; collapsed to the CI overview `/ci`.

### Not changed
- No doc page slugs changed, so no `redirects.json` entries are needed.
- No Swagger/API-reference pages touched (this is a route/link change, not an API-shape change).
- Link **text** that reads "Dashboard" was left as-is (it's a recognized glossary term); only the URL targets changed. Flagging in case you'd prefer "Bitrise CI" for consistency.

### What a reviewer must verify before merge
- [x] The re-land change (`bitrise-website` #20428) has shipped — `/ci` resolves in production before these links go live. (The original #20350 was reverted, so **do not merge until #20428 ships**.)
- [x] `/apps/add/cli` is the correct current URL for "Create New project from CLI".
- [ ] Slugs / partials / sidebar render correctly (`npm start` in the docs repo).
- [ ] No screenshots referencing the old `/dashboard` URL went stale.

