### PR TITLE
Document modular YAML support in the Workflow Editor (TW-1801)

### DIFF
--- a/docs/bitrise-ci/configure-builds/configuration-yaml/customizing-your-configuration-yaml.mdx
+++ b/docs/bitrise-ci/configure-builds/configuration-yaml/customizing-your-configuration-yaml.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Customizing your configuration YAML"
 description: "Any tool that can edit `bitrise.yml` can add custom properties to it. This way you can add special properties or notes to your env vars, or even try new configurations of your Workflow in `bitrise.yml`. All you have to add is add a `meta` field and a namespace label with key and value to the right place."
-sidebar_position: 6
+sidebar_position: 7
 slug: /bitrise-ci/configure-builds/configuration-yaml/customizing-your-configuration-yaml
 ---
 

--- a/docs/bitrise-ci/configure-builds/configuration-yaml/editing-a-modular-configuration-in-the-workflow-editor.mdx
+++ b/docs/bitrise-ci/configure-builds/configuration-yaml/editing-a-modular-configuration-in-the-workflow-editor.mdx
@@ -21,7 +21,7 @@ In every other case, the Workflow Editor works exactly as before.
 
 :::
 
-For the format itself — the `include` keyword, nesting, and merge rules — see [Modular YAML configuration](/en/bitrise-ci/configure-builds/configuration-yaml/modular-yaml-configuration).
+For the `include` keyword, nesting, and merge rules, see [Modular YAML configuration](/en/bitrise-ci/configure-builds/configuration-yaml/modular-yaml-configuration).
 
 ## The two views
 
@@ -29,7 +29,7 @@ Everything in the modular editor follows from two ideas.
 
 **Merged config** shows your entire configuration with every module assembled and every property resolved: the configuration that actually runs. It's read-only by design, so that every change stays traceable to the file that owns it. You can start builds here.
 
-**Module view** shows one file: the one in the active tab. You have full editing rights over everything that file defines. Entities the file only refers to — a <GlossTerm baseform="workflow">Workflow</GlossTerm> defined in another module, for example — appear read-only, so you always know where the definition lives.
+**Module view** shows one file: the one in the active tab. You have full editing rights over everything that file defines. Entities that the file only refers to appear read-only. A <GlossTerm baseform="workflow">Workflow</GlossTerm> defined in another module shows up here, but you edit its definition in the module that owns it.
 
 | | Merged config | Module | Module from another repository, branch, tag, or commit |
 | --- | --- | --- | --- |
@@ -55,12 +55,12 @@ If you already know which file you need, open it directly: click **+** on the ta
 
 ## Editing a module
 
-Editing a module is the same as editing a single-file configuration: you can create, edit, delete, and reorder anything the file defines, on any page of the editor — Workflows, Pipelines, Step bundles, Env Vars, Triggers, Containers, Stacks & Machines.
+Editing a module is the same as editing a single-file configuration: you can create, edit, delete, and reorder anything the file defines, on any page of the editor: Workflows, Pipelines, Step bundles, Env Vars, Triggers, Containers, Stacks & Machines.
 
 Two things are specific to modular configurations:
 
 - **The active tab is the file you're editing.** Switching tabs switches the file. The tab shows a dot while it has unsaved changes.
-- **Entities defined in another module are read-only here.** You can still change how *this* file uses them — for example, remove a Workflow from a Pipeline — but to change the definition, use **Edit definition** to open the module that owns it.
+- **Entities defined in another module are read-only here.** You can still change how *this* file uses them. You can remove a Workflow from a Pipeline, for example. To change the definition, use **Edit definition** to open the module that owns it.
 
 Pickers work across the whole configuration: a Workflow defined in one module can be referenced from another.
 
@@ -68,7 +68,7 @@ Pickers work across the whole configuration: a Workflow defined in one module ca
 
 ## Starting a build
 
-Start builds from the **Merged config** tab. A single module is usually an incomplete slice of the configuration — another file can add Steps or change triggers — so running from a module could run something different from what you see. The merged configuration is the one that runs, so it's the one you start builds from.
+Start builds from the **Merged config** tab. A single module is usually an incomplete slice of the configuration: another file can add Steps or change triggers. Running from a module could run something different from what you see. The merged configuration is the one that runs, so it's the one you start builds from.
 
 ## Pushing your changes
 
@@ -81,7 +81,7 @@ Saving pushes your changed modules together, in one commit, to one branch.
 
 Only modules you actually changed are written, and read-only modules are never touched. After a successful push, the editor reloads your configuration so that any changes to `include` take effect.
 
