### PR TITLE
Add JA style check (JTF via textlint) + translation guide

### DIFF
--- a/.github/workflows/ja-style-check.yml
+++ b/.github/workflows/ja-style-check.yml
@@ -1,0 +1,51 @@
+# =====================================================================
+# JA style check — enforces the JTF Japanese Standard Style Guide
+# =====================================================================
+# Runs the open-source JTF checker (textlint + textlint-rule-preset-jtf-style)
+# on changed Japanese docs. This is the automated QA gate for register/orthography
+# — the stand-in for a native reviewer on *style* (not meaning).
+#
+# Self-contained: installs textlint on the fly, so it does NOT touch the repo's
+# existing package.json. Config lives in .textlintrc.yaml at the repo root.
+#
+# ADJUST the paths below to your Docusaurus i18n layout if different.
+# =====================================================================
+name: JA style check (JTF)
+
+on:
+  pull_request:
+    paths:
+      - 'i18n/ja/**/*.md'
+      - 'i18n/ja/**/*.mdx'
+      - '.textlintrc.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  jtf-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+
+      - name: Lint changed Japanese docs against the JTF style guide
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          # NOTE: textlint core parses .md well. .mdx (JSX in docs) may need an MDX
+          # plugin — validate on a sample page before trusting the .mdx path.
+          FILES=$(git diff -z --name-only --diff-filter=AM "$BASE" HEAD \
+                  | tr '\0' '\n' | grep -E '^i18n/ja/.*\.(md|mdx)$' || true)
+          if [ -z "$FILES" ]; then echo "No Japanese docs changed."; exit 0; fi
+          echo "Checking:"; echo "$FILES"
+          # Isolated run via npx --package: installs textlint + the JTF preset + the
+          # comments filter into npx's cache only — does NOT touch the repo's own
+          # package.json or node_modules (important: this repo is a Docusaurus app).
+          echo "$FILES" | xargs npx --yes \
+            --package textlint \
+            --package textlint-rule-preset-jtf-style \
+            --package textlint-filter-rule-comments \
+            textlint -c .textlintrc.yaml

--- a/.textlintrc.yaml
+++ b/.textlintrc.yaml
@@ -1,0 +1,16 @@
+# JTF Japanese Standard Style Guide — automated checker config for the JA docs.
+# Uses textlint + textlint-rule-preset-jtf-style (open-source implementation of the
+# JTF standard). Enforces register (です・ます), katakana long-vowels, punctuation,
+# spacing, etc. Some rules auto-fix with `textlint --fix`.
+#
+# This is the automated stand-in for a native reviewer on STYLE/ORTHOGRAPHY.
+# It does NOT judge meaning — that still needs the one-time human calibration.
+#
+# Tune per team preference: any numbered JTF rule can be turned off, e.g.
+#   preset-jtf-style:
+#     "4.3.1.丸かっこ（）": false
+# See the preset README for the full rule list.
+filters:
+  comments: true            # honor <!-- textlint-disable --> in docs
+rules:
+  preset-jtf-style: true

