### PR TITLE
docs: sync push-changes options with the corrected Workflow Editor copy

### DIFF
--- a/docs/bitrise-ci/configure-builds/configuration-yaml/storing-an-apps-configuration-yaml.mdx
+++ b/docs/bitrise-ci/configure-builds/configuration-yaml/storing-an-apps-configuration-yaml.mdx
@@ -126,15 +126,15 @@ When your `bitrise.yml` is stored in your repository, the Workflow Editor can pu
 1. Make your changes in the Workflow Editor.
 1. Click **Save changes** in the top right corner.
 1. Choose how to save:
-   - **Push to current branch**: commits and pushes directly to the branch you loaded from.
-   - **Create new branch**: pushes to a new branch of your choice, useful for code review.
+   - **Current branch**: commits and pushes directly to the branch you loaded from.
+   - **New branch**: pushes to a new branch of your choice, useful for code review.
    - **Manual update**: download or copy the YAML and commit it yourself.
 
    :::note 
 
    You can only push directly from the Workflow Editor if you use GitHub or GitLab. If you use Bitbucket Cloud, you will need to commit the file manually every time.
 
-   If your repository has branch protection rules that require pull requests before merging, **Push to current branch** can fail with a generic `Failed to push changes. Please try again.` error. If you run into this, branch protection is a likely cause: use **Create a new branch** instead, which commits your changes to a new branch and gives you a link to open a pull request from it.
+   If your repository has branch protection rules that require pull requests before merging, **Current branch** can fail with a generic `Failed to push changes. Please try again.` error. If you run into this, branch protection is a likely cause: use **New branch** instead, which commits your changes to a new branch and gives you a link to open a pull request from it.
 
    :::
 1. Write a commit message and click **Push changes**.


### PR DESCRIPTION
## What

Updates the "Push changes" section of [Storing an app's configuration YAML](https://devcenter.bitrise.io/en/bitrise-ci/configure-builds/configuration-yaml/storing-an-apps-configuration-yaml) to match the Workflow Editor's corrected radio labels:

- "Push to current branch" → **"Current branch"**
- "Create new branch" (bullet) / "Create a new branch" (branch-protection note — an inconsistency introduced when the note was originally written) → **"New branch"**

## Why

This traces back to the same investigation as [#35](https://github.com/bitrise-io/docs/pull/35): that PR added a note about a branch-protection push failure and, in writing it, described the button as "Create a new branch" — which didn't actually match the live button text at the time ("Create new branch," no article). That mismatch led to two follow-up code PRs, which in turn got UX review from Csaba Sipos and landed on a further-corrected, terser final wording: **"Current branch" / "New branch"** — not either of the earlier "Create (a) new branch" variants. See [bitrise-workflow-editor#1865](https://github.com/bitrise-io/bitrise-workflow-editor/pull/1865) for the full rationale.

## ⚠️ Depends on

**Do not merge before [bitrise-io/bitrise-workflow-editor#1865](https://github.com/bitrise-io/bitrise-workflow-editor/pull/1865) merges.** Opening this as a draft PR now so it's ready to go the moment that one lands; merging it first would describe UI text that doesn't exist yet.

## Test plan

- [x] `node scripts/check-links-source.js docs/bitrise-ci/configure-builds/configuration-yaml/storing-an-apps-configuration-yaml.mdx` → clean, no broken links/anchors

🤖 Generated with [Claude Code](https://claude.com/claude-code)