### PR TITLE
Scope Linux tooling workaround to the linux-docker-bitvirt image

### DIFF
--- a/docs/bitrise-build-hub/build-hub-for-github-actions/configuring-build-hub-for-github-actions.mdx
+++ b/docs/bitrise-build-hub/build-hub-for-github-actions/configuring-build-hub-for-github-actions.mdx
@@ -204,9 +204,9 @@ For more information on the `runs-on` property, check out the [GitHub Actions do
 
 ### Enabling Linux machines to access tooling
 
-:::note[Only for the Docker-based Linux image]
+:::warning[Only for the deprecated Docker-based Linux image]
 
-This section only applies to machine pools using the Docker-based `linux-docker-bitvirt` image. The `linux-bitvirt-2026` image doesn't require any of these steps.
+This section only applies to machine pools using the deprecated Docker-based `linux-docker-bitvirt` image. The `linux-bitvirt-2026` image doesn't require any of these steps.
 
 :::
 

--- a/docs/bitrise-build-hub/build-hub-for-github-actions/configuring-build-hub-for-github-actions.mdx
+++ b/docs/bitrise-build-hub/build-hub-for-github-actions/configuring-build-hub-for-github-actions.mdx
@@ -204,7 +204,13 @@ For more information on the `runs-on` property, check out the [GitHub Actions do
 
 ### Enabling Linux machines to access tooling
 
-Linux machines require a workaround to access the preinstalled tools on the Linux image when running a GitHub Actions workflow on Build Hub.
+:::note[Only for the Docker-based Linux image]
+
+This section only applies to machine pools using the Docker-based `linux-docker-bitvirt` image. The `linux-bitvirt-2026` image doesn't require any of these steps.
+
+:::
+
+Machine pools using the `linux-docker-bitvirt` image require a workaround to access the preinstalled tools on the Linux image when running a GitHub Actions workflow on Build Hub.
 
 When a GitHub Actions workflow uses the `container:` property to run steps inside a Docker container, the runner changes the environment in ways that break the image's tool setup. This means that the build can't access `asdf` as the tool manager and therefore preinstalled tools are not accessible.
 


### PR DESCRIPTION
Scopes the "Enabling Linux machines to access tooling" section to the Docker-based linux-docker-bitvirt image. The non-Docker linux-bitvirt-2026 image doesn't need these steps, so the section now says so up front (note + scoped intro sentence).

Requested and content-approved by Julia Fodor-Horvath (PM): https://bitfall.slack.com/archives/C0A7GTS031C/p1785163011537339

Jira: TW-1798