### PR TITLE
ACI-5189 RBE for Bazel: select worker pools by name (Pool exec property)

### DIFF
--- a/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
+++ b/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
@@ -105,7 +105,7 @@ What each flag does:
 
 `--remote_default_exec_properties` applies to the whole invocation, and Bazel ignores it for any target whose execution platform sets its own `exec_properties`. To route different targets to different worker pools — for example, running tests on a pool with a different macOS image — define a platform for each pool and set the `Pool` property there:
 
-```
+```python
 platform(
     name = "macos_tests",
     constraint_values = [

--- a/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
+++ b/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
@@ -75,16 +75,7 @@ You can use the Bitrise Build Cache with remote build execution both on Bitrise 
 
 ## Recommended flags for remote build execution
 
-Bazel offers a number of command flags that are needed to get the most out of remote build execution.
-
-| Flag and recommend values | Description |
-| --- | --- |
-| `--jobs=100` | Defines the maximum number of build/test actions Bazel may have "in flight" at once. If you omit the flag Bazel silently falls back to the number of logical CPU cores on the host VM. That default is appropriate for local execution but severely under‑utilises the RBE cluster.  `--jobs=100` is a good starting point for most Android/iOS monorepos but it can be increased gradually based on the worker count. |
-| `--remote_default_exec_properties=Pool=<pool-name>` | Selects the worker pool that runs your remote actions. The value is the name of your worker pool as shown on Bitrise.  The property set must match the worker pool exactly: make sure that no other `exec_properties` are set anywhere for the targets, otherwise Bazel will not match the worker pool and the build will fail. |
-| `--spawn_strategy=remote,local` | Determines the order in which Bazel tries to execute an action. Bazel will use the first strategy in the list that can run a given action. The default value is `remote,worker,sandboxed,local`.  Keep remote first so actions run in your remote execution environment, with a graceful fallback to local execution. |
-| `--noremote_upload_local_results` | Skips re‑uploading outputs that were produced locally. Remote workers already push artifacts to the cache, saving bandwidth.  This config flag is also configured via Bitrise Build Cache CLI. If you use it, please make sure that `--cache-push` flag is false or off in the CLI when you use this flag. |
-
-We recommend adding these flags to your `.bazelrc` file and reuse:
+Bazel offers a number of command flags that are needed to get the most out of remote build execution. We recommend adding them to your `.bazelrc` file and reuse:
 
 ```yaml
 build:remote --jobs=100
@@ -94,6 +85,15 @@ build:remote --remote_default_exec_properties=Pool=<pool-name>
 ```
 
 Replace `<pool-name>` with the name of your worker pool. If you have worker pools in multiple data centers, use the same pool name in each data center so the same configuration works everywhere.
+
+What each flag does:
+
+| Flag and recommend values | Description |
+| --- | --- |
+| `--jobs=100` | Defines the maximum number of build/test actions Bazel may have "in flight" at once. If you omit the flag Bazel silently falls back to the number of logical CPU cores on the host VM. That default is appropriate for local execution but severely under‑utilises the RBE cluster.  `--jobs=100` is a good starting point for most Android/iOS monorepos but it can be increased gradually based on the worker count. |
+| `--remote_default_exec_properties=Pool=<pool-name>` | Selects the worker pool that runs your remote actions. The value is the name of your worker pool as shown on Bitrise.  The property set must match the worker pool exactly: make sure that no other `exec_properties` are set anywhere for the targets, otherwise Bazel will not match the worker pool and the build will fail. |
+| `--spawn_strategy=remote,local` | Determines the order in which Bazel tries to execute an action. Bazel will use the first strategy in the list that can run a given action. The default value is `remote,worker,sandboxed,local`.  Keep remote first so actions run in your remote execution environment, with a graceful fallback to local execution. |
+| `--noremote_upload_local_results` | Skips re‑uploading outputs that were produced locally. Remote workers already push artifacts to the cache, saving bandwidth.  This config flag is also configured via Bitrise Build Cache CLI. If you use it, please make sure that `--cache-push` flag is false or off in the CLI when you use this flag. |
 
 With everything in place, you can invoke remote build execution by adding the remote config to any Bazel command:
 

--- a/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
+++ b/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
@@ -80,34 +80,40 @@ Bazel offers a number of command flags that are needed to get the most out of re
 | Flag and recommend values | Description |
 | --- | --- |
 | `--jobs=100` | Defines the maximum number of build/test actions Bazel may have "in flight" at once. If you omit the flag Bazel silently falls back to the number of logical CPU cores on the host VM. That default is appropriate for local execution but severely under‑utilises the RBE cluster.  `--jobs=100` is a good starting point for most Android/iOS monorepos but it can be increased gradually based on the worker count. |
-| MacOS:  `--remote_default_exec_properties=Arch=arm64`  `--remote_default_exec_properties=OSFamily=Darwin`  Linux:  `--remote_default_exec_properties=Arch=amd64`  `--remote_default_exec_properties=OSFamily=Linux` | Defines the default execution platform (worker pool). Supply key‑value pairs such as `Arch=arm64` or `OSFamily=Darwin`. Multiple occurrences are merged.  Make sure that no other `exec_properties` are set anywhere for the targets, otherwise Bazel will not match the worker pool and the build will fail. |
+| `--remote_default_exec_properties=Pool=<pool-name>` | Selects the worker pool that runs your remote actions. The value is the name of your worker pool as shown on Bitrise.  The property set must match the worker pool exactly: make sure that no other `exec_properties` are set anywhere for the targets, otherwise Bazel will not match the worker pool and the build will fail. |
 | `--spawn_strategy=remote,local` | Determines the order in which Bazel tries to execute an action. Bazel will use the first strategy in the list that can run a given action. The default value is `remote,worker,sandboxed,local`.  Keep remote first so actions run in your remote execution environment, with a graceful fallback to local execution. |
 | `--noremote_upload_local_results` | Skips re‑uploading outputs that were produced locally. Remote workers already push artifacts to the cache, saving bandwidth.  This config flag is also configured via Bitrise Build Cache CLI. If you use it, please make sure that `--cache-push` flag is false or off in the CLI when you use this flag. |
 
 We recommend adding these flags to your `.bazelrc` file and reuse:
 
-MacOS:
-
 ```yaml
 build:remote --jobs=100
 build:remote --noremote_upload_local_results
 build:remote --spawn_strategy=remote,local
-build:remote --remote_default_exec_properties=Arch=arm64
-build:remote --remote_default_exec_properties=OSFamily=Darwin
+build:remote --remote_default_exec_properties=Pool=<pool-name>
 ```
 
-Linux:
-
-```yaml
-build:remote --jobs=100
-build:remote --noremote_upload_local_results
-build:remote --spawn_strategy=remote,local
-build:remote --remote_default_exec_properties=Arch=amd64
-build:remote --remote_default_exec_properties=OSFamily=Linux
-```
+Replace `<pool-name>` with the name of your worker pool. If you have worker pools in multiple data centers, use the same pool name in each data center so the same configuration works everywhere.
 
 With everything in place, you can invoke remote build execution by adding the remote config to any Bazel command:
 
 ```bash
 bazel build //... --config=remote
 ```
+
+## Selecting a worker pool per target
+
+`--remote_default_exec_properties` applies to the whole invocation, and Bazel ignores it for any target whose execution platform sets its own `exec_properties`. To route different targets to different worker pools — for example, running tests on a pool with a different macOS image — define a platform for each pool and set the `Pool` property there:
+
+```
+platform(
+    name = "macos_tests",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:arm64",
+    ],
+    exec_properties = {"Pool": "<pool-name>"},
+)
+```
+
+Register the platform with `--extra_execution_platforms` and use standard Bazel platform and toolchain resolution to assign targets to it.

--- a/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
+++ b/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Remote build execution for Bazel"
+title: "Remote Build Execution for Bazel"
 description: "Remote execution of a Bazel build allows you to distribute build and test actions across multiple machines. This speeds up builds and tests, allows reuse of build outputs across teams, and provides a consistent environment."
 sidebar_position: 4
 slug: /bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel

--- a/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
+++ b/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Remote build execution for Bazel"
-description: "Remote execution of a Bazel build allows you to distribute build and test actions across multiple machines. This speeds up build and test execution, allows reuse of build outputs across development teams, and provides"
+description: "Remote execution of a Bazel build allows you to distribute build and test actions across multiple machines. This speeds up builds and tests, allows reuse of build outputs across teams, and provides a consistent environment."
 sidebar_position: 4
 slug: /bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel
 ---
@@ -75,7 +75,7 @@ You can use the Bitrise Build Cache with Remote Build Execution both on Bitrise 
 
 ## Recommended flags for Remote Build Execution
 
-Bazel offers a number of command flags that are needed to get the most out of Remote Build Execution. We recommend adding them to your `.bazelrc` file and reuse:
+Bazel offers a number of command flags that are needed to get the most out of Remote Build Execution. We recommend adding them to your `.bazelrc` file so you can reuse them:
 
 ```yaml
 build:remote --jobs=100
@@ -88,9 +88,9 @@ Replace `<pool-name>` with the name of your worker pool. If you have worker pool
 
 What each flag does:
 
-| Flag and recommend values | Description |
+| Flag and recommended values | Description |
 | --- | --- |
-| `--jobs=100` | Defines the maximum number of build/test actions Bazel may have "in flight" at once. If you omit the flag Bazel silently falls back to the number of logical CPU cores on the host VM. That default is appropriate for local execution but severely under‑utilises the RBE cluster.  `--jobs=100` is a good starting point for most Android/iOS monorepos but it can be increased gradually based on the worker count. |
+| `--jobs=100` | Defines the maximum number of build/test actions Bazel may have "in flight" at once. If you omit the flag Bazel silently falls back to the number of logical CPU cores on the host VM. That default is appropriate for local execution but severely underutilizes the RBE cluster.  `--jobs=100` is a good starting point for most Android/iOS monorepos but it can be increased gradually based on the worker count. |
 | `--remote_default_exec_properties=Pool=<pool-name>` | Selects the worker pool that runs your remote actions. The value is the name of your worker pool as shown on Bitrise.  The property set must match the worker pool exactly: make sure that no other `exec_properties` are set anywhere for the targets, otherwise Bazel will not match the worker pool and the build will fail. |
 | `--spawn_strategy=remote,local` | Determines the order in which Bazel tries to execute an action. Bazel will use the first strategy in the list that can run a given action. The default value is `remote,worker,sandboxed,local`.  Keep remote first so actions run in your remote execution environment, with a graceful fallback to local execution. |
 | `--noremote_upload_local_results` | Skips re‑uploading outputs that were produced locally. Remote workers already push artifacts to the cache, saving bandwidth.  This config flag is also configured via Bitrise Build Cache CLI. If you use it, please make sure that `--cache-push` flag is false or off in the CLI when you use this flag. |

--- a/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
+++ b/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
@@ -86,6 +86,12 @@ build:remote --remote_default_exec_properties=Pool=<pool-name>
 
 Replace `<pool-name>` with the name of your worker pool. If you have worker pools in multiple data centers, use the same pool name in each data center so the same configuration works everywhere.
 
+With everything in place, you can invoke Remote Build Execution by adding the remote config to any Bazel command:
+
+```bash
+bazel build //... --config=remote
+```
+
 What each flag does:
 
 | Flag and recommended values | Description |
@@ -94,12 +100,6 @@ What each flag does:
 | `--remote_default_exec_properties=Pool=<pool-name>` | Selects the worker pool that runs your remote actions. The value is the name of your worker pool as shown on Bitrise.  The property set must match the worker pool exactly: make sure that no other `exec_properties` are set anywhere for the targets, otherwise Bazel will not match the worker pool and the build will fail. |
 | `--spawn_strategy=remote,local` | Determines the order in which Bazel tries to execute an action. Bazel will use the first strategy in the list that can run a given action. The default value is `remote,worker,sandboxed,local`.  Keep remote first so actions run in your remote execution environment, with a graceful fallback to local execution. |
 | `--noremote_upload_local_results` | Skips re‑uploading outputs that were produced locally. Remote workers already push artifacts to the cache, saving bandwidth.  This config flag is also configured via Bitrise Build Cache CLI. If you use it, please make sure that `--cache-push` flag is false or off in the CLI when you use this flag. |
-
-With everything in place, you can invoke Remote Build Execution by adding the remote config to any Bazel command:
-
-```bash
-bazel build //... --config=remote
-```
 
 ## Selecting a worker pool per target
 

--- a/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
+++ b/docs/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel.mdx
@@ -12,9 +12,9 @@ import Partial_OpeningTheWorkflowEditor from '@site/src/partials/opening-the-wor
 
 Remote execution of a Bazel build allows you to distribute build and test actions across multiple machines. This speeds up build and test execution, allows reuse of build outputs across development teams, and provides a consistent environment.
 
-You can use the Bitrise Build Cache with remote build execution both on Bitrise and in a non-Bitrise CI environment.
+You can use the Bitrise Build Cache with Remote Build Execution both on Bitrise and in a non-Bitrise CI environment.
 
-## Configuring remote build execution on Bitrise
+## Configuring Remote Build Execution on Bitrise
 
 <Tabs>
 <TabItem value="workflow-editor" label="Workflow Editor" default>
@@ -41,7 +41,7 @@ You can use the Bitrise Build Cache with remote build execution both on Bitrise 
 </TabItem>
 </Tabs>
 
-## Configuring remote build execution in a non-Bitrise environment
+## Configuring Remote Build Execution in a non-Bitrise environment
 
 <Tabs>
 <TabItem value="other-ci" label="Other CI" default>
@@ -73,9 +73,9 @@ You can use the Bitrise Build Cache with remote build execution both on Bitrise 
 </Tabs>
 
 
-## Recommended flags for remote build execution
+## Recommended flags for Remote Build Execution
 
-Bazel offers a number of command flags that are needed to get the most out of remote build execution. We recommend adding them to your `.bazelrc` file and reuse:
+Bazel offers a number of command flags that are needed to get the most out of Remote Build Execution. We recommend adding them to your `.bazelrc` file and reuse:
 
 ```yaml
 build:remote --jobs=100
@@ -95,7 +95,7 @@ What each flag does:
 | `--spawn_strategy=remote,local` | Determines the order in which Bazel tries to execute an action. Bazel will use the first strategy in the list that can run a given action. The default value is `remote,worker,sandboxed,local`.  Keep remote first so actions run in your remote execution environment, with a graceful fallback to local execution. |
 | `--noremote_upload_local_results` | Skips re‑uploading outputs that were produced locally. Remote workers already push artifacts to the cache, saving bandwidth.  This config flag is also configured via Bitrise Build Cache CLI. If you use it, please make sure that `--cache-push` flag is false or off in the CLI when you use this flag. |
 
-With everything in place, you can invoke remote build execution by adding the remote config to any Bazel command:
+With everything in place, you can invoke Remote Build Execution by adding the remote config to any Bazel command:
 
 ```bash
 bazel build //... --config=remote


### PR DESCRIPTION
Updates the [Remote Build Execution for Bazel](https://docs.bitrise.io/bitrise-build-cache/build-cache-for-bazel/remote-build-execution-for-bazel) page for pool-name routing — the multi-pool-per-DC feature.

## What changes for users

Worker pool selection moves from hardcoded platform properties (`Arch=arm64`/`OSFamily=Darwin` etc.) to a single routing key, the pool's name:

```
--remote_default_exec_properties=Pool=<pool-name>
```

## Page changes

- **Recommended flags section restructured**: the copy-pasteable `.bazelrc` snippet now leads the section (with the `Pool=<pool-name>` placeholder and a note to reuse the same pool name across data centers), followed by the per-flag explanation table. Previously the snippet was buried after the table, duplicated per OS.
- **The `--remote_default_exec_properties` table row** documents `Pool=<pool-name>` instead of the per-OS `Arch`/`OSFamily` pairs, keeping the warning that any other `exec_properties` on targets break pool matching (exact-match semantics).
- **New section — Selecting a worker pool per target**: `platform()` targets with `exec_properties = {"Pool": ...}`, including the gotcha that `--remote_default_exec_properties` is ignored when an execution platform sets its own `exec_properties`.
- **Consistent capitalization**: "Remote Build Execution" is now capitalized where it names the Bitrise feature (title, headings, feature references), matching the sibling pages ("If you have Remote Build Execution enabled for your workspace") and the style guide's proper-noun rule; generic uses of the technique stay lowercase. Slug unchanged, no redirect needed.
- **Housekeeping**: completed the truncated frontmatter `description`, fixed the "recommend values" table-header typo, Americanized "under-utilises".

## Open questions (docs follow-ups, not blockers for this page)

- How `Pool` interacts with the activate-build-cache Step/CLI on Bitrise CI: does `--rbe` gain a pool-name input, or do Bitrise-CI users add the flag to their project `.bazelrc`? The "Configuring on Bitrise" section may need a line once decided.
- Where users find their pool name (UI page vs provided at onboarding) — the table currently says "as shown on Bitrise".

Source link checker passes on the edited page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)