### PR TITLE
docs: fix stale content in bitrise-ci/bitrise-cli

### DIFF
--- a/docs/bitrise-ci/bitrise-cli/adding-a-new-project-from-a-cli.mdx
+++ b/docs/bitrise-ci/bitrise-cli/adding-a-new-project-from-a-cli.mdx
@@ -36,9 +36,9 @@ And that’s it! You are done: the URL to your new project will be printed out, 
 
 ## Adding the project
 
-1. Go to the [Create New project from CLI](https://app.bitrise.io/dashboard/add-project-from-cli) page.
+1. Go to the [New CI project from CLI](https://app.bitrise.io/apps/add/cli) page.
 
-   You can reach this page from your [Dashboard](https://app.bitrise.io/dashboard/builds): click the **Add new project** button on the right, and then select **Add New project from CLI**.
+   You can reach this page from your [Dashboard](https://app.bitrise.io/dashboard/builds): click the **New CI project** button on the right, and then select **New CI project from CLI**.
 
    ![2025-12-10-adding-project-with-cli.png](/img/_paligo/uuid-a6c8e931-615c-8697-8cf6-ab8d5269420b.png)
 1. Set the account that will own the project, and the privacy of the project.

--- a/docs/bitrise-ci/bitrise-cli/initializing-a-bitrise-project-locally.mdx
+++ b/docs/bitrise-ci/bitrise-cli/initializing-a-bitrise-project-locally.mdx
@@ -14,9 +14,7 @@ When you add a new app to Bitrise, we detect the type of your project and genera
 With the Bitrise CLI, you can make this work on your own computer:
 
 1. [Install the Bitrise CLI](/en/bitrise-ci/bitrise-cli/installing-and-updating-the-bitrise-cli) on your computer.
-1. Make sure that `$GOPATH/bin` is added to `$PATH` on your computer.
-
-   By default, your Go <GlossTerm baseform="workspace">workspace</GlossTerm> is at `$HOME/go/bin`.
+1. `bitrise init` needs Go to run.
 
    :::note[Installing Go]
 
@@ -45,4 +43,4 @@ With the Bitrise CLI, you can make this work on your own computer:
 
 Based on the scanner outputs, the plugin generates a Bitrise configuration, with a `bitrise.yml` file. In the automatically generated Workflows, every required input will have a valid value.
 
-The plugin also generates a `bitrise.secrets.yml` file. You can store your <GlossTerm baseform="Secret">Secrets</GlossTerm> in this file.
+The plugin also generates a `.bitrise.secrets.yml` file. You can store your <GlossTerm baseform="Secret">Secrets</GlossTerm> in this file.

--- a/docs/bitrise-ci/bitrise-cli/installing-and-upgrading-the-offline-workflow-editor.mdx
+++ b/docs/bitrise-ci/bitrise-cli/installing-and-upgrading-the-offline-workflow-editor.mdx
@@ -17,17 +17,13 @@ Bitrise <GlossTerm baseform="workflow editor">Workflow Editor</GlossTerm> is des
 1. Make sure you have [Go](https://golang.org/) installed on your local computer.
 1. Run `bitrise setup` to install offline Workflow Editor as part of the Bitrise Plugins.
 
-   Running `bitrise setup` also checks if Bitrise Core tools, OS X tools, Bitrise Plugins and Toolkits are installed on your local machine. If not, the command will automatically install them.
+   Running `bitrise setup` also checks if Bitrise Core tools, Bitrise Plugins and Toolkits are installed on your local machine. If not, it will automatically install them. On macOS, it also checks for Homebrew, prompting you to install it manually if missing.
 
 
 ## Starting the offline Workflow Editor
 
 1. `cd` into a directory where you have your `bitrise.yml`.
 1. Run `bitrise :workflow-editor` command to start your offline session.
-
-Here is the overall look and feel:
-
-![Installing_and_upgrading_the_offline_Workflow_Editor.png](/img/_paligo/uuid-29b363bc-ce14-f6a3-f310-62543138452e.png)
 
 
 ## Upgrading Workflow Editor version

--- a/docs/bitrise-ci/bitrise-cli/running-your-first-local-build-with-the-cli.mdx
+++ b/docs/bitrise-ci/bitrise-cli/running-your-first-local-build-with-the-cli.mdx
@@ -19,7 +19,7 @@ If you use [bitrise.io](https://www.bitrise.io), you can download your app’s `
 If you want to create a `bitrise.yml` yourself, simply create a `bitrise.yml` file in the root of your project. You can use this as the base content of the `bitrise.yml`:
 
 ```yaml
-format_version: 11
+format_version: '26'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:


### PR DESCRIPTION
## Summary
Fixes 6 findings from an automated docs-vs-implementation validation of `docs/bitrise-ci/bitrise-cli` (TW-1777):

- Remove the offline Workflow Editor screenshot showing the pre-React-rewrite top-tab-bar UI — replaced by a left-sidebar navigation over a year ago (S4).
- Fix the dead "Adding a new project from a CLI" deep link and relabel the CTA to match the live "New CI project" wizard (S3).
- Correct the generated Secrets filename to `.bitrise.secrets.yml` (was missing its leading dot) (S2).
- Remove the incorrect `$GOPATH/bin` prerequisite for `bitrise init`; bitrise manages its own Go toolchain and installs it automatically (S2).
- Clarify that only Homebrew requires manual install on macOS; Core tools/Plugins/Toolkits auto-install as documented (S1).
- Bump the example `bitrise.yml` `format_version` from 11 to the current 26 (S1).

Full validation reports: branch `validate/bitrise-ci-bitrise-cli` in the docs-validation repo.

## Test plan
- [x] Verified each fix against the implementation (bitrise CLI, bitrise-workflow-editor, bitrise-website source) during the validation run
- [ ] Docs build passes CI