### PR TITLE
docs(bitrise-ci/references): fix docs-vs-implementation drift found in validation

### DIFF
--- a/docs/bitrise-ci/references/available-environment-variables.mdx
+++ b/docs/bitrise-ci/references/available-environment-variables.mdx
@@ -55,12 +55,12 @@ Steps can also expose Step outputs as Env Vars. For example, a Step that builds 
 | --- | --- |
 | $BITRISE_BUILD_NUMBER | Build number of the build on [bitrise.io](https://www.bitrise.io). |
 | $BITRISE_APP_TITLE | The title of your project on [bitrise.io](https://www.bitrise.io). You can change it any time on the **Project settings** page of the project. |
-| $BITRISE_APP_URL | The URL or your project on [bitrise.io](https://www.bitrise.io). This is not the same as the Git repository URL! A project URL has the following format:  `app.bitrise.io/APP-SLUG/`  For example: https://app.bitrise.io/app/31e481ce08e0xfd9. |
+| $BITRISE_APP_URL | The URL or your project on [bitrise.io](https://www.bitrise.io). This is not the same as the Git repository URL! A project URL has the following format:  `app.bitrise.io/app/APP-SLUG`  For example: https://app.bitrise.io/app/31e481ce08e0xfd9. |
 | $BITRISE_APP_SLUG | The slug that uniquely identifies your project on [bitrise.io](https://www.bitrise.io). It’s part of the project URL, too. |
 | $BITRISE_BUILD_URL | The URL of the build on [bitrise.io](https://www.bitrise.io). |
-| $BITRISE_BUILD_SLUG | The slug that uniquely identifies a build on [bitrise.io](https://www.bitrise.io). It’s part of the build URL, too.  For example, let’s take a look at this build URL: https://app.bitrise.io/build/d75abbebxfc9ca4e. The build slug is `d65abbebxfc9ca4e` in this example. |
+| $BITRISE_BUILD_SLUG | The slug that uniquely identifies a build on [bitrise.io](https://www.bitrise.io). It’s part of the build URL, too.  For example, let’s take a look at this build URL: https://app.bitrise.io/app/31e481ce08e0xfd9/build/d75abbebxfc9ca4e. The build slug is `d75abbebxfc9ca4e` in this example. |
 | $BITRISE_BUILD_TRIGGER_TIMESTAMP | The date and time when the build was triggered. |
-| $GIT_REPOSITORY_URL | The URL of the Git repository that hosts your project. This can be changed in the **Settings** tab of the app. It can be in either SSH or HTTPS format. |
+| $GIT_REPOSITORY_URL | The URL of the Git repository that hosts your project. This can be changed in the **Repository** section of the **Project settings** page. It can be in either SSH or HTTPS format. |
 | $BITRISE_GIT_BRANCH | The git branch that is built by Bitrise. For example, `main`. |
 | $BITRISEIO_GIT_BRANCH_DEST | Used only with builds triggered by pull requests: the destination/target branch of the pull request that triggered the build.  For example, a pull request wants to merge the content of a branch into the branch `main`. In this case, this Env Var’s value is `main`. |
 | $BITRISE_GIT_TAG | If a build is triggered by a Git Tag, this Env Var stores the tag used. |
@@ -75,7 +75,7 @@ Steps can also expose Step outputs as Env Vars. For example, a Step that builds 
 | $GITHUB_PR_IS_DRAFT | For projects hosted on GitHub only: it is set to `true` if the build is triggered by [a draft pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests). |
 | $BITRISE_PROVISION_URL | The URL of the Apple provisioning profiles uploaded to [bitrise.io](https://www.bitrise.io). If there is more than one provisioning profile uploaded for your project, a pipe character (`|`) separates the URLs in the list.  This is only relevant for iOS projects and for cross-platform projects with iOS versions. |
 | $BITRISE_CERTIFICATE_URL | The URL of the Apple certificates uploaded to [bitrise.io](https://www.bitrise.io). If there is more than one certificate uploaded for your project, a pipe character (`|`) separates the URLs in the list.  This is only relevant for iOS projects and for cross-platform projects with iOS versions. |
-| $BITRISE_CERTIFICATE_PASSPHRASE | The passphrase you set for the uploaded Apple certificates on the project’s **Code Signing & Files** tab. If there is more than one certificate with a passphrase, a pipe character (`|`) separates the phrases in the list.  This is only relevant for iOS projects and for cross-platform projects with iOS versions. |
+| $BITRISE_CERTIFICATE_PASSPHRASE | The passphrase you set for the uploaded Apple certificates on the project’s **Code signing** tab. If there is more than one certificate with a passphrase, a pipe character (`|`) separates the phrases in the list.  This is only relevant for iOS projects and for cross-platform projects with iOS versions. |
 | $BITRISE_IO | Indicates that the build is running in a bitrise.io environment. Value is set to true by Bitrise when it starts a build. |
 | `$BITRISE_TRIGGER_BY` | Identifies the entity that triggered the build. The value can be:  - The Git user's name when the build is [triggered by a Git provider](/en/bitrise-ci/run-and-analyze-builds/build-triggers/configuring-build-triggers). - The Bitrise user's name if the build is triggered manually from the Bitrise web UI. - The value specified in the `triggered_by` build parameter if the build is triggered any other way (such as [scheduled builds](/en/bitrise-ci/run-and-analyze-builds/starting-builds/scheduling-builds) or builds triggered by the [API](/en/bitrise-ci/api/api-overview)). |
 | `$BITRISE_TRIGGER_METHOD` | The method by which the build was triggered.  - `schedule`: When the build is triggered by a scheduler. - `webhook`: When the build is triggered automatically by a webhook at a Git provider. - `manual`: When the build is triggered by any other trigger, including the API. |
@@ -143,5 +143,5 @@ erased_envs:
 | $GIT_CLONE_COMMIT_COUNT | The commit count of the cloned commit. This Env Var is influenced by the `clone_depth` Step input. For more information, check out the [Git Clone Step description](https://github.com/bitrise-steplib/steps-git-clone). |
 | $GIT_CLONE_COMMIT_AUTHOR_NAME | The name of the author of the cloned commit. |
 | $GIT_CLONE_COMMIT_AUTHOR_EMAIL | The email of the author of the cloned commit. |
-| $GIT_CLONE_COMMIT_COMMITER_NAME | The name of the committer of the cloned commit. |
-| $GIT_CLONE_COMMIT_COMMITER_EMAIL | The email of the committer of the cloned commit. |
+| $GIT_CLONE_COMMIT_COMMITTER_NAME | The name of the committer of the cloned commit. |
+| $GIT_CLONE_COMMIT_COMMITTER_EMAIL | The email of the committer of the cloned commit. |

--- a/docs/bitrise-ci/references/configuration-yaml-reference.mdx
+++ b/docs/bitrise-ci/references/configuration-yaml-reference.mdx
@@ -124,8 +124,9 @@ services:
      --health-retries 5
  redis: 
    image: redis:7
-     ports: - 6379:6379
-     options: >-
+   ports:
+   - 6379:6379
+   options: >-
      --health-cmd "redis-cli ping"
      --health-interval 10s
      --health-timeout 5s
@@ -367,6 +368,8 @@ It can have both static and dynamic values, as well as combine the two types.
 - `<target_id>`: The ID of the triggered Workflow or Pipeline.
 - `<event_type>`: The code event that triggered the build: `PR/push/tag`.
 
+The maximum length is 100 characters.
+
 **Example of `pipelines:<pipeline-ID>:status_report_name`**
 
 ```yaml
@@ -490,7 +493,7 @@ Be aware of transitive dependency: if a Workflow that is set to always run has a
 
 **Supported values:**
 
-- `none`: If a parent Workflow fails, the Workflow will not run. This is the default value.
+- `off`: If a parent Workflow fails, the Workflow will not run. This is the default value.
 - `workflow`: If a parent Workflow fails, the Workflow will run anyway.
 
 Read more: [Configuring a Bitrise Pipeline](/en/bitrise-ci/workflows-and-pipelines/build-pipelines/configuring-a-bitrise-pipeline)
@@ -550,7 +553,7 @@ The property determines the number of copies running in parallel. Each copy rece
 - $BITRISE_IO_PARALLEL_INDEX: a zero based index for each copy of the Workflow.
 - $BITRISE_IO_PARALLEL_TOTAL: the total number of copies.
 
-**Supported values**: An integer.
+**Supported values**: An integer between 1 and 200.
 
 Read more: [Parallelism in Pipelines](/en/bitrise-ci/workflows-and-pipelines/build-pipelines/configuring-a-bitrise-pipeline#running-variations-of-the-same-workflow).
 
@@ -575,7 +578,7 @@ workflows:
 
 A short summary of the Workflow.
 
-**Example of**
+**Example of `workflows:<workflow-id>:summary`**
 
 ```yaml
 workflows:
@@ -636,6 +639,8 @@ It can have both static and dynamic values, as well as combine the two types.
 - `<target_id>`: The ID of the triggered Workflow or Pipeline.
 - `<event_type>`: The code event that triggered the build: `PR/push/tag`.
 
+The maximum length is 100 characters.
+
 **Example of `workflows:<workflow-id>:status_report_name`**
 
 ```yaml
@@ -689,7 +694,7 @@ Use this property and `before_run` to create chains of Workflows.
 
 Read more: [Chaining Workflows together](/en/bitrise-ci/workflows-and-pipelines/workflows/managing-workflows#chaining-workflows-together).
 
-**Example of `workflows:<workflow-id>:before_run`**
+**Example of `workflows:<workflow-id>:after_run`**
 
 In this example, we're creating a configuration in which the `deploy` Workflow runs after the `ci` Workflow:
 
@@ -820,7 +825,7 @@ workflows:
 
 ## Step bundle properties
 
-### `step_bundles:<step-bundle-id:title`
+### `step_bundles:<step-bundle-id>:title`
 
 The title of the Step bundle. It is an optional property as the Step bundle ID uniquely identifies the bundle.
 
@@ -1114,6 +1119,25 @@ workflows:
   primary:
     triggers:
       enabled: false
+```
+
+### `triggers:priority`
+
+Sets a priority for an individual trigger condition, overriding the priority of the Workflow or Pipeline it triggers.
+
+**Supported values**: An integer between -100 and 100. The higher the value, the higher the priority. The default value is 0.
+
+Read more: [Build priority](/en/bitrise-ci/configure-builds/configuring-build-settings/build-priority).
+
+**Example of `triggers:priority`**
+
+```yaml
+workflows:
+  primary:
+    triggers:
+      push:
+      - branch: main
+        priority: 10
 ```
 
 ### `triggers:push`

--- a/docs/bitrise-ci/references/glossary.md
+++ b/docs/bitrise-ci/references/glossary.md
@@ -32,10 +32,6 @@ A Secret is a specific type of [Environment Variable](/en/bitrise-ci/configure-b
 
 A build stack indicates the full configuration of the virtual machine that Bitrise uses to run your build. Each stack includes an operating system, and a large number of pre-installed software and tools. For example, our Xcode stacks run on macOS operating systems and contain, among many other tools, the Xcode version that is indicated in the name of the stack.
 
-## Stage {#stage}
-
-A Stage is a collection of Workflows. Stages are the top-level building blocks of Pipelines. A Stage can contain multiple Workflows, which all run in parallel in the same Stage. If all Workflows are successful in a Stage, the Pipeline moves on to the next Stage. If any of the Workflows fail, the Pipeline ends without running the other Stages unless you configure a given Stage to always run.
-
 ## Step {#step}
 
 A Step is a block of script execution that encapsulates a build task on Bitrise: the code to perform that task, the inputs and parameters you can define for the task, and the outputs the task generates.

--- a/docs/bitrise-ci/references/steps-reference/step-data-in-the-bitriseyml-file.mdx
+++ b/docs/bitrise-ci/references/steps-reference/step-data-in-the-bitriseyml-file.mdx
@@ -18,7 +18,7 @@ If you don’t specify any input or other Step property in the `bitrise.yml` con
 Let’s see an example with a single [**Script**](https://github.com/bitrise-io/steps-script) Step, which will be executed when you run `bitrise run test`:
 
 ```yaml
-format_version: 11
+format_version: '26'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
     
 workflows:
@@ -36,7 +36,7 @@ Indentation in the [YAML format](https://github.com/yaml/yaml-spec) is very impo
 :::
 
 ```yaml
-format_version: 11
+format_version: '26'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
     
 workflows:
@@ -52,7 +52,7 @@ If the Step doesn’t have any required inputs you don’t have to specify an in
 Step input values are always **string** / text values and they are passed to the Step as Environment Variables. The value can be multiline too, using the standard YAML multiline format:
 
 ```yaml
-format_version: 11
+format_version: '26'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
@@ -72,7 +72,7 @@ If you use a multiline value, like the one above, you have to indent the value w
 Force a Step to run even if a previous Step fails by setting the `is_always_run` property to `true`:
 
 ```yaml
-format_version: 1.3.1
+format_version: '26'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:
@@ -88,7 +88,7 @@ workflows:
 Use the `title` property to add a descriptive title to your Step:
 
 ```yaml
-format_version: 11
+format_version: '26'
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:

--- a/docs/bitrise-ci/references/steps-reference/step-outputs-reference.mdx
+++ b/docs/bitrise-ci/references/steps-reference/step-outputs-reference.mdx
@@ -9,10 +9,13 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GlossTerm from '@site/src/components/GlossTerm';
 
-<GlossTerm baseform="Step">Step</GlossTerm> outputs are environment items that are the result of running a given Step. For example, the [**Deploy to Bitrise.io - Build Artifacts, Test Reports, and Pipeline intermediate files**](https://github.com/bitrise-steplib/steps-deploy-to-bitrise-io) Step generates two output envs by default:
+<GlossTerm baseform="Step">Step</GlossTerm> outputs are environment items that are the result of running a given Step. For example, the [**Deploy to Bitrise.io - Build Artifacts, Test Reports, and Pipeline intermediate files**](https://github.com/bitrise-steplib/steps-deploy-to-bitrise-io) Step generates five output envs by default:
 
 - $BITRISE_PUBLIC_INSTALL_PAGE_URL
 - BITRISE_PUBLIC_INSTALL_PAGE_URL_MAP
+- BITRISE_PERMANENT_DOWNLOAD_URL_MAP
+- BITRISE_ARTIFACT_DETAILS_PAGE_URL
+- BITRISE_ARTIFACT_DETAILS_PAGE_URL_MAP
 
 You can check out the default outputs of a Step in the <GlossTerm baseform="Workflow Editor">Workflow Editor</GlossTerm> on [bitrise.io](https://www.bitrise.io) or in the `step.yml` file of the Step.
 
@@ -35,10 +38,10 @@ The default outputs of a Step cannot be changed by the user in the `bitrise.yml`
 ```yaml
 workflows:
   primary:
-  steps:
-  - gradle-runner:
-      outputs:
-      - BITRISE_APK_PATH: ALIAS_APK_PATH
+    steps:
+    - gradle-runner:
+        outputs:
+        - BITRISE_APK_PATH: ALIAS_APK_PATH
 ```
 
 In this example, the value for the `BITRISE_APK_PATH` Environment Variable will be exported under the `ALIAS_APK_PATH` key.

--- a/docs/bitrise-ci/references/steps-reference/step-properties-reference.mdx
+++ b/docs/bitrise-ci/references/steps-reference/step-properties-reference.mdx
@@ -26,5 +26,7 @@ import Partial_TIPMetaPropertiesAsPermanentComments from '@site/src/partials/tip
 - `project_type_tags` : project type tags if the Step is project type specific. Example: `ios` or `android`. Completely optional, and only used for search and filtering in Step lists.
 - `type_tags` : generic type tags related to the Step. Example: `utility`, `test` or `notification`. Similar to `project_type_tags`, this property is completely optional, and only used for search and filtering in Step lists.
 - `deps` : specifies the required dependencies of the Step. To declare a dependency, specify a package manager and then the dependency you wish to install.
+- `dependencies` : a newer, generic alternative to `deps`: specifies required dependencies as a list of `manager`/`name` pairs.
+- `toolkit` : specifies how the Step runs (for example, as a `bash` script or a `go` binary) and its entry point.
 - `inputs` : inputs (Environments) of the Step.
 - `outputs` : outputs (Environments) of the Step.


### PR DESCRIPTION
## Summary
Fixes every confirmed finding (1×S4, 2×S3 acted on, plus all S2/S1) from the bitrise-ci/references docs validation run — see the full scoreboard on `validate/bitrise-ci-references`. Every finding was independently re-verified via git-blame/log against the owning implementation repo (bitrise, pipeline-service, bitrise-website, bitrise-steplib) before being fixed here; none turned out to be a product regression.

- **configuration-yaml-reference.mdx**: `should_always_run: none` → `off` (the only real value — `none` would fail config parsing); documented the undocumented `status_report_name` (100 char) and `parallel` (1-200) limits; fixed a broken `services` YAML example; added the missing `triggers:priority` entry; fixed a few caption/heading typos
- **available-environment-variables.mdx**: fixed `COMMITER` → `COMMITTER` git-clone env var spelling; updated the Project settings tab names ("Code Signing & Files" → "Code signing", "Settings" → "Repository" section wording); fixed stale example URLs
- **glossary.md**: removed the `Stage` entry (legacy model, superseded by graph Pipelines since Dec 2024; not referenced by any `<GlossTerm>`)
- **step-outputs-reference.mdx**: Deploy to Bitrise.io's default-outputs list updated from 2 to the current 5; fixed a broken YAML indentation example
- **step-data-in-the-bitriseyml-file.mdx**: `format_version` examples updated to current (`'26'`)
- **step-properties-reference.mdx**: added missing `toolkit` and `dependencies` properties

## Test plan
- [x] `node scripts/check-links-source.js` clean on all edited files
- [x] All edited YAML examples verified to parse with PyYAML
- [x] Every S3+ finding independently confirmed via git-blame/log before fixing (see `validate/bitrise-ci-references` branch reports)