### PR TITLE
docs: fix stale content in bitrise-ci/deploying

### DIFF
--- a/docs/bitrise-ci/deploying/android-deployment/generate-and-deploy-multiple-flavor-apks-in-a-single-workflow.mdx
+++ b/docs/bitrise-ci/deploying/android-deployment/generate-and-deploy-multiple-flavor-apks-in-a-single-workflow.mdx
@@ -19,13 +19,11 @@ You can generate, code sign and deploy multiple flavor (multi-flavor) APKs/AABs 
 To generate APK files for several different flavors:
 
 1. <Partial_OpeningTheWorkflowEditor />
-1. Insert **Gradle Runner** Step after the Android testing Steps. **Android Build** Step can only build one variant so if this Step is part of your Workflow, then we advise you to replace it with our **Gradle Runner** Step.
+1. Insert **Gradle Runner** Step after the Android testing Steps. The **Android Build** Step also supports multiple variants via its **Variant** input (list them separated by a line break), but this tutorial continues with **Gradle Runner**.
 1. Click the **Config** section of the Step.
-1. Specify **assemble** Gradle tasks by adding your build variants’ task names in the **Gradle task to run** Step input field - as many task names as many build variants you want to build in one workflow. Each task name must be exactly the same build variant name what you have listed in the **Build Variant** window of Android Studio! Make sure you separate them only with a space, no need for a comma ! In this image, you can see the order of the Steps for the deploy workflow and the **Gradle Task to run** Step input with two build variants:
+1. Specify **assemble** Gradle tasks by adding your build variants’ task names in the **Gradle task to run** Step input field - as many task names as many build variants you want to build in one workflow. Each task name must be exactly the same build variant name what you have listed in the **Build Variant** window of Android Studio! Make sure you separate them only with a space, no need for a comma! For example, with two build variants:
 
    `assembleDemo` and `assembleFull` (for APKs) or `bundleDemo` and `bundleFull` (for AABs)
-
-   ![Generate_and_deploy_multiple_flavor_APKs_in_a_single_workflow.jpg](/img/_paligo/uuid-b702773a-d24b-62a5-fa83-208936e116a3.jpg)
 1. **Gradle Runner** generates a `$BITRISE_APK_PATH_LIST` / `$BITRISE_AAB_PATH_LIST` Environment Variable output that contains APKs/AABs built for ALL build variants defined above. We will need this output Environment Variable later.
 
 
@@ -40,6 +38,6 @@ To generate APK files for several different flavors:
 
    - **Keystore url**
    - **Keystore password**
-   - **Keystore alias**
+   - **Key alias**
 1. Add the **Google Play Deploy** Step AFTER the **Android Sign** Step.
 1. Set the `$BITRISE_SIGNED_APK_PATH` or the `$BITRISE_SIGNED_AAB_PATH` Environment Variable in the **APK or App Bundle file path** Step input field so that the **Google Play Deploy** Step can release all your build variants to the app store.

--- a/docs/bitrise-ci/deploying/android-deployment/generating-and-deploying-android-app-bundles.mdx
+++ b/docs/bitrise-ci/deploying/android-deployment/generating-and-deploying-android-app-bundles.mdx
@@ -128,7 +128,7 @@ You can generate an Android App Bundle for your Android app with our **Android B
        - android-build:
    ```
 1. Provide the root directory of your Android project in the `project_location` input field.
-1. Set the value of the `build-type` input to `aab`.
+1. Set the value of the `build_type` input to `aab`.
 
    ```yaml
    my-workflow:
@@ -141,7 +141,7 @@ You can generate an Android App Bundle for your Android app with our **Android B
        - android-unit-test: {}
        - android-build:
            inputs:
