### PR TITLE
docs: add Bitrise for Jira app setup guide

### DIFF
--- a/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-for-jira-app.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-for-jira-app.mdx
@@ -9,20 +9,19 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GlossTerm from '@site/src/components/GlossTerm';
 import Partial_OpeningTheWorkspaceSettingsPage from '@site/src/partials/opening-the-workspace-settings-page.mdx';
-import NT from '@site/src/components/NT';
 
-The <NT>Bitrise for Jira</NT> app surfaces your <NT>Bitrise</NT> build and pipeline statuses directly on <NT>Jira</NT> issues, so your team can see where work stands without leaving <NT>Jira</NT>.
+The Bitrise for Jira app surfaces your Bitrise build and pipeline statuses directly on Jira issues, so your team can see where work stands without leaving Jira.
 
-Build information appears on a <NT>Jira</NT> issue in two places:
+Build information appears on a Jira issue in two places:
 
-- A dedicated **<NT>Bitrise builds</NT>** section, where you can also re-run or abort a build.
-- The **<NT>Builds</NT>** tab of <NT>Jira</NT>'s standard development panel.
+- A dedicated **Bitrise builds** section, where you can also re-run or abort a build.
+- The **Builds** tab of Jira's standard development panel.
 
 {/* TODO: screenshot of the Bitrise builds section on a Jira issue, showing build status and the re-run/abort actions (capture at 1728×875 per the Style Guide) */}
 
 :::important[Issue key required]
 
-Build information only appears on a <NT>Jira</NT> issue when the issue key (for example, `PROJ-123`) is present in at least one of the following:
+Build information only appears on a Jira issue when the issue key (for example, `PROJ-123`) is present in at least one of the following:
 
 - The branch name.
 - A Git tag.