--- a/localization/JA-TRANSLATION-GUIDE.md
+++ b/localization/JA-TRANSLATION-GUIDE.md
@@ -1,0 +1,112 @@
+# Bitrise Japanese Docs — Auto-Translation Guide
+
+House rules for machine-translating docs.bitrise.io into Japanese as reliably as an LLM can, for a Claude-driven pipeline with no full-time in-house Japanese linguist.
+
+**Status legend — read this first, so nothing here is mistaken for magic that isn't wired:**
+- **[LIVE]** — implemented and working in the scripts today.
+- **[PROCESS]** — a human step we recommend (not code).
+- **[ROADMAP]** — designed here but **not built yet**; do not rely on it until it ships.
+
+> **Standing assumption:** the Bitrise app UI is English-only for Japanese users, so on-screen labels, product names, Step names, code, and URLs stay in English; only the surrounding prose is translated.
+
+Base standard: the **JTF Japanese Standard Style Guide (translation)** — native-authored, has an English edition and a free style-checker tool.
+
+---
+
+## 1. What Japanese to write — register & tone  **[LIVE]**
+
+These rules are embedded in the translator's system prompt (`translate_docs.py`), so every run applies them:
+- **Register:** polite **です・ます調** throughout; instructions as 〜してください / 〜します. No plain だ・である style. Light, neutral honorifics (no heavy keigo).
+- **Voice:** clear and instructional; subject omission is natural — don't force 「あなた」.
+
+## 2. Orthography  **[LIVE]**
+
+Also embedded in the prompt:
+- Full-width Japanese punctuation (。 、).
+- Keep the long-vowel mark on katakana loanwords (サーバー, not サーバ).
+- Half-width numerals.
+- Embedded English / product terms stay in Latin script inside the Japanese sentence.
+
+*(The JTF **automated style-checker** that would enforce all of this mechanically is **[ROADMAP]** — see §8. Today these rules live only as prompt instructions.)*
+
+## 3. What never gets translated  **[LIVE]**
+
+Enforced by `ja-do-not-translate-glossary.yaml` (verified against the file):
+- **Pattern-masked before the model sees the text** (`protect_patterns`): fenced code blocks, inline code, URLs, env vars, filenames, MDX/JSX components, admonitions, templates, front-matter keys. This is byte-exact and tested. URLs are **not** tagged and **not** translated.
+- **Term lists kept English** (`do_not_translate`): `bitrise_products`, `bitrise_concepts`, `third_party`, `platforms_languages`, `acronyms`, `code_literals`, `ui_labels_hard_protect`, `step_names_and_field_labels`.
+- **Context-protected** (`ui_labels_context_protect`): common words frozen only when they clearly refer to a UI element.
+
+## 4. Terminology consistency — "same thing, same word, everywhere"  **[LIVE]**
+
+Mechanism: a **preferred-translations map** — one approved Japanese rendering per English term we *do* translate — in its own file `ja-preferred-translations.yaml`, injected into every translation prompt via `translate_docs.py --preferred`.
+
+```yaml
+preferred_translations:
+  "build number": "ビルド番号"
+  "environment variable": "環境変数"
+  # English term (lowercased) : the ONE approved Japanese rendering
+```
+
+- A term is either **kept English** (§3) **or** has a **fixed rendering here** — never both.
+- **Why a separate file:** the glossary is regenerated weekly by the builder, which would overwrite terms added there. This file is human-owned; the builder never touches it, so edits are permanent. *(The old `preferred_translations:` stub inside the glossary is vestigial — ignore it; this file supersedes it.)*
+- Growing this map is the main curation job: spot two renderings of one concept → pick one → add it here.
+
+## 5. Reliability checklist that is TRUE today  **[LIVE]**
+
+What actually makes the current output as good as LLM translation gets:
+1. Code/URLs/identifiers physically masked, so they can't be mangled (tested byte-exact).
+2. Product/UI/Step names forced to stay English via the glossary.
+3. JTF register + orthography rules in the prompt.
+4. Preferred-terms map for consistent terminology.
+5. Claude is a strong model for JA (honorifics/omission handling).
+
+## 6. Human calibration  **[PROCESS]**
+
+Because there's no in-house linguist: have a fluent Japanese reader review a sample of pilot pages **once** to (a) confirm the house style, (b) seed/correct `ja-preferred-translations.yaml`, and (c) sanity-check the do-not-translate behavior. After that, the [LIVE] mechanisms run unattended. This is the single most valuable non-code step.
+
+---
+
+## 7. Reuse of existing translations — translation memory  **[ROADMAP — NOT BUILT]**
+
+*Designed, not yet implemented. Do not assume this is running.*
+
+Plan: a `ja-translation-memory.json` storing each English segment → approved Japanese, so identical English is reused verbatim (free + automatically consistent) instead of re-translated. Seed it from the old pre-drop `/ja/` pages: import old EN↔JA pairs, run them through the checks (§8); passing ones are reused, failing ones are re-translated. This is the "reuse existing translations unless they prove bad" behavior — but it needs building.
+
+## 8. Automated quality gate & propagation  **[ROADMAP — NOT BUILT]**
+
+*Designed, not yet implemented.*
+
+- Automated checks in CI: JTF style-checker, a terminology check (every preferred term rendered its one way), a cross-page consistency check (no English segment rendered two ways), structure check. (Today only the do-not-translate masking is automated; the rest are manual/eyeball.)
+- Invalidation & propagation: when a preferred rendering is fixed, invalidate every stored segment containing that term so the correction re-translates on every page ("fix once, fix everywhere"). Requires the translation memory (§7) to exist first.
+
+---
+
+## 9. How it's wired today (files)
+
+| File | Role | Status |
+|------|------|--------|
+| `ja-do-not-translate-glossary.yaml` | patterns + do-not-translate terms | **LIVE** |
+| `ja-preferred-translations.yaml` | terminology consistency map | **LIVE** |
+| `translate_docs.py` | masks, injects style + glossary + preferred, translates | **LIVE** |
+| translation memory / CI QA checks / invalidation | reuse + gates + propagation | **ROADMAP** |
+
+Run today:
+```bash
+python3 translate_docs.py \
+  --glossary ja-do-not-translate-glossary.yaml \
+  --preferred ja-preferred-translations.yaml \
+  --src-root docs --dest-root i18n/ja/... path/to/changed.md
+```
+
+## 10. Definition of done for a translated page (today)
+
+- [ ] All protected terms/code/URLs still English (masking).
+- [ ] Glossary terms kept English; preferred terms use their one rendering.
+- [ ] Register/orthography read as natural です・ます Japanese (eyeball until the JTF checker is wired).
+- [ ] Markdown/MDX structure intact.
+
+---
+
+### References
+- JTF Japanese Standard Style Guide (translation) — base standard + free checker.
+- Industry LLM-translation practice: isolation zones for code, prompt-embedded glossary, translation memory for reuse/consistency.