-             - build-type: aab
+             - build_type: aab
    ```
 
    :::tip[APK and AAB in the same Workflow]
@@ -181,7 +181,7 @@ Signing an Android App Bundle file works the same way as signing an APK: the mos
    Check out all the available configuration options of the **Android Sign** Step in the Workflow Editor. You can:
 
    - Enable or disable memory page alignment with the **Page alignment** input.
-   - Use `apksigner` instead of the default `jarsigner` with the **Enables apksigner** input.
+   - Choose which tool signs the app with the **Signer tool** input: `automatic` (default, uses `apksigner` for APKs and `jarsigner` for AABs), `apksigner`, or `jarsigner`.
    - Enforce a specific [Signature Scheme](https://source.android.com/docs/security/features/apksigning#schemes) with the **APK Signature Scheme** input.
 
    :::
@@ -240,7 +240,7 @@ Signing an Android App Bundle file works the same way as signing an APK: the mos
    Check out all the available configuration options of the `android-sign` Step in [its step.yml file](https://github.com/bitrise-steplib/steps-sign-apk/blob/master/step.yml). You can:
 
    - Enable or disable memory page alignment with the `page_align` input.
-   - Use `apksigner` instead of the default `jarsigner` with the `use_apk_signer` input.
+   - Choose which tool signs the app with the `signer_tool` input: `automatic` (default, uses `apksigner` for APKs and `jarsigner` for AABs), `apksigner`, or `jarsigner`.
    - Enforce a specific [Signature Scheme](https://source.android.com/docs/security/features/apksigning#schemes) with the `signer_scheme` input.
 
    :::

--- a/docs/bitrise-ci/deploying/deploying-apps-to-applivery.mdx
+++ b/docs/bitrise-ci/deploying/deploying-apps-to-applivery.mdx
@@ -27,8 +27,6 @@ Combined with Bitrise, you can cover the entire development life cycle, from tes
 ## Deploying your app to Applivery
 
 1. Add the **Applivery iOS Deploy** or the **Applivery Android Deploy** <GlossTerm baseform="Step">Step</GlossTerm> to your <GlossTerm baseform="Workflow">Workflow</GlossTerm>. Make sure you add the Step after the Steps that build your app.
-
-   ![Applivery_Workflow_Step.png](/img/_paligo/uuid-794fef65-3c3b-12e1-e60f-f01f02802b37.png)
 1. Get your Applivery App Token to link your Bitrise app with your Applivery app. [Read more about how to get your App Token](https://www.applivery.com/docs/api/app-distribution/apps-api-authentication/).
 1. Open your app on Bitrise and click the **Workflows** tab to open the <GlossTerm baseform="workflow editor">Workflow Editor</GlossTerm>.
 1. Go to the **<GlossTerm baseform="secret">Secrets</GlossTerm>** tab.

--- a/docs/bitrise-ci/deploying/deploying-your-app-to-appaloosa.mdx
+++ b/docs/bitrise-ci/deploying/deploying-your-app-to-appaloosa.mdx
@@ -19,10 +19,9 @@ Appaloosa also gives you great insight on the efficiency of your deployment with
 
 They are entreprise ready with LDAP, OAuth, SAML and Active Directory integrations as well as a RESTful API. [Get in touch](mailto:sales@appaloosa-store.com) for more details. Plus your mobile apps can be targeted to groups of users or distributed to all collaborators.
 
-To deploy your app on Appaloosa, simply add the **Appaloosa** <GlossTerm baseform="Step">Step</GlossTerm> to your app’s <GlossTerm baseform="Workflow">Workflow</GlossTerm>. If you don’t already have an account on Appaloosa, it will be created on the go.
+To deploy your app on Appaloosa, add the **Appaloosa** <GlossTerm baseform="Step">Step</GlossTerm> to your app’s <GlossTerm baseform="Workflow">Workflow</GlossTerm>. You need an Appaloosa account before you can use the Step.
 
-- As a **registered user** you simply need your *store id* and *API Key*.
-- As an **unregistered user**, an *email address* is enough.
-- Optionally you can provide a *description*, *screenshot* urls (up to 5) and, if registered, *group ids*.
+- You need your *store id* and *API Key* from your Appaloosa account.
+- Optionally you can provide a *description*, *screenshot* urls (up to 5), and *group ids*.
 
 With Bitrise and Appaloosa, you can focus on your mobile app development and we take care of the rest!

--- a/docs/bitrise-ci/deploying/ios-deployment/deploying-an-ios-app-to-bitriseio.mdx
+++ b/docs/bitrise-ci/deploying/ios-deployment/deploying-an-ios-app-to-bitriseio.mdx
@@ -34,8 +34,6 @@ To deploy an iOS app to [bitrise.io](https://www.bitrise.io/), you will always n
    - `apple-id`if you use [Apple ID authorization](/en/bitrise-platform/integrations/apple-services-connection/about-connecting-to-apple-services).
 1. Set the **Distribution method** input of the Step to `development`.
 
-   ![deployiosapptobitrise.png](/img/_paligo/uuid-3bb43658-43d6-234e-9788-d71d49d5c1db.png)
-
    You can use other export methods, too, but if you only deploy to Bitrise and want to install your app on the specified devices of internal testers, `development` is sufficient.
 1. Make sure the [**Deploy to Bitrise.io - Build Artifacts, Test Reports, and Pipeline intermediate files**](https://github.com/bitrise-steplib/steps-deploy-to-bitrise-io) Step is in your Workflow.
 
@@ -44,7 +42,7 @@ To deploy an iOS app to [bitrise.io](https://www.bitrise.io/), you will always n
 1. When the build is finished, go to the app’s **Builds** page and click the latest build.
 1. Click the **Artifacts** tab to find your IPA file.
 
-   You can also find the public install URL here. Click the expand-arrow icon next to the IPA file to reveal the details and to find the toggle for the public install page. Make sure that’s toggled on so you’re able to send the link to non-Bitrise users.
+   You can also find the public install URL here. Click **View artifact** next to the IPA file to open its details page, then click **Manage access** and make sure the public install link is set to **Enabled** so you’re able to send the link to non-Bitrise users.
 
    To install an app from the public install page, you must use a native Safari browser of the iOS device. You cannot click the installation link if you’re browsing from a third-party app. For more information, check out [Installing an .ipa file on test devices from the Artifacts tab](/en/bitrise-ci/deploying/ios-deployment/installing-an-ipa-file-from-the-public-install-page#installing-an-ipa-file-on-test-devices-from-the-artifacts-tab)
 

--- a/docs/bitrise-ci/deploying/ios-deployment/installing-an-ipa-file-from-the-public-install-page.mdx
+++ b/docs/bitrise-ci/deploying/ios-deployment/installing-an-ipa-file-from-the-public-install-page.mdx
@@ -147,8 +147,6 @@ Please note that you can only add a test device to Bitrise if you already have a
 
    ![Installing_an_ipa_file_from_the_public_install_page.jpg](/img/_paligo/uuid-f13c2746-f8bf-10d2-0284-1090f23c47e0.jpg)
 1. Your device’s name and UDID gets populated automatically. You can only change the device name here. Tap **Register Device**.
-
-   ![Installing_an_ipa_file_from_the_public_install_page.jpg](/img/_paligo/uuid-2d349c93-c464-218d-ac79-de7b3da38089.jpg)
 1. You land on the public install page where the **Install** button is now available. Tap it!
 
    ![Installing_an_ipa_file_from_the_public_install_page.jpg](/img/_paligo/uuid-bb823f44-e4f5-b338-c82f-e2175f034f30.jpg)
@@ -195,8 +193,6 @@ Please note that you can only add a test device to Bitrise if you already have a
 
    ![Installing_an_ipa_file_from_the_public_install_page.jpg](/img/_paligo/uuid-f13c2746-f8bf-10d2-0284-1090f23c47e0.jpg)
 1. Your device’s name and UDID gets populated automatically. You can only change the device name here. Tap **Register Device**.
-
-   ![Installing_an_ipa_file_from_the_public_install_page.jpg](/img/_paligo/uuid-2d349c93-c464-218d-ac79-de7b3da38089.jpg)
 1. You land on the public install page where the **Install** button is now available. Tap it!
 
    ![Installing_an_ipa_file_from_the_public_install_page.jpg](/img/_paligo/uuid-bb823f44-e4f5-b338-c82f-e2175f034f30.jpg)


### PR DESCRIPTION
## Summary
Fixes surfaced by a docs-validation pass on `docs/bitrise-ci/deploying` against the
implementation (bitrise-website, bitrise-api, bitrise-steplib, pipeline-service,
bitrise-workflow-editor). All changes below were confirmed against current Step
specs, product code, or git history — see the validation run for full evidence
(branch `validate/bitrise-ci-deploying` in bitrise-io/docs-validation).

- **Appaloosa**: remove the "unregistered user, email only" onboarding flow —
  removed from the Step in 2021; every current version requires registering on
  Appaloosa first.
- **Android Sign**: rename `Keystore alias` → `Key alias`; replace the removed
  `use_apk_signer` input with the current `signer_tool` enum (`automatic` /
  `apksigner` / `jarsigner`).
- **Android Build**: correct the "can only build one variant" claim (it supports
  multiple variants via its `Variant` input) and fix the `build-type` → `build_type`
  YAML key typo, which was silently producing an APK instead of the intended AAB.
- **Applivery / install page / Deploy to Bitrise.io**: remove three stale
  screenshots (a briefly-used Step title, a pre-2020 device-registration page, and
  retired Workflow Editor chrome + an extra unmentioned Step).
- **Deploy to Bitrise.io**: point readers to the current artifact details page
  (**View artifact** → **Manage access**) for the public install link toggle, which
  moved out of the Artifacts tab expand-arrow.

## Test plan
- [ ] Docs build passes (no MDX/link errors)
- [ ] Spot-check the 6 changed pages render correctly in the local preview