@@ -34,8 +33,8 @@ Build information only appears on a <NT>Jira</NT> issue when the issue key (for 
 
 Setting up the app has two sides:
 
-- **On <NT>Jira</NT>**: a <NT>Jira</NT> admin installs the app and completes the connection.
-- **On <NT>Bitrise</NT>**: a user who can create the token and has <NT>Platform Engineer</NT> (or <NT>Admin</NT>) access on the relevant <GlossTerm baseform="project">projects</GlossTerm> decides which projects to connect. See [Creating a token](#creating-a-token) for why that access level is required.
+- **On Jira**: a Jira admin installs the app and completes the connection.
+- **On Bitrise**: a user who can create the token and has Platform Engineer (or Admin) access on the relevant <GlossTerm baseform="project">projects</GlossTerm> decides which projects to connect. See [Creating a token](#creating-a-token) for why that access level is required.
 
 This page walks through both sides from start to finish. Each section names who's responsible.
 
@@ -50,42 +49,42 @@ This page walks through both sides from start to finish. Each section names who'
 
 ## Installing the app in Jira
 
-You need permission to install and configure apps on the <NT>Jira</NT> site.
+You need permission to install and configure apps on the Jira site.
 
-1. In <NT>Jira</NT>, go to **<NT>Apps</NT> > <NT>Explore more apps</NT>** and search for **<NT>Bitrise for Jira</NT>**.
-1. Select the app and click **<NT>Get it now</NT>** to install it.
+1. In Jira, go to **Apps > Explore more apps** and search for **Bitrise for Jira**.
+1. Select the app and click **Get it now** to install it.
 
 :::note
 
-If you're not a <NT>Jira</NT> admin, use **<NT>Request to install</NT>** to send an approval request to your admin instead.
+If you're not a Jira admin, use **Request to install** to send an approval request to your admin instead.
 
 :::
 
 ## Creating a token
 
-The app authenticates to <NT>Bitrise</NT> with an API token, either a <NT>workspace API token</NT> or a <NT>Personal access token</NT>. Who can create one, and what access it needs, depends on the type:
+The app authenticates to Bitrise with an API token, either a workspace API token or a Personal access token. Who can create one, and what access it needs, depends on the type:
 
 | | Workspace API token | Personal access token |
 |---|---|---|
 | Belongs to | The workspace | An individual user |
 | Scope | A single workspace; can be limited to specific projects | Everything the user can access, across all their workspaces |
-| Who can create it | A <NT>workspace</NT> owner, or a member with the <NT>Manager</NT> <NT>workspace</NT> role | Any user, for their own account |
-| Needed on each connected project | <NT>Platform Engineer</NT> (or higher) as the token's <NT>Bitrise CI</NT> product-access role | <NT>Platform Engineer</NT> (or higher) as the token owner's own project role |
+| Who can create it | A workspace owner, or a member with the Manager workspace role | Any user, for their own account |
+| Needed on each connected project | Platform Engineer (or higher) as the token's Bitrise CI product-access role | Platform Engineer (or higher) as the token owner's own project role |
 | Survives people leaving | Yes | No — the connection breaks if the user loses access |
 | Recommended for | Most setups | Connecting apps that span more than one Workspace |
 
 :::tip[Recommendation]
 
-Use a <NT>Workspace API token</NT>. It's tied to the <NT>Workspace</NT> rather than a person, can be scoped to just the Bitrise projects you want to connect to the app, and doesn't break when someone leaves the team. Choose a <NT>Personal access token</NT> only if you need to connect projects from more than one <NT>Workspace</NT>.
+Use a Workspace API token. It's tied to the Workspace rather than a person, can be scoped to just the Bitrise projects you want to connect to the app, and doesn't break when someone leaves the team. Choose a Personal access token only if you need to connect projects from more than one Workspace.
 
 :::
 
 :::note[Why Platform Engineer]
 
-On each connected project, the app registers an outgoing webhook (needs the `change_settings` permission) and re-runs or aborts builds (needs `run_builds`). <NT>Platform Engineer</NT> is the lowest <NT>Bitrise CI</NT> role that covers both: <NT>Admin</NT> and <NT>Owner</NT> also work, but <NT>Developer</NT> and <NT>Tester/QA</NT> don't have enough access.
+On each connected project, the app registers an outgoing webhook (needs the `change_settings` permission) and re-runs or aborts builds (needs `run_builds`). Platform Engineer is the lowest Bitrise CI role that covers both: Admin and Owner also work, but Developer and Tester/QA don't have enough access.
 
-- For a <NT>Personal access token</NT>, this is the token owner's own role on the project.
-- For a <NT>Workspace API token</NT>, this is the <NT>Bitrise CI</NT> product access role you set on the token. The <NT>Workspace Role</NT> (<NT>Viewer</NT>, <NT>Contributor</NT>, <NT>Manager</NT>) is separate: it only controls who can manage the token, not what the app can do on connected projects.
+- For a Personal access token, this is the token owner's own role on the project.
+- For a Workspace API token, this is the Bitrise CI product access role you set on the token. The Workspace Role (Viewer, Contributor, Manager) is separate: it only controls who can manage the token, not what the app can do on connected projects.
 
 :::
 
@@ -93,18 +92,18 @@ On each connected project, the app registers an outgoing webhook (needs the `cha
 <TabItem value="workspace-api-token" label="Workspace API token" default>
 
 1. <Partial_OpeningTheWorkspaceSettingsPage />
-1. On the left, select **<NT>Security</NT>**.
-1. Click **<NT>Create token</NT>** and follow [Creating a Workspace API token](/en/bitrise-platform/workspaces/workspace-api-token), with these settings:
+1. On the left, select **Security**.
+1. Click **Create token** and follow [Creating a Workspace API token](/en/bitrise-platform/workspaces/workspace-api-token), with these settings:
 
-   - Set the **<NT>Workspace Role</NT>** to **<NT>Manager</NT>** (this controls who can manage the token, not what the app can do).
-   - Under **<NT>Configure Access to Products</NT>**, toggle **<NT>Bitrise CI</NT>** on and set its role to **<NT>Platform Engineer</NT>** or higher: this is the access the app actually uses on connected projects.
+   - Set the **Workspace Role** to **Manager** (this controls who can manage the token, not what the app can do).
+   - Under **Configure Access to Products**, toggle **Bitrise CI** on and set its role to **Platform Engineer** or higher: this is the access the app actually uses on connected projects.
    - Choose whether the token applies to all projects or only selected ones.
 
 </TabItem>
 <TabItem value="personal-access-token" label="Personal access token">
 
 1. [Create a personal access token](/en/bitrise-platform/accounts/personal-access-tokens).
-1. Make sure your own account has at least <NT>Platform Engineer</NT> role on every project you want to connect.
+1. Make sure your own account has at least Platform Engineer role on every project you want to connect.
 
 </TabItem>
 </Tabs>
@@ -117,45 +116,45 @@ You can only view a token's value at the moment you create it. Copy it and store
 
 :::tip
 
-You can set the token to never expire. If you set an expiry, the <NT>Jira</NT> connection stops working when the token expires: [Maintaining the connection](#maintaining-the-connection).
+You can set the token to never expire. If you set an expiry, the Jira connection stops working when the token expires: [Maintaining the connection](#maintaining-the-connection).
 
 :::
 
 ## Connecting Bitrise projects
 
-To connect <NT>Bitrise</NT> projects to <NT>Jira</NT>, you need the API token and a list of the projects you want to connect. The connection is completed on the <NT>Jira</NT> side, so a <NT>Jira</NT> admin must do that part.
+To connect Bitrise projects to Jira, you need the API token and a list of the projects you want to connect. The connection is completed on the Jira side, so a Jira admin must do that part.
 
-1. **On <NT>Bitrise</NT>:** Decide which <NT>Bitrise</NT> projects should send updates to <NT>Jira</NT>. Make a list of the specific projects, or decide to connect all of them.
-1. Share the API token and the project list with the <NT>Jira</NT> admin through a secure channel, such as a password manager or secrets tool, not over plain email or chat.
-1. **On <NT>Jira</NT>:** Go to **<NT>Apps</NT> > <NT>Manage your apps</NT> > <NT>Bitrise for Jira</NT>** and open its configuration page.
-1. Under **<NT>Bitrise API Token</NT>**, paste the token you received and click **<NT>Save</NT>**.
-1. Under **<NT>Connected Bitrise Projects</NT>**, select the projects you were given and click **<NT>Save</NT>**.
+1. **On Bitrise:** Decide which Bitrise projects should send updates to Jira. Make a list of the specific projects, or decide to connect all of them.
+1. Share the API token and the project list with the Jira admin through a secure channel, such as a password manager or secrets tool, not over plain email or chat.
+1. **On Jira:** Go to **Apps > Manage your apps > Bitrise for Jira** and open its configuration page.
+1. Under **Bitrise API Token**, paste the token you received and click **Save**.
+1. Under **Connected Bitrise Projects**, select the projects you were given and click **Save**.
 
 :::note
 
-An outgoing webhook is created automatically in <NT>Bitrise</NT> for each connected project. You don't need to configure webhooks manually.
+An outgoing webhook is created automatically in Bitrise for each connected project. You don't need to configure webhooks manually.
 
 :::
 
 ## Verifying the connection
 
-You can verify the connection with a <NT>Jira</NT> admin.
+You can verify the connection with a Jira admin.
 
-1. Open a <NT>Jira</NT> issue whose key appears in the branch name, a Git tag, the pull request title, the pull request description, or a commit message of work in a connected <NT>Bitrise</NT> project.
-1. Confirm that <NT>Bitrise</NT> build status appears in the **<NT>Bitrise builds</NT>** section of the issue and in the **<NT>Builds</NT>** tab of the development panel.
+1. Open a Jira issue whose key appears in the branch name, a Git tag, the pull request title, the pull request description, or a commit message of work in a connected Bitrise project.
+1. Confirm that Bitrise build status appears in the **Bitrise builds** section of the issue and in the **Builds** tab of the development panel.
 
 If nothing appears, see [Troubleshooting](#troubleshooting).
 
 ## Maintaining the connection
 
 - **Token expiry or change:** If the API token expires, is regenerated, or is replaced, the connection stops working. Update the token on the app's configuration page and re-check your connected projects.
-- **New Bitrise projects:** When you add a new project in <NT>Bitrise</NT> that you want to appear in <NT>Jira</NT>, return to the app's configuration page and add it under **<NT>Connected Bitrise Projects</NT>**.
+- **New Bitrise projects:** When you add a new project in Bitrise that you want to appear in Jira, return to the app's configuration page and add it under **Connected Bitrise Projects**.
 
 ## Troubleshooting
 
-- **No build status on issues:** Confirm the issue key is present in the branch name, a Git tag, the pull request title, the pull request description, or a commit message. Then check that the token is still valid and that the relevant project is selected under **<NT>Connected Bitrise Projects</NT>**.
-- **A project is missing from the list:** The token can't access it. Check that the token (or the project role of its owner, for a <NT>Personal access token</NT>) includes that project, or ask whoever created the token to update it.
-- **Build status that used to work stops appearing:** The usual cause is someone unchecking **<NT>Attach Bitrise OIDC token</NT>** on the connected project's outgoing webhook, in <NT>Bitrise</NT>. Check the **<NT>Activity</NT>** section on the app's <NT>Jira</NT> configuration page for rejected deliveries.
+- **No build status on issues:** Confirm the issue key is present in the branch name, a Git tag, the pull request title, the pull request description, or a commit message. Then check that the token is still valid and that the relevant project is selected under **Connected Bitrise Projects**.
+- **A project is missing from the list:** The token can't access it. Check that the token (or the project role of its owner, for a Personal access token) includes that project, or ask whoever created the token to update it.
+- **Build status that used to work stops appearing:** The usual cause is someone unchecking **Attach Bitrise OIDC token** on the connected project's outgoing webhook, in Bitrise. Check the **Activity** section on the app's Jira configuration page for rejected deliveries.
 
 ## Related pages
 

--- a/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-for-jira-app.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-for-jira-app.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Bitrise for Jira app"
 description: "The Bitrise for Jira app surfaces your Bitrise build and pipeline statuses directly on Jira issues, so your team can see where work stands without leaving Jira."
-sidebar_position: 10
-slug: /bitrise-platform/integrations/bitrise-for-jira-app
+sidebar_position: 11
+slug: /bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-for-jira-app
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-for-jira-app.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-for-jira-app.mdx
@@ -75,7 +75,7 @@ The app authenticates to Bitrise with an API token, either a workspace API token
 | Belongs to | The workspace | An individual user |
 | Scope | A single workspace; can be limited to specific projects | Everything the user can access, across all their workspaces |
 | Who can create it | A workspace owner, or a member with the Manager workspace role | Any user, for their own account |
-| Needed on each connected project | Platform Engineer (or higher) as the token's Bitrise CI product-access role | Platform Engineer (or higher) as the token owner's own project role |
+| Needed on each connected project | Platform Engineer as the token's Bitrise CI product-access role | Platform Engineer (or higher) as the token owner's own project role |
 | Survives people leaving | Yes | No — the connection breaks if the user loses access |
 | Recommended for | Most setups | Connecting apps that span more than one Workspace |
 
@@ -90,7 +90,7 @@ Use a Workspace API token. It's tied to the Workspace rather than a person, can 
 On each connected project, the app registers an outgoing webhook (needs the `change_settings` permission) and re-runs or aborts builds (needs `run_builds`). Platform Engineer is the lowest Bitrise CI role that covers both: Admin and Owner also work, but Developer and Tester/QA don't have enough access.
 
 - For a Personal access token, this is the token owner's own role on the project.
-- For a Workspace API token, this is the Bitrise CI product access role you set on the token. The Workspace Role (Viewer, Contributor, Manager) is separate: it only controls who can manage the token, not what the app can do on connected projects.
+- For a Workspace API token, this is the Bitrise CI product access role you set on the token. The Workspace role (Viewer, Contributor, Manager) is separate: it only controls who can manage the token, not what the app can do on connected projects.
 
 :::
 
@@ -101,8 +101,8 @@ On each connected project, the app registers an outgoing webhook (needs the `cha
 1. On the left, select **Security**.
 1. Click **Create token** and follow [Creating a Workspace API token](/en/bitrise-platform/workspaces/workspace-api-token), with these settings:
 
-   - Set the **Workspace Role** to **Manager** (this controls who can manage the token, not what the app can do).
-   - Under **Configure Access to Products**, toggle **Bitrise CI** on and set its role to **Platform Engineer** or higher: this is the access the app actually uses on connected projects.
+   - Set the **Workspace role** to **Manager** (this controls who can manage the token, not what the app can do).
+   - Under **Configure access to products**, toggle **Bitrise CI** on and set its role to **Platform Engineer**: this is the access the app actually uses on connected projects.
    - Choose whether the token applies to all projects or only selected ones.
 
 </TabItem>
@@ -116,7 +116,7 @@ On each connected project, the app registers an outgoing webhook (needs the `cha
 
 :::important[Save the token]
 
-You can only view a token's value at the moment you create it. Copy it and store it securely before closing the dialog.
+You can only view a token's value at the moment you create it. Copy it and store it securely before leaving the **Save token** step.
 
 :::
 

--- a/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-for-jira-app.mdx
+++ b/docs/bitrise-ci/run-and-analyze-builds/build-data-and-troubleshooting/bitrise-for-jira-app.mdx
@@ -12,6 +12,12 @@ import Partial_OpeningTheWorkspaceSettingsPage from '@site/src/partials/opening-
 
 The Bitrise for Jira app surfaces your Bitrise build and pipeline statuses directly on Jira issues, so your team can see where work stands without leaving Jira.
 
+:::important[Jira Cloud only]
+
+The Bitrise for Jira app works with Jira Cloud only: it doesn't support self-hosted Jira (Jira Data Center or Jira Server).
+
+:::
+
 Build information appears on a Jira issue in two places:
 
 - A dedicated **Bitrise builds** section, where you can also re-run or abort a build.

--- a/docs/bitrise-platform/integrations/bitrise-for-jira-app.mdx
+++ b/docs/bitrise-platform/integrations/bitrise-for-jira-app.mdx
@@ -1,0 +1,163 @@
+---
+title: "Bitrise for Jira app"
+description: "The Bitrise for Jira app surfaces your Bitrise build and pipeline statuses directly on Jira issues, so your team can see where work stands without leaving Jira."
+sidebar_position: 10
+slug: /bitrise-platform/integrations/bitrise-for-jira-app
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GlossTerm from '@site/src/components/GlossTerm';
+import Partial_OpeningTheWorkspaceSettingsPage from '@site/src/partials/opening-the-workspace-settings-page.mdx';
+import NT from '@site/src/components/NT';
+
+The <NT>Bitrise for Jira</NT> app surfaces your <NT>Bitrise</NT> build and pipeline statuses directly on <NT>Jira</NT> issues, so your team can see where work stands without leaving <NT>Jira</NT>.
+
+Build information appears on a <NT>Jira</NT> issue in two places:
+
+- A dedicated **<NT>Bitrise builds</NT>** section, where you can also re-run or abort a build.
+- The **<NT>Builds</NT>** tab of <NT>Jira</NT>'s standard development panel.
+
+{/* TODO: screenshot of the Bitrise builds section on a Jira issue, showing build status and the re-run/abort actions (capture at 1728×875 per the Style Guide) */}
+
+:::important[Issue key required]
+
+Build information only appears on a <NT>Jira</NT> issue when the issue key (for example, `PROJ-123`) is present in at least one of the following:
+
+- The branch name.
+- A Git tag.
+- The pull request title.
+- The pull request description.
+- A commit message.
+
+:::
+
+Setting up the app has two sides:
+
+- **On <NT>Jira</NT>**: a <NT>Jira</NT> admin installs the app and completes the connection.
+- **On <NT>Bitrise</NT>**: a user who can create the token and has <NT>Platform Engineer</NT> (or <NT>Admin</NT>) access on the relevant <GlossTerm baseform="project">projects</GlossTerm> decides which projects to connect. See [Creating a token](#creating-a-token) for why that access level is required.
+
+This page walks through both sides from start to finish. Each section names who's responsible.
+
+## Setup at a glance
+
+| Task | Done on |
+|---|---|
+| Installing the app in Jira | Jira, by a Jira admin |
+| Creating a token | Bitrise, by whoever creates the token |
+| Connecting Bitrise projects | Bitrise, then Jira |
+| Verifying the connection | Jira, by a Jira admin |
+
+## Installing the app in Jira
+
+You need permission to install and configure apps on the <NT>Jira</NT> site.
+
+1. In <NT>Jira</NT>, go to **<NT>Apps</NT> > <NT>Explore more apps</NT>** and search for **<NT>Bitrise for Jira</NT>**.
+1. Select the app and click **<NT>Get it now</NT>** to install it.
+
+:::note
+
+If you're not a <NT>Jira</NT> admin, use **<NT>Request to install</NT>** to send an approval request to your admin instead.
+
+:::
+
+## Creating a token
+
+The app authenticates to <NT>Bitrise</NT> with an API token, either a <NT>workspace API token</NT> or a <NT>Personal access token</NT>. Who can create one, and what access it needs, depends on the type:
+
+| | Workspace API token | Personal access token |
+|---|---|---|
+| Belongs to | The workspace | An individual user |
+| Scope | A single workspace; can be limited to specific projects | Everything the user can access, across all their workspaces |
+| Who can create it | A <NT>workspace</NT> owner, or a member with the <NT>Manager</NT> <NT>workspace</NT> role | Any user, for their own account |
+| Needed on each connected project | <NT>Platform Engineer</NT> (or higher) as the token's <NT>Bitrise CI</NT> product-access role | <NT>Platform Engineer</NT> (or higher) as the token owner's own project role |
+| Survives people leaving | Yes | No — the connection breaks if the user loses access |
+| Recommended for | Most setups | Connecting apps that span more than one Workspace |
+
+:::tip[Recommendation]
+
+Use a <NT>Workspace API token</NT>. It's tied to the <NT>Workspace</NT> rather than a person, can be scoped to just the Bitrise projects you want to connect to the app, and doesn't break when someone leaves the team. Choose a <NT>Personal access token</NT> only if you need to connect projects from more than one <NT>Workspace</NT>.
+
+:::
+
+:::note[Why Platform Engineer]
+
+On each connected project, the app registers an outgoing webhook (needs the `change_settings` permission) and re-runs or aborts builds (needs `run_builds`). <NT>Platform Engineer</NT> is the lowest <NT>Bitrise CI</NT> role that covers both: <NT>Admin</NT> and <NT>Owner</NT> also work, but <NT>Developer</NT> and <NT>Tester/QA</NT> don't have enough access.
+
+- For a <NT>Personal access token</NT>, this is the token owner's own role on the project.
+- For a <NT>Workspace API token</NT>, this is the <NT>Bitrise CI</NT> product access role you set on the token. The <NT>Workspace Role</NT> (<NT>Viewer</NT>, <NT>Contributor</NT>, <NT>Manager</NT>) is separate: it only controls who can manage the token, not what the app can do on connected projects.
+
+:::
+
+<Tabs>
+<TabItem value="workspace-api-token" label="Workspace API token" default>
+
+1. <Partial_OpeningTheWorkspaceSettingsPage />
+1. On the left, select **<NT>Security</NT>**.
+1. Click **<NT>Create token</NT>** and follow [Creating a Workspace API token](/en/bitrise-platform/workspaces/workspace-api-token), with these settings:
+
+   - Set the **<NT>Workspace Role</NT>** to **<NT>Manager</NT>** (this controls who can manage the token, not what the app can do).
+   - Under **<NT>Configure Access to Products</NT>**, toggle **<NT>Bitrise CI</NT>** on and set its role to **<NT>Platform Engineer</NT>** or higher: this is the access the app actually uses on connected projects.
+   - Choose whether the token applies to all projects or only selected ones.
+
+</TabItem>
+<TabItem value="personal-access-token" label="Personal access token">
+
+1. [Create a personal access token](/en/bitrise-platform/accounts/personal-access-tokens).
+1. Make sure your own account has at least <NT>Platform Engineer</NT> role on every project you want to connect.
+
+</TabItem>
+</Tabs>
+
+:::important[Save the token]
+
+You can only view a token's value at the moment you create it. Copy it and store it securely before closing the dialog.
+
+:::
+
+:::tip
+
+You can set the token to never expire. If you set an expiry, the <NT>Jira</NT> connection stops working when the token expires: [Maintaining the connection](#maintaining-the-connection).
+
+:::
+
+## Connecting Bitrise projects
+
+To connect <NT>Bitrise</NT> projects to <NT>Jira</NT>, you need the API token and a list of the projects you want to connect. The connection is completed on the <NT>Jira</NT> side, so a <NT>Jira</NT> admin must do that part.
+
+1. **On <NT>Bitrise</NT>:** Decide which <NT>Bitrise</NT> projects should send updates to <NT>Jira</NT>. Make a list of the specific projects, or decide to connect all of them.
+1. Share the API token and the project list with the <NT>Jira</NT> admin through a secure channel, such as a password manager or secrets tool, not over plain email or chat.
+1. **On <NT>Jira</NT>:** Go to **<NT>Apps</NT> > <NT>Manage your apps</NT> > <NT>Bitrise for Jira</NT>** and open its configuration page.
+1. Under **<NT>Bitrise API Token</NT>**, paste the token you received and click **<NT>Save</NT>**.
+1. Under **<NT>Connected Bitrise Projects</NT>**, select the projects you were given and click **<NT>Save</NT>**.
+
+:::note
+
+An outgoing webhook is created automatically in <NT>Bitrise</NT> for each connected project. You don't need to configure webhooks manually.
+
+:::
+
+## Verifying the connection
+
+You can verify the connection with a <NT>Jira</NT> admin.
+
+1. Open a <NT>Jira</NT> issue whose key appears in the branch name, a Git tag, the pull request title, the pull request description, or a commit message of work in a connected <NT>Bitrise</NT> project.
+1. Confirm that <NT>Bitrise</NT> build status appears in the **<NT>Bitrise builds</NT>** section of the issue and in the **<NT>Builds</NT>** tab of the development panel.
+
+If nothing appears, see [Troubleshooting](#troubleshooting).
+
+## Maintaining the connection
+
+- **Token expiry or change:** If the API token expires, is regenerated, or is replaced, the connection stops working. Update the token on the app's configuration page and re-check your connected projects.
+- **New Bitrise projects:** When you add a new project in <NT>Bitrise</NT> that you want to appear in <NT>Jira</NT>, return to the app's configuration page and add it under **<NT>Connected Bitrise Projects</NT>**.
+
+## Troubleshooting
+
+- **No build status on issues:** Confirm the issue key is present in the branch name, a Git tag, the pull request title, the pull request description, or a commit message. Then check that the token is still valid and that the relevant project is selected under **<NT>Connected Bitrise Projects</NT>**.
+- **A project is missing from the list:** The token can't access it. Check that the token (or the project role of its owner, for a <NT>Personal access token</NT>) includes that project, or ask whoever created the token to update it.
+- **Build status that used to work stops appearing:** The usual cause is someone unchecking **<NT>Attach Bitrise OIDC token</NT>** on the connected project's outgoing webhook, in <NT>Bitrise</NT>. Check the **<NT>Activity</NT>** section on the app's <NT>Jira</NT> configuration page for rejected deliveries.
+
+## Related pages
+
+- [Workspace API token](/en/bitrise-platform/workspaces/workspace-api-token)
+- [Personal access tokens](/en/bitrise-platform/accounts/personal-access-tokens)


### PR DESCRIPTION
## Summary
- Adds a new DevCenter page documenting the Bitrise for Jira app: installing it in Jira, creating a Bitrise API token, connecting projects, verifying the connection, maintaining it, and troubleshooting.
- Sourced from the RD Confluence draft, rewritten to house style (task-based framing instead of an invented "Bitrise admin" role, gerund procedure headings, Tabs for the two token types).
- Token permission requirements (Platform Engineer or higher, needed for the outgoing webhook's `change_settings` and build rerun/abort's `run_builds`) confirmed against `bitrise-website` source and product engineering — see TW-1795 for details.

## Test plan
- [x] `node scripts/check-links-source.js docs/bitrise-platform/integrations/bitrise-for-jira-app.mdx` passes clean
- [ ] Reviewer sanity-check against the live Bitrise for Jira app UI (token creation dialog, config page save flow) before merge