### PR TITLE
docs(workspaces): note invitation rate limits [ER-2916]

### DIFF
--- a/docs/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/workspace-collaboration.mdx
+++ b/docs/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/workspace-collaboration.mdx
@@ -54,6 +54,12 @@ You can invite people to a workspace if they have a Bitrise account. Workspace m
 - Assign them [user access roles](/en/bitrise-platform/projects/roles-and-permissions-for-bitrise-ci) to manage their permissions on the project. When adding users in bulk, all of them will be assigned the same role.
 - Add users to [global access groups](/en/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/workspace-groups#global-access-groups): The invited users will have the same role on all projects owned by the workspace. You can't select specific projects when adding users this way.
 
+:::note[Invitation limits]
+
+To prevent abuse, invitations sent from workspaces on non-paid plans may be rate-limited. If you reach a limit while inviting members, wait a while before trying again.
+
+:::
+
 :::note[SAML SSO]
 
 Bitrise supports SAML SSO for your workspace. To learn more, check out [SAML SSO in Bitrise](/en/bitrise-platform/accounts/saml-sso-in-bitrise/configuring-saml-sso-on-bitrise).


### PR DESCRIPTION
[ER-2916](https://bitrise.atlassian.net/browse/ER-2916) · code PR: bitrise-io/bitrise-website#20377

Bulk workspace invites from non-paid workspaces are now rate-limited to block spam abuse. Adds a short, deliberately vague note to the workspace collaboration page — no exact thresholds, so we don't help abusers calibrate or lock ourselves into specific numbers.

> ⚠️ Agent-authored — please verify wording/placement before merging.

Not covered here: the `POST /organizations/{org-slug}/members` API reference now also returns `429`. That page is generated from the OpenAPI spec, so it needs a spec regen rather than a manual edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ER-2916]: https://bitrise.atlassian.net/browse/ER-2916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