--- a/localization/ja-preferred-translations.yaml
+++ b/localization/ja-preferred-translations.yaml
@@ -1,0 +1,32 @@
+# ============================================================================
+# Preferred Japanese translations — the terminology consistency map
+# ============================================================================
+# One approved Japanese rendering per English term we DO translate. The translator
+# (translate_docs.py --preferred) injects these so the same concept reads the same
+# way on every page.
+#
+# WHY THIS IS A SEPARATE FILE (not in the glossary):
+#   The glossary is REGENERATED from the product every week by build_ui_library.py,
+#   which would overwrite anything added there. This file is human-owned and the
+#   builder never touches it — so edits here are safe and permanent.
+#
+# RULES:
+#   - A term is either kept in English (do-not-translate glossary) OR has a fixed
+#     rendering here. Never both.
+#   - Add a term whenever you spot two renderings of one concept; pick one, put it here.
+#
+# STATUS: seed values below — a fluent Japanese reviewer must confirm/replace these
+#   before they are treated as authoritative.
+# ============================================================================
+preferred_translations:
+  "build": "ビルド"
+  "build number": "ビルド番号"
+  "environment variable": "環境変数"
+  "cache": "キャッシュ"
+  "artifact": "アーティファクト"
+  "trigger": "トリガー"
+  "deployment": "デプロイ"
+  "rollout": "ロールアウト"
+  "code signing": "コード署名"
+  "provisioning profile": "プロビジョニングプロファイル"
+  # add more as reviewers standardize them


### PR DESCRIPTION
Adds an automated Japanese style check plus the translation guide and terminology map. Separate from PR #124 and from the in-flight translate_docs work — only adds new files, so no conflict.

What's here:
- .textlintrc.yaml + .github/workflows/ja-style-check.yml — runs textlint with textlint-rule-preset-jtf-style (open-source implementation of the JTF Japanese Standard Style Guide) on changed Japanese docs. Automated stand-in for a native reviewer on STYLE/orthography (register, katakana, punctuation) — not meaning.
- localization/JA-TRANSLATION-GUIDE.md — house guide with a LIVE vs ROADMAP legend.
- localization/ja-preferred-translations.yaml — terminology-consistency map (human-owned).

Self-contained: the workflow installs textlint via npx into its cache only; it does NOT touch this repo's package.json / node_modules.

Before making this a required check: textlint core parses .md well, but .mdx (JSX in docs) may need an MDX plugin. Validate on one .mdx page first; keep the check non-blocking until confirmed.

Not in this PR (on purpose): the translate_docs.py changes (JTF style rules + a --preferred terms flag) will come as a diff to fold into the translate branch, so we don't clobber the in-flight work.
