### PR TITLE
docs(bitrise-ci/api): fix docs-vs-implementation drift in the api section

### DIFF
--- a/docs/bitrise-ci/api/adding-and-managing-apps.mdx
+++ b/docs/bitrise-ci/api/adding-and-managing-apps.mdx
@@ -32,7 +32,7 @@ The procedure and the examples are aimed at adding a private app with an SSH git
 
 1. Register the app by calling the `register` endpoint and setting all required parameters.
 
-   You need to set your git provider, the repository URL, the slug of the repository as it appears at the provider, and the slug of the owner of the repository. You also need to add the slug of the Workspace that will own the app: due to legacy naming conventions, you need the `organization_slug` parameter.
+   You need to set your git provider, the repository URL, and the slug of the repository as it appears at the provider. You also need to add the slug of the Workspace that will own the app: due to legacy naming conventions, you need the `organization_slug` parameter.
 
    ```yaml
    curl -X POST -H 'Authorization: ACCESS-TOKEN' 'https://api.bitrise.io/v0.1/apps/register' -d \
@@ -157,6 +157,7 @@ The required parameter is:
 
 The optional parameters are:
 
+- apple_api_credential_slug: The new Apple API key's slug (recommendation: use the UI to set this)
 - apple_credential_user_id: The new apple credential user ID (recommendation: use the UI to set this)
 - apple_credential_user_slug: The new apple credential user slug (recommendation: use the UI to set this)
 - default_branch: The new default branch for the application.
@@ -178,11 +179,14 @@ curl -X 'PATCH' 'https://api.bitrise.io/v0.1/apps/THE-APP-SLUG' -H 'accept: appl
 
 You can grant [Workspace groups](/en/bitrise-platform/workspaces/collaboration-and-permissions-in-workspaces/workspace-groups#creating-groups-for-workspaces) access to application teams on Bitrise. It means that all members of the group will be able to work on the app in [the role assigned to the group](/en/bitrise-platform/projects/roles-and-permissions-for-bitrise-ci).
 
-List all groups that have been granted a given role on an app's team by using the `GET /apps/{app-slug}/roles/{role-name}` endpoint. The role-name parameter takes three possible values:
+List all groups that have been granted a given role on an app's team by using the `GET /apps/{app-slug}/roles/{role-name}` endpoint. The role-name parameter takes the following values:
 
+- `owner`
 - `admin`
-- `manager`: this is the equivalent of the **Developer** role on bitrise.io.
-- `member`: this is the equivalent of **Tester/QA** on bitrise.io.
+- `manager`
+- `member`
+- `release_manager`
+- `platform_engineer`
 
 In this example, we're querying a list of Workspace groups that have been granted Admin role to a specific app:
 
@@ -353,7 +357,7 @@ curl -X 'PUT' \
 
 | Endpoints | Function | Required role |
 | --- | --- | --- |
-| PATCH /user/\{user-slug\}/apps/machine_types | Migrate a specified machine type to another in all apps owned by the same user. | N/A |
+| PATCH /users/\{user-slug\}/apps/machine_types | Migrate a specified machine type to another in all apps owned by the same user. | N/A |
 | PATCH /organizations/\{org-slug\}/apps/machine_types | Migrate a specified machine type to another in all apps owned by the same Workspace. | Workspace owner |
 
 The Bitrise API provides two endpoints that allow you to switch between one [machine type](/en/bitrise-platform/infrastructure/build-machines/about-build-machines) and another for all apps owned by either a user or a [Workspace](/en/bitrise-platform/workspaces/workspaces-overview). The endpoints parse the `bitrise.yml` file of each app, look for all occurrences of a specified machine type, and replace them with another type. For example, you can switch from M1 Medium to M1 Large on all your apps with this endpoint.
@@ -378,7 +382,7 @@ The endpoints can change the machine types for both default stacks and Workflow-
 
 ```bash
 curl -X 'PATCH' \
-  'https://api.bitrise.io/v0.1/user/USER-SLUG/apps/machine_types' \
+  'https://api.bitrise.io/v0.1/users/USER-SLUG/apps/machine_types' \
   -H 'accept: application/json' \
   -H 'Authorization: PERSONAL-ACCESS-TOKEN' \
   -H 'Content-Type: application/json' \