-If the branch moved on while you were editing — someone else pushed, and one of the modules you changed also changed in the repository — the push is rejected as a whole. None of your modules are written, so your repository is never left half-updated.
+If someone else pushed while you were editing, and one of the modules you changed also changed in the repository, the push is rejected as a whole. None of your modules are written, so your repository is never left half-updated.
 
 :::note[Updating your repository manually]
 
@@ -103,7 +103,7 @@ Until the editor reloads, the file tree and the tabs show the structure from the
 
 ### The Workflow Editor doesn't show my modules
 
-**Cause**: Your setup doesn't meet all three conditions above, or the feature hasn't reached your Workspace yet — it's being rolled out gradually.
+**Cause**: Your setup doesn't meet all three conditions above, or the feature hasn't reached your Workspace yet. It's being rolled out gradually.
 
 **Fix**: Check that your configuration has at least one `include`, that it is stored in your repository, and that your Workspace plan includes modular YAML configuration. If all three hold and you still get the single-file editor, [contact our support team](https://support.bitrise.io/en/articles/11689194-how-to-submit-a-ticket-to-bitrise-support).
 

--- a/docs/bitrise-ci/configure-builds/configuration-yaml/editing-a-modular-configuration-in-the-workflow-editor.mdx
+++ b/docs/bitrise-ci/configure-builds/configuration-yaml/editing-a-modular-configuration-in-the-workflow-editor.mdx
@@ -29,13 +29,13 @@ Everything in the modular editor follows from two ideas.
 
 **Merged config** shows your entire configuration with every module assembled and every property resolved: the configuration that actually runs. It's read-only by design, so that every change stays traceable to the file that owns it. You can start builds here.
 
-**Module view** shows one file: the one in the active tab. You have full editing rights over everything that file defines. Entities that the file only refers to appear read-only. A <GlossTerm baseform="workflow">Workflow</GlossTerm> defined in another module shows up here, but you edit its definition in the module that owns it.
+Module view shows one file: the one in the active tab. You have full editing rights over everything that file defines. Entities that the file only refers to appear read-only. A <GlossTerm baseform="workflow">Workflow</GlossTerm> defined in another module shows up here, but you edit its definition in the module that owns it.
 
-| | Merged config | Module | Module from another repository, branch, tag, or commit |
+| **Surface** | **What you see** | **Editing** | **Starting builds** |
 | --- | --- | --- | --- |
-| Shows | The full, resolved configuration | What this file defines, plus references to entities defined elsewhere | What this file defines |
-| Editing | Read-only | Full editing | Read-only |
-| Starting builds | Yes | No | No |
+| Merged config | The full, resolved configuration | Read-only | Yes |
+| A module in your repository | What the file defines, plus references to entities defined elsewhere | Full editing | No |
+| A module from another repository, branch, tag, or commit | What the file defines | Read-only | No |
 
 {/* TODO screenshot: Merged config tab, Workflows page, one Workflow selected — shows the "Defined in <path>" line and the "Edit definition" action. 1728×875 */}
 
@@ -59,8 +59,8 @@ Editing a module is the same as editing a single-file configuration: you can cre
 
 Two things are specific to modular configurations:
 
-- **The active tab is the file you're editing.** Switching tabs switches the file. The tab shows a dot while it has unsaved changes.
-- **Entities defined in another module are read-only here.** You can still change how *this* file uses them. You can remove a Workflow from a Pipeline, for example. To change the definition, use **Edit definition** to open the module that owns it.
+- The active tab is the file you're editing. Switching tabs switches the file. The tab shows a dot while it has unsaved changes.
+- Entities defined in another module are read-only here. You can still change how *this* file uses them. You can remove a Workflow from a Pipeline, for example. To change the definition, use **Edit definition** to open the module that owns it.
 
 Pickers work across the whole configuration: a Workflow defined in one module can be referenced from another.
 
@@ -85,7 +85,7 @@ If someone else pushed while you were editing, and one of the modules you change
 
 :::note[Updating your repository manually]
 
-If you commit configuration changes by hand, click **Manual update** in the push dialog. You get every changed module with a download and a copy option, and you commit them to your repository yourself.
+If you commit your configuration changes by hand, click **Manual update** in the push dialog. You get every changed module with a download and a copy option, and you commit them to your repository yourself.
 
 :::
 
@@ -93,13 +93,13 @@ If you commit configuration changes by hand, click **Manual update** in the push
 
 ## Limitations
 
-- **Adding and removing modules.** Edit the `include` list by hand in the YAML view. The editor picks up the new structure after your next successful save, when it reloads the configuration.
-- **Editing `include` parameters** such as `path`, `repository`, `branch`, `tag`, or `commit`. These are also edited in the YAML view.
-- **Editing modules from another repository, branch, tag, or commit.** They load so you can read them, but they can't be edited.
+- Adding and removing modules. Edit the `include` list by hand in the YAML view. The editor picks up the new structure after your next successful save, when it reloads the configuration.
+- Editing `include` parameters such as `path`, `repository`, `branch`, `tag`, or `commit`. These are also edited in the YAML view.
+- Editing modules from another repository, branch, tag, or commit. They load so you can read them, but they can't be edited.
 
 Until the editor reloads, the file tree and the tabs show the structure from the last load, even if you have already edited the `include` list. The merged configuration reflects your edits immediately.
 
-## Troubleshooting
+## Troubleshooting modular configurations
 
 ### The Workflow Editor doesn't show my modules
 

--- a/docs/bitrise-ci/configure-builds/configuration-yaml/editing-a-modular-configuration-in-the-workflow-editor.mdx
+++ b/docs/bitrise-ci/configure-builds/configuration-yaml/editing-a-modular-configuration-in-the-workflow-editor.mdx
@@ -1,0 +1,132 @@
+---
+title: "Editing a modular configuration in the Workflow Editor"
+description: "Open, edit, and push a configuration that is split across multiple YAML files. The Workflow Editor loads every module, shows the merged result, and pushes your changes back to Git."
+sidebar_position: 6
+slug: /bitrise-ci/configure-builds/configuration-yaml/editing-a-modular-configuration-in-the-workflow-editor
+---
+
+import GlossTerm from '@site/src/components/GlossTerm';
+
+If your configuration is split across several YAML files with the `include` keyword, you don't have to leave the <GlossTerm baseform="workflow editor">Workflow Editor</GlossTerm> to change one of them. The editor loads your whole file tree: you can read the merged configuration, edit individual modules, and push every change back to your repository in one step. Editing a module works exactly like editing a single `bitrise.yml` file.
+
+:::important[When you get the modular editor]
+
+The Workflow Editor switches to the modular experience automatically when all of the following are true:
+
+- Your configuration is modular: it has at least one `include`.
+- You [store your configuration in your own repository](/en/bitrise-ci/configure-builds/configuration-yaml/storing-an-apps-configuration-yaml#storing-the-bitriseyml-file-in-your-repository), not on bitrise.io.
+- Your <GlossTerm baseform="workspace">Workspace</GlossTerm> is on a plan that includes modular YAML configuration.
+
+In every other case, the Workflow Editor works exactly as before.
+
+:::
+
+For the format itself — the `include` keyword, nesting, and merge rules — see [Modular YAML configuration](/en/bitrise-ci/configure-builds/configuration-yaml/modular-yaml-configuration).
+
+## The two views
+
+Everything in the modular editor follows from two ideas.
+
+**Merged config** shows your entire configuration with every module assembled and every property resolved: the configuration that actually runs. It's read-only by design, so that every change stays traceable to the file that owns it. You can start builds here.
+
+**Module view** shows one file: the one in the active tab. You have full editing rights over everything that file defines. Entities the file only refers to — a <GlossTerm baseform="workflow">Workflow</GlossTerm> defined in another module, for example — appear read-only, so you always know where the definition lives.
+
+| | Merged config | Module | Module from another repository, branch, tag, or commit |
+| --- | --- | --- | --- |
+| Shows | The full, resolved configuration | What this file defines, plus references to entities defined elsewhere | What this file defines |
+| Editing | Read-only | Full editing | Read-only |
+| Starting builds | Yes | No | No |
+
+{/* TODO screenshot: Merged config tab, Workflows page, one Workflow selected — shows the "Defined in <path>" line and the "Edit definition" action. 1728×875 */}
+
+## Finding the module you need to edit
+
+You don't have to know which file defines what. Start in **Merged config** and let the editor tell you.
+
+1. Open the Workflow Editor and stay on the **Merged config** tab.
+1. Find the Workflow, <GlossTerm baseform="pipeline">Pipeline</GlossTerm>, or other entity you want to change. Every card shows the module that defines it, for example `Defined in .bitrise/workflows/deploy.yml`.
+1. Select the entity, then click **Edit definition**. The editor opens the module that defines it in a new tab, with the entity selected.
+
+If an entity is defined in more than one module, **Edit definition** lists those modules in merge order so you can pick the one you want.
+
+If you already know which file you need, open it directly: click **+** on the tab bar and select the file in the **Open module** popover. The popover mirrors your repository's folder structure.
+
+{/* TODO screenshot: the "Open module" popover open, showing the file tree. 1728×875 */}
+
+## Editing a module
+
+Editing a module is the same as editing a single-file configuration: you can create, edit, delete, and reorder anything the file defines, on any page of the editor — Workflows, Pipelines, Step bundles, Env Vars, Triggers, Containers, Stacks & Machines.
+
+Two things are specific to modular configurations:
+
+- **The active tab is the file you're editing.** Switching tabs switches the file. The tab shows a dot while it has unsaved changes.
+- **Entities defined in another module are read-only here.** You can still change how *this* file uses them — for example, remove a Workflow from a Pipeline — but to change the definition, use **Edit definition** to open the module that owns it.
+
+Pickers work across the whole configuration: a Workflow defined in one module can be referenced from another.
+
+{/* TODO screenshot: a module tab open (for example deploy.yml) with an editable Workflow. 1728×875 */}
+
+## Starting a build
+
+Start builds from the **Merged config** tab. A single module is usually an incomplete slice of the configuration — another file can add Steps or change triggers — so running from a module could run something different from what you see. The merged configuration is the one that runs, so it's the one you start builds from.
+
+## Pushing your changes
+
+Saving pushes your changed modules together, in one commit, to one branch.
+
+1. Click **Save changes**.
+1. Check the list of changed modules in the **Push changes** dialog. Each module is listed with its full path.
+1. Choose **Current branch** or **New branch**, then write a commit message.
+1. Click **Push changes**.
+
+Only modules you actually changed are written, and read-only modules are never touched. After a successful push, the editor reloads your configuration so that any changes to `include` take effect.
+
+If the branch moved on while you were editing — someone else pushed, and one of the modules you changed also changed in the repository — the push is rejected as a whole. None of your modules are written, so your repository is never left half-updated.
+
+:::note[Updating your repository manually]
+
+If you commit configuration changes by hand, click **Manual update** in the push dialog. You get every changed module with a download and a copy option, and you commit them to your repository yourself.
+
+:::
+
+{/* TODO screenshot: the "Push changes" dialog listing changed modules with full paths. 1728×875 */}
+
+## Limitations
+
+- **Adding and removing modules.** Edit the `include` list by hand in the YAML view. The editor picks up the new structure after your next successful save, when it reloads the configuration.
+- **Editing `include` parameters** such as `path`, `repository`, `branch`, `tag`, or `commit`. These are also edited in the YAML view.
+- **Editing modules from another repository, branch, tag, or commit.** They load so you can read them, but they can't be edited.
+
+Until the editor reloads, the file tree and the tabs show the structure from the last load, even if you have already edited the `include` list. The merged configuration reflects your edits immediately.
+
+## Troubleshooting
+
+### The Workflow Editor doesn't show my modules
+
+**Cause**: Your setup doesn't meet all three conditions above, or the feature hasn't reached your Workspace yet — it's being rolled out gradually.
+
+**Fix**: Check that your configuration has at least one `include`, that it is stored in your repository, and that your Workspace plan includes modular YAML configuration. If all three hold and you still get the single-file editor, [contact our support team](https://support.bitrise.io/en/articles/11689194-how-to-submit-a-ticket-to-bitrise-support).
+
+### The field I want to edit is greyed out
+
+**Cause**: You are either on the **Merged config** tab, which is read-only, or in a module that refers to the entity without defining it.
+
+**Fix**: Select the entity and click **Edit definition** to open the module that defines it.
+
+### I edited the `include` list, but the tabs and the file tree didn't change
+
+**Cause**: The editor reads your file structure when it loads the configuration, so it doesn't restructure itself while you type.
+
+**Fix**: Save and push your changes. The editor reloads the configuration afterwards, and the new structure appears.
+
+### I can't start a build from the module I'm editing
+
+**Cause**: Builds always run the merged configuration, so you can't start one from a module view.
+
+**Fix**: Switch to the **Merged config** tab and start the build there.
+
+## Related
+
+- [Modular YAML configuration](/en/bitrise-ci/configure-builds/configuration-yaml/modular-yaml-configuration)
+- [Editing an app's bitrise.yml file](/en/bitrise-ci/configure-builds/configuration-yaml/editing-an-app-s-bitrise-yml-file)
+- [Storing an app's configuration YAML](/en/bitrise-ci/configure-builds/configuration-yaml/storing-an-apps-configuration-yaml)

--- a/docs/bitrise-ci/configure-builds/configuration-yaml/editing-an-apps-bitriseyml-file.mdx
+++ b/docs/bitrise-ci/configure-builds/configuration-yaml/editing-an-apps-bitriseyml-file.mdx
@@ -17,6 +17,12 @@ Your Bitrise configuration is defined in YAML files. All Bitrise <GlossTerm base
 - [Editing the bitrise.yml file in the Workflow Editor](#editing-the-bitriseyml-file-online). You can do so even if you [store your configuration file in your repository](/en/bitrise-ci/configure-builds/configuration-yaml/storing-an-apps-configuration-yaml#storing-the-bitriseyml-file-in-your-repository). The Workflow Editor can push your changes directly your repository. 
 - [Editing the bitrise.yml file locally](#editing-the-bitriseyml-file-locally) in an editor of your choice. You can copy the content to the online editor or push it to your repository if you store your configuration file there.
 
+:::note[Modular configurations]
+
+If your configuration is split across several files with the `include` keyword, the Workflow Editor loads every module and lets you edit them one file at a time. See [Editing a modular configuration in the Workflow Editor](/en/bitrise-ci/configure-builds/configuration-yaml/editing-a-modular-configuration-in-the-workflow-editor).
+
+:::
+
 <Partial_IMPORTANTFamiliarityWithTheStructureOfTheBitriseYmlFile />
 
 ## Editing the bitrise.yml file online

--- a/docs/bitrise-ci/configure-builds/configuration-yaml/modular-yaml-configuration.mdx
+++ b/docs/bitrise-ci/configure-builds/configuration-yaml/modular-yaml-configuration.mdx
@@ -205,7 +205,7 @@ When merging the configurations, it is possible to encounter overlaps and overri
   - In any other case, the value from the most recently read file is used.
 - Items of array type (for example, lists of Environment Variables or [trigger map items](/en/bitrise-ci/run-and-analyze-builds/build-triggers/yaml-syntax-for-build-triggers)): if the collection is present in both the most recently read file and the existing merged configuration, the merged value is an ordered array of values, with all values from the merged configuration followed by the values from the most recently read file.
 
-You can see the merged configuration file in the <GlossTerm baseform="workflow editor">Workflow Editor</GlossTerm>: select **<GlossTerm baseform="bitrise.yml">bitrise.yml</GlossTerm>** from the left navigation menu to view it.
+You can see the merged configuration in the <GlossTerm baseform="workflow editor">Workflow Editor</GlossTerm> on the **Merged config** tab. For how to open and edit the individual modules from there, see [Editing a modular configuration in the Workflow Editor](/en/bitrise-ci/configure-builds/configuration-yaml/editing-a-modular-configuration-in-the-workflow-editor).
 
 **Merging rules**
 


### PR DESCRIPTION
Documents the Workflow Editor's support for modular (`include`-based) configurations. Requested by Kaushal Vyas in #team-tech-writers (28 July).

**New page:** Editing a modular configuration in the Workflow Editor

**Also updates:**
- `modular-yaml-configuration` — replaces stale instructions for viewing the merged config
- `editing-an-apps-bitriseyml-file` — pointer to the new page
- `customizing-your-configuration-yaml` — `sidebar_position` 6 to 7

## Not ready to merge

- [ ] 4 screenshots — placeholders are in place as MDX comments with framing notes (Balazs Wagner)
- [ ] UI copy: the **Edit definition** label, and whether to name the read-only styling (Balazs Wagner)
- [ ] Behaviour: multi-module push, run in module views, cross-repo module presentation (Tamas Papik / Laszlo Mocso)
- [ ] Publish timing — the feature is on a gradual LaunchDarkly ramp (Kaushal Vyas)

Conflict resolution is deliberately not documented: the Scope page says N-file resolution ships in this iteration, while the Behavior page (the stated SSOT) says iteration 1 surfaces only the first conflicting file and the multi-file UI is still in design. The page documents the guarantee that a conflicting push is rejected whole, and stays silent on the resolver UI.

No changelog entry in this PR — the changelog is a manually invoked skill and Zoli controls what goes in it.

Ilana to check back on **13 August**.