@@ -424,9 +428,9 @@ You can change [the email notification settings](/en/bitrise-ci/configure-builds
 
 Both parameters take three possible values:
 
-- `always`: Always send notification. The default value for failed builds.
-- `never`: Never send notification.
-- `change`: Send notification only when the [build status](/en/bitrise-ci/run-and-analyze-builds/build-statuses) changes compared to the previous build on the same branch. The default value for successful builds.
+- `always`: Always send notification.
+- `never`: Never send notification. The default value for both failed and successful builds.
+- `change`: Send notification only when the [build status](/en/bitrise-ci/run-and-analyze-builds/build-statuses) changes compared to the previous build on the same branch.
 
 For example, if you wish to receive a notification for a failed build only when the previous build was successful, you need to set the value of the on_failure parameter to `change` (replace the APP-SLUG in the example with your app's slug and ACCESS-TOKEN with your [personal access token](/en/bitrise-platform/accounts/personal-access-tokens)):
 

--- a/docs/bitrise-ci/api/github-app-configuration-api.mdx
+++ b/docs/bitrise-ci/api/github-app-configuration-api.mdx
@@ -62,7 +62,7 @@ curl -X 'POST' \
 
 ## Extending GitHub app permissions to builds
 
-The Bitrise GitHub App generates a short-term, temporary token for each build that is triggered via the app. This token has only one permission by default: content:read. This means the build can access the GitHub repository but can't do anything else.
+The Bitrise GitHub App generates a short-term, temporary token for each build that is triggered via the app. This token has only one permission by default: contents:read. This means the build can access the GitHub repository but can't do anything else.
 
 You can extend these permissions so that you can perform other operations during a build. For example, this can enable users to push Git tags from their builds, create custom status reports, put a label on a pull request, or push a new version number.
 

--- a/docs/bitrise-ci/api/identifying-workspaces-and-apps-with-their-slugs.mdx
+++ b/docs/bitrise-ci/api/identifying-workspaces-and-apps-with-their-slugs.mdx
@@ -58,6 +58,8 @@ You can get the slug for all Workspaces and apps you have access to with simple 
 
    ```json
    {
+     "data": [
+       {
          "name": "TestOrg",
          "slug": "2dec5c71bbce73d9",
          "avatar_icon_url": "https://bitrise-public-content-production.s3.amazonaws.com/org-icons/default_avatar-09.png",
@@ -67,9 +69,11 @@ You can get the slug for all Workspaces and apps you have access to with simple 
              "slug": "1b3f130835b1c09ef2",
              "username": "bitbot",
              "email": "bit.bot@bitrise.io"
-           },
+           }
          ]
-       },
+       }
+     ]
+   }
    ```
 
 </TabItem>

--- a/docs/bitrise-ci/api/incoming-and-outgoing-webhooks.mdx
+++ b/docs/bitrise-ci/api/incoming-and-outgoing-webhooks.mdx
@@ -56,7 +56,7 @@ Notifying your Git provider about the build status does not require outgoing web
 To set up an outgoing webhook for an application, you need to specify the app itself and at least two of the creation parameters:
 
 - The webhook URL: you can get this from the service you want to integrate with Bitrise.
-- The events that trigger the webhook. Currently, this takes two possible values: `all` and `build`.
+- The events that trigger the webhook. Currently, this takes three possible values: `all`, `build`, and `pipeline`.
 
 :::note[Required role]
 

--- a/docs/bitrise-ci/api/managing-android-keystore-files.mdx
+++ b/docs/bitrise-ci/api/managing-android-keystore-files.mdx
@@ -92,12 +92,19 @@ To add an Android keystore file to your app using the API, you will need to:
 
    This sets the processed flag of the file to `true`. This flag can't be changed again afterwards!
 
+The create call also accepts these optional parameters, to store the keystore's credentials alongside the file:
+
+- password: The keystore's password.
+- alias: The alias of the key you want to use.
+- private_key_password: The password of the key.
+- keystore_file_name: The keystore's file name. Required if the app already has another keystore file.
+
 **Creating and uploading a new Android keystore file**
 
 Creating the file:
 
 ```bash
-curl -X POST -H 'Authorization: THE-ACCESS-TOKEN' 'https://api.bitrise.io/v0.1/apps/APP-SLUG/android-keystore-files' -d '{"upload_file_name":"simplesample.jks","upload_file_size":2062}'
+curl -X POST -H 'Authorization: THE-ACCESS-TOKEN' 'https://api.bitrise.io/v0.1/apps/APP-SLUG/android-keystore-files' -d '{"upload_file_name":"simplesample.jks","upload_file_size":2062,"password":"KEYSTORE-PASSWORD","alias":"KEY-ALIAS","private_key_password":"KEY-PASSWORD","keystore_file_name":"simplesample.jks"}'
 ```
 
 Response:

--- a/docs/bitrise-ci/api/managing-files-in-generic-file-storage.mdx
+++ b/docs/bitrise-ci/api/managing-files-in-generic-file-storage.mdx
@@ -25,7 +25,7 @@ You can upload, delete, update, and list any project files in the `GENERIC FILE 
 
 :::note[Required role]
 
-You must have an admin or owner role role on the app's team to manage files in the Generic File Storage using the Bitrise API.
+You must have an admin or owner role on the app's team to manage files in the Generic File Storage using the Bitrise API.
 
 For a complete list of user roles and role cheatsheets, check [Roles and permissions for Bitrise CI](/en/bitrise-platform/projects/roles-and-permissions-for-bitrise-ci).
 
@@ -108,7 +108,7 @@ Response:
 
 :::note[Required role]
 
-You must have an admin or owner role role on the app's team to manage files in the Generic File Storage using the Bitrise API.
+You must have an admin or owner role on the app's team to manage files in the Generic File Storage using the Bitrise API.
 
 For a complete list of user roles and role cheatsheets, check [Roles and permissions for Bitrise CI](/en/bitrise-platform/projects/roles-and-permissions-for-bitrise-ci).
 
@@ -158,7 +158,7 @@ Note that the `download_url` is generated only when the file’s `is_protected` 
 
 :::note[Required role]
 
-You must have an admin or owner role role on the app's team to manage files in the Generic File Storage using the Bitrise API.
+You must have an admin or owner role on the app's team to manage files in the Generic File Storage using the Bitrise API.
 
 For a complete list of user roles and role cheatsheets, check [Roles and permissions for Bitrise CI](/en/bitrise-platform/projects/roles-and-permissions-for-bitrise-ci).
 
@@ -215,7 +215,7 @@ You can delete your uploaded file from the Generic File Storage using the `DELET
 
 :::note[Required role]
 
-You must have an admin or owner role role on the app's team to manage files in the Generic File Storage using the Bitrise API.
+You must have an admin or owner role on the app's team to manage files in the Generic File Storage using the Bitrise API.
 
 For a complete list of user roles and role cheatsheets, check [Roles and permissions for Bitrise CI](/en/bitrise-platform/projects/roles-and-permissions-for-bitrise-ci).
 

--- a/docs/bitrise-ci/api/managing-ios-code-signing-files.mdx
+++ b/docs/bitrise-ci/api/managing-ios-code-signing-files.mdx
@@ -110,6 +110,12 @@ For a **build certificate** you can set the same attributes as above but you can
 curl -X PATCH -H 'Authorization: THE-ACCESS-TOKEN' 'https://api.bitrise.io/v0.1/apps/APP-SLUG/build-certificates/BUILD-CERTIFICATE-SLUG -d '{"certificate_password":"s0m3-v3ry-s3cr3t-str1ng"}'
 ```
 
+:::note[Availability of the `certificate_password`]
+
+Note that, the same way as the `download_url`, the `certificate_password` is only returned in the response when the file's `is_protected` attribute is false.
+
+:::
+
 :::warning[Be careful when setting attributes]
 
 You can set the `is_protected`, `is_exposed` and `processed` attributes of the files you've uploaded:

--- a/docs/bitrise-ci/api/pagination-of-api-calls.md
+++ b/docs/bitrise-ci/api/pagination-of-api-calls.md
@@ -29,7 +29,7 @@ The `next` property of the `paging` object is only included if there’s at leas
 Limit the number of response pages with the `limit` parameter:
 
 ```
-https://api.bitrise.io/v0.1/me/apps?limit=10
+https://api.bitrise.io/v0.1/apps?limit=10
 ```
 
 This call sets the `page_item_limit` property to 10. The default (and maximum) value of the parameter is 50.
@@ -42,10 +42,10 @@ Iterate through response items:
 
 **Iterating through all your registered apps**
 
-1. Call `https://api.bitrise.io/v0.1/me/apps`.
+1. Call `https://api.bitrise.io/v0.1/apps`.
 1. Process the items (`data` property).
 1. Check the `paging` (root) property.
 1. If there’s a `next` property inside `paging`, call the endpoint again, with the `next` query parameter
 
-   - Example: `https://api.bitrise.io/v0.1/me/apps?next=NEXTVALUE`, where `NEXTVALUE` is the value of the `next` property you got in your previous response.
+   - Example: `https://api.bitrise.io/v0.1/apps?next=NEXTVALUE`, where `NEXTVALUE` is the value of the `next` property you got in your previous response.
 1. Repeat this until the `paging` object does not include a `next` property, which means that the page you received was the last one.

--- a/docs/bitrise-ci/api/triggering-and-aborting-builds.mdx
+++ b/docs/bitrise-ci/api/triggering-and-aborting-builds.mdx
@@ -40,7 +40,7 @@ Here’s a minimal sample JSON body which specifies `main` as the value of the `
 ```json
 {
   "hook_info": {
-    "type": "bitrise",
+    "type": "bitrise"
   },
   "build_params": {
     "branch": "main"
@@ -83,7 +83,7 @@ Here’s a jQuery example using the `payload` parameter:
 $.post("https://api.bitrise.io/v0.1/apps/APP-SLUG/builds/", {
     "payload":{
         "hook_info":{
-            "type":"bitrise",
+            "type":"bitrise"
         },
         "build_params":{
             "branch":"main",
@@ -215,7 +215,7 @@ curl -X 'POST' \
 
 You can define additional [Environment Variables](/en/bitrise-ci/configure-builds/environment-variables) (Env Vars) for your build. These additional variables will be handled with priority between `Secrets` and `App Env Vars`, which means that you can not overwrite Env Vars defined in your build configuration (for example, App Env Vars), only [Secrets](/en/bitrise-ci/configure-builds/secrets).
 
-Define additional Env Vars with the environments parameter. This parameter must be an **array of objects**, and every item of the array must include at least a `mapped_to` property. This must contain:
+Define additional Env Vars with the environments parameter. This parameter must be an **array of objects**, and every item of the array must include at least a `key` property. This must contain:
 
 - The key of the Env Var.
 - The value of the Env Var.
@@ -228,8 +228,8 @@ By default, Env Var names inside values will be replaced in triggered build by a
 
 ```yaml
 "environments":[
-  {"mapped_to":"API_TEST_ENV","value":"This is the test value","is_expand":true},
-  {"mapped_to":"HELP_ENV","value":"$HOME variable contains user's home directory path","is_expand":false},
+  {"key":"API_TEST_ENV","value":"This is the test value","is_expand":true},
+  {"key":"HELP_ENV","value":"$HOME variable contains user's home directory path","is_expand":false},
 ]
 ```
 
@@ -265,7 +265,7 @@ You can abort running builds, and set the reason for aborting, as well as specif
 
 :::note[Required role]
 
-You must have an admin or owner role on the app's team to manage incoming or outgoing webhooks using the API.
+You must have an owner, admin, or developer role on the app's team to abort a build using the API.
 
 For a complete list of user roles and role cheatsheets, check [Roles and permissions for Bitrise CI](/en/bitrise-platform/projects/roles-and-permissions-for-bitrise-ci).
 


### PR DESCRIPTION
## Summary
Fixes 16 findings surfaced by a docs-vs-implementation validation run against `bitrise-api` / `bitrise-website` (2 S4, 5 S3, 5 S2, 4 S1 — severity 0-5, see `docs-validation` repo for the full audit trail).

- Fix wrong-cased machine-types migration endpoint path (`/user/` → `/users/`)
- Replace the dead `/me/apps` pagination example with the live `/apps` endpoint
- Add missing app role-group values (`owner`, `release_manager`, `platform_engineer`)
- Fix build-notification email defaults (both `on_failure`/`on_success` now default to `never`)
- Document the `pipeline` outgoing-webhook event type
- Document optional Android keystore create params and add example values
- Document the undocumented `apple_api_credential_slug` app-update param
- Remove `git_owner` from the register-app required-params description
- Document `certificate_password` redaction, mirroring the existing `download_url` note
- Fix the wrong required-role note under "Aborting a build" (was copy-pasted from the webhooks section)
- Replace deprecated `mapped_to` with `key` in the custom Env Var example
- Cosmetic: `contents:read` typo, missing `data` envelope in the organizations example, duplicated "role role", trailing commas in two JSON/JS samples

## Test plan
- [x] `node scripts/check-links-source.js` clean on all touched files
- [x] Verified every finding against the implementation (bitrise-api / bitrise-website source + git history)
- [ ] Docs site preview review

🤖 Generated with [Claude Code](https://claude.com/claude-